### PR TITLE
ShopifyOrderService: Create, get, delete, update, list, count close and open orders

### DIFF
--- a/ShopifySharp.Tests/GlobalSuppressions.cs
+++ b/ShopifySharp.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Language Usage Opportunities", "RECS0002:Convert anonymous method to method group")]
+

--- a/ShopifySharp.Tests/ShopifyAuthorizationService/When_building_an_authorization_url.cs
+++ b/ShopifySharp.Tests/ShopifyAuthorizationService/When_building_an_authorization_url.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Humanizer;
+using ShopifySharp.Enums;
 
 namespace ShopifySharp.Tests
 {

--- a/ShopifySharp.Tests/ShopifyCustomerService/When_counting_customers.cs
+++ b/ShopifySharp.Tests/ShopifyCustomerService/When_counting_customers.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp.Tests
             _Count = _Service.CountAsync().Await().AsTask.Result;
         };
 
-        It should_retrieve_a_count = () =>
+        It should_retrieve_a_count_of_customers = () =>
         {
             _Count.ShouldNotBeNull();
         };

--- a/ShopifySharp.Tests/ShopifyCustomerService/When_deleting_a_customer.cs
+++ b/ShopifySharp.Tests/ShopifyCustomerService/When_deleting_a_customer.cs
@@ -24,17 +24,16 @@ namespace ShopifySharp.Tests
             try
             {
                 _Service.DeleteAsync(_CustomerId).Await();
-                _ThrewException = false;
             }
             catch (ShopifyException e)
             {
-                _ThrewException = true;
-            };
+                _Exception = e;
+            }
         };
 
         It should_delete_a_customer = () =>
         {
-            _ThrewException.ShouldBeFalse();
+            _Exception.ShouldBeNull();
         };
 
         Cleanup after = () =>
@@ -43,7 +42,9 @@ namespace ShopifySharp.Tests
         };
 
         static long _CustomerId;
-        static bool _ThrewException = false;
+        
         static ShopifyCustomerService _Service;
+
+        static ShopifyException _Exception;
     }
 }

--- a/ShopifySharp.Tests/ShopifyCustomerService/When_listing_customers_with_options.cs
+++ b/ShopifySharp.Tests/ShopifyCustomerService/When_listing_customers_with_options.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp.Tests
             _Result = _Service.ListAsync(_Options).Await().AsTask.Result;
         };
 
-        It should_only_retrieve_a_limited_number_of_customers = () =>
+        It should_only_list_1_customer = () =>
         {
             _Result.Count().ShouldBeLessThanOrEqualTo(_Limit);
         };

--- a/ShopifySharp.Tests/ShopifyOrderService/Test_Data/OrderCreation.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/Test_Data/OrderCreation.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.Test_Data
+{
+    public static class OrderCreation
+    {
+        public static ShopifyOrder CreateValidOrder()
+        {
+            return new ShopifyOrder()
+            {
+                CreatedAt = DateTime.UtcNow,
+                BillingAddress = new ShopifyAddress()
+                {
+                    Address1 = "123 4th Street",
+                    City = "Minneapolis",
+                    Province = "Minnesota",
+                    ProvinceCode = "MN",
+                    Zip = "55401",
+                    Phone = "555-555-5555",
+                    FirstName = "John",
+                    LastName = "Doe",
+                    Company = "Tomorrow Corporation",
+                    Country = "United States",
+                    CountryCode = "US",
+                    Default = true,
+                },
+                LineItems = new List<ShopifyLineItem>()
+                {
+                    new ShopifyLineItem()
+                    {
+                        Name = "Test Line Item",
+                        Title = "Test Line Item Title"
+                    }
+                },
+                FinancialStatus = Enums.ShopifyOrderFinancialStatus.Paid,
+                TotalPrice = 5.00,
+                Email = Guid.NewGuid().ToString() + "@example.com",
+                Note = "Test note about the customer.",
+            };
+        }
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_closing_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_closing_an_order.cs
@@ -1,0 +1,41 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_closing_an_order
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Order = Service.CreateAsync(OrderCreation.CreateValidOrder()).Await().AsTask.Result;
+        };
+
+        Because of = () =>
+        {
+            Service.CloseAsync(Order.Id.Value).Await();
+        };
+
+        It should_close_an_order = () =>
+        {
+            //Update the order from Shopify
+            Order = Service.GetAsync(Order.Id.Value).Await().AsTask.Result;
+
+            Order.ClosedAt.HasValue.ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Order.Id.Value).Await();
+        };
+
+        static ShopifyOrderService Service;
+        static ShopifyOrder Order;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_counting_orders.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_counting_orders.cs
@@ -1,0 +1,37 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_counting_orders
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+        };
+
+        Because of = () =>
+        {
+            Result = Service.CountAsync().Await().AsTask.Result;
+        };
+
+        It should_retrieve_a_count_of_orders = () =>
+        {
+            Result.ShouldNotBeNull();
+        };
+
+        Cleanup after = () =>
+        {
+
+        };
+
+        static ShopifyOrderService Service;
+
+        static int? Result;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_creating_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_creating_an_order.cs
@@ -1,0 +1,14 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_creating_an_order
+    {
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_creating_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_creating_an_order.cs
@@ -1,14 +1,43 @@
 ﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Humanizer;
 
 namespace ShopifySharp.Tests
 {
     [Subject(typeof(ShopifyOrderService))]
     public class When_creating_an_order
     {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+        };
+
+        Because of = () =>
+        {
+            Order = Service.CreateAsync(OrderCreation.CreateValidOrder()).Await().AsTask.Result;
+        };
+
+        It should_create_an_order = () =>
+        {
+            Order.ShouldNotBeNull();
+            Order.Id.HasValue.ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            if(Order != null)
+            {
+                Service.DeleteAsync(Order.Id.Value).Await();
+            }
+        };
+
+        static ShopifyOrderService Service;
+
+        static ShopifyOrder Order;
     }
 }

--- a/ShopifySharp.Tests/ShopifyOrderService/When_deleting_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_deleting_an_order.cs
@@ -1,0 +1,46 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_deleting_an_order
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Order = Service.CreateAsync(OrderCreation.CreateValidOrder()).Await().AsTask.Result;
+        };
+
+        Because of = () =>
+        {
+            try
+            {
+                Service.DeleteAsync(Order.Id.Value).Await();
+            }
+            catch(ShopifyException e)
+            {
+                Exception = e;
+            }
+        };
+
+        It should_delete_an_order = () =>
+        {
+            Exception.ShouldBeNull();
+        };
+
+        Cleanup after = () =>
+        {
+
+        };
+
+        static ShopifyOrderService Service;
+        static ShopifyOrder Order;
+        static ShopifyException Exception;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_getting_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_getting_an_order.cs
@@ -1,0 +1,38 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_getting_an_order
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Order = Service.CreateAsync(OrderCreation.CreateValidOrder()).Await().AsTask.Result;
+        };
+
+        Because of = () =>
+        {
+            Order = Service.GetAsync(Order.Id.Value).Await().AsTask.Result;
+        };
+
+        It should_get_an_order = () =>
+        {
+            Order.ShouldNotBeNull();
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Order.Id.Value).Await();
+        };
+
+        static ShopifyOrderService Service;
+        static ShopifyOrder Order;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_listing_orders.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_listing_orders.cs
@@ -1,0 +1,46 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_listing_orders
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+            // TODO: Create three orders
+            for (int i = 0; i < 3; i++)
+            {
+
+            }
+        };
+
+        Because of = () =>
+        {
+            Result = Service.ListAsync().Await().AsTask.Result;
+        };
+
+        It should_list_orders = () =>
+        {
+            Result.ShouldNotBeNull();
+            Result.Count().ShouldBeGreaterThanOrEqualTo(2);
+        };
+
+        Cleanup after = () =>
+        {
+            // TODO: Delete orders
+        };
+
+        static ShopifyOrderService Service;
+
+        static IEnumerable<ShopifyOrder> Result;
+
+        static List<long> CreatedIds = new List<long>();
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_listing_orders_with_options.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_listing_orders_with_options.cs
@@ -1,0 +1,51 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_listing_orders_with_options
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+            // TODO: Create three orders
+            for(int i = 0; i < 3; i++)
+            {
+
+            }
+        };
+
+        Because of = () =>
+        {
+            Result = Service.ListAsync(Options).Await().AsTask.Result;
+        };
+
+        It should_only_list_2_orders = () =>
+        {
+            Result.ShouldNotBeNull();
+            Result.Count().Equals(2).ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            // TODO: Delete orders
+        };
+
+        static ShopifyOrderService Service;
+
+        static IEnumerable<ShopifyOrder> Result;
+
+        static ShopifyOrderFilterOptions Options = new ShopifyOrderFilterOptions()
+        {
+            Limit = 2
+        };
+
+        static List<long> CreatedIds = new List<long>();
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_opening_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_opening_an_order.cs
@@ -1,0 +1,42 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_opening_an_order
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Order = Service.CreateAsync(OrderCreation.CreateValidOrder()).Await().AsTask.Result;
+        };
+
+        Because of = () =>
+        {
+            Service.CloseAsync(Order.Id.Value).Await();
+            Service.OpenAsync(Order.Id.Value).Await();
+        };
+
+        It should_open_an_order = () =>
+        {
+            //Update the order from Shopify
+            Order = Service.GetAsync(Order.Id.Value).Await().AsTask.Result;
+
+            Order.ClosedAt.HasValue.ShouldBeFalse();
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Order.Id.Value).Await();
+        };
+
+        static ShopifyOrderService Service;
+        static ShopifyOrder Order;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService/When_updating_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService/When_updating_an_order.cs
@@ -1,0 +1,42 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_updating_an_order
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Order = Service.CreateAsync(OrderCreation.CreateValidOrder()).Await().AsTask.Result;
+        };
+
+        Because of = () =>
+        {
+            Order.Note = "Test notes";
+            Service.UpdateAsync(Order).Await();
+        };
+
+        It should_update_an_order = () =>
+        {
+            //Update the order from Shopify
+            Order = Service.GetAsync(Order.Id.Value).Await().AsTask.Result;
+
+            Order.Note.Equals("Test notes").ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Order.Id.Value).Await();
+        };
+
+        static ShopifyOrderService Service;
+        static ShopifyOrder Order;
+    }
+}

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ShopifyCustomerService\When_retrieving_a_customer_with_fields.cs" />
     <Compile Include="ShopifyCustomerService\When_searching_for_a_customer.cs" />
     <Compile Include="ShopifyCustomerService\When_updating_a_customer.cs" />
+    <Compile Include="ShopifyOrderService\Test_Data\OrderCreation.cs" />
     <Compile Include="ShopifyOrderService\When_counting_orders.cs" />
     <Compile Include="ShopifyOrderService\When_creating_an_order.cs" />
     <Compile Include="ShopifyOrderService\When_listing_orders.cs" />
@@ -103,7 +104,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="ShopifyOrderService\Test_Data\" />
     <Folder Include="ShopifyShopService\Test_Data\" />
   </ItemGroup>
   <Choose>

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -67,6 +67,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ShopifyAuthorizationService\When_building_an_authorization_url.cs" />
     <Compile Include="ShopifyCustomerService\Test_Data\CustomerCreation.cs" />
     <Compile Include="ShopifyCustomerService\When_counting_customers.cs" />
@@ -79,6 +80,10 @@
     <Compile Include="ShopifyCustomerService\When_retrieving_a_customer_with_fields.cs" />
     <Compile Include="ShopifyCustomerService\When_searching_for_a_customer.cs" />
     <Compile Include="ShopifyCustomerService\When_updating_a_customer.cs" />
+    <Compile Include="ShopifyOrderService\When_counting_orders.cs" />
+    <Compile Include="ShopifyOrderService\When_creating_an_order.cs" />
+    <Compile Include="ShopifyOrderService\When_listing_orders.cs" />
+    <Compile Include="ShopifyOrderService\When_listing_orders_with_options.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="ShopifyShopService\When_getting_a_shop.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -98,6 +103,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="ShopifyOrderService\Test_Data\" />
     <Folder Include="ShopifyShopService\Test_Data\" />
   </ItemGroup>
   <Choose>

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -81,10 +81,15 @@
     <Compile Include="ShopifyCustomerService\When_searching_for_a_customer.cs" />
     <Compile Include="ShopifyCustomerService\When_updating_a_customer.cs" />
     <Compile Include="ShopifyOrderService\Test_Data\OrderCreation.cs" />
+    <Compile Include="ShopifyOrderService\When_closing_an_order.cs" />
     <Compile Include="ShopifyOrderService\When_counting_orders.cs" />
     <Compile Include="ShopifyOrderService\When_creating_an_order.cs" />
+    <Compile Include="ShopifyOrderService\When_deleting_an_order.cs" />
+    <Compile Include="ShopifyOrderService\When_getting_an_order.cs" />
     <Compile Include="ShopifyOrderService\When_listing_orders.cs" />
     <Compile Include="ShopifyOrderService\When_listing_orders_with_options.cs" />
+    <Compile Include="ShopifyOrderService\When_opening_an_order.cs" />
+    <Compile Include="ShopifyOrderService\When_updating_an_order.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="ShopifyShopService\When_getting_a_shop.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ShopifySharp/Converters/ShopifyFulfillmentStatusConverter.cs
+++ b/ShopifySharp/Converters/ShopifyFulfillmentStatusConverter.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using ShopifySharp.Enums;
+
+namespace ShopifySharp.Converters
+{
+    /// <summary>
+    /// A custom enum converter for <see cref="ShopifyFulfillmentStatus"/> enums which sets the default value to <see cref="ShopifyFulfillmentStatus.None"/> when the value is null.
+    /// </summary>
+    public class ShopifyFulfillmentStatusConverter : StringEnumConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (string.IsNullOrEmpty(reader.Value?.ToString()))
+                return ShopifyFulfillmentStatus.None;
+
+            return base.ReadJson(reader, objectType, existingValue, serializer);
+        }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyClientDetails.cs
+++ b/ShopifySharp/Entities/ShopifyClientDetails.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyClientDetails
+    {
+        [JsonProperty("accept_language")]
+        public string AcceptLanguage { get; set; }
+
+        [JsonProperty("browser_height")]
+        public string BrowserHeight { get; set; }
+
+        [JsonProperty("browser_ip")]
+        public string BrowserIp { get; set; }
+
+        [JsonProperty("browser_width")]
+        public string BrowserWidth { get; set; }
+
+        [JsonProperty("session_height")]
+        public string SessionHeight { get; set; }
+
+        [JsonProperty("user_agent")]
+        public string UserAgent { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyClientDetails.cs
+++ b/ShopifySharp/Entities/ShopifyClientDetails.cs
@@ -9,21 +9,39 @@ namespace ShopifySharp
 {
     public class ShopifyClientDetails
     {
+        /// <summary>
+        /// Shopify does not offer documentation for this field.
+        /// </summary>
         [JsonProperty("accept_language")]
         public string AcceptLanguage { get; set; }
 
+        /// <summary>
+        /// The browser screen height in pixels, if available.
+        /// </summary>
         [JsonProperty("browser_height")]
         public string BrowserHeight { get; set; }
 
+        /// <summary>
+        /// The browser IP address.
+        /// </summary>
         [JsonProperty("browser_ip")]
         public string BrowserIp { get; set; }
 
+        /// <summary>
+        /// The browser screen width in pixels, if available.
+        /// </summary>
         [JsonProperty("browser_width")]
         public string BrowserWidth { get; set; }
 
+        /// <summary>
+        /// A hash of the session.
+        /// </summary>
         [JsonProperty("session_height")]
         public string SessionHeight { get; set; }
 
+        /// <summary>
+        /// The browser's user agent string.
+        /// </summary>
         [JsonProperty("user_agent")]
         public string UserAgent { get; set; }
     }

--- a/ShopifySharp/Entities/ShopifyDiscountCode.cs
+++ b/ShopifySharp/Entities/ShopifyDiscountCode.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyDiscountCode
+    {
+        /// <summary>
+        /// The amount of the discount.
+        /// </summary>
+        [JsonProperty("amount")]
+        public string Amount { get; set; }
+
+        /// <summary>
+        /// The discount code.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// The type of discount.
+        /// </summary>
+        [JsonProperty("type")]
+        public ShopifyDiscountCodeType Type { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyFulfillment.cs
+++ b/ShopifySharp/Entities/ShopifyFulfillment.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +9,52 @@ namespace ShopifySharp
 {
     public class ShopifyFulfillment : ShopifyObject
     {
+        /// <summary>
+        /// The date and time when the fulfillment was created. 
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
 
+        /// <summary>
+        /// A historical record of each item in the fulfillment.
+        /// </summary>
+        [JsonProperty("line_items")]
+        public IEnumerable<ShopifyLineItem> LineItems { get; set; }
+
+        /// <summary>
+        /// The unique numeric identifier for the order.
+        /// </summary>
+        [JsonProperty("order_id")]
+        public long OrderId { get; set; }
+
+        /// <summary>
+        /// A textfield with information about the receipt.
+        /// </summary>
+        [JsonProperty("receipt")]
+        public string Receipt { get; set; }
+
+        /// <summary>
+        /// The status of the fulfillment.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// The name of the shipping company.
+        /// </summary>
+        [JsonProperty("tracking_company")]
+        public string TrackingCompany { get; set; }
+
+        /// <summary>
+        /// The shipping number, provided by the shipping company.
+        /// </summary>
+        [JsonProperty("tracking_number")]
+        public string TrackingNumber { get; set; }
+
+        /// <summary>
+        /// The date and time when the fulfillment was last modified.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
     }
 }

--- a/ShopifySharp/Entities/ShopifyFulfillment.cs
+++ b/ShopifySharp/Entities/ShopifyFulfillment.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyFulfillment : ShopifyObject
+    {
+
+    }
+}

--- a/ShopifySharp/Entities/ShopifyFulfillment.cs
+++ b/ShopifySharp/Entities/ShopifyFulfillment.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// A textfield with information about the receipt.
         /// </summary>
         [JsonProperty("receipt")]
-        public string Receipt { get; set; }
+        public object Receipt { get; set; }
 
         /// <summary>
         /// The status of the fulfillment.

--- a/ShopifySharp/Entities/ShopifyLineItem.cs
+++ b/ShopifySharp/Entities/ShopifyLineItem.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyLineItem : ShopifyObject
+    {
+
+    }
+}

--- a/ShopifySharp/Entities/ShopifyLineItem.cs
+++ b/ShopifySharp/Entities/ShopifyLineItem.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +10,113 @@ namespace ShopifySharp
 {
     public class ShopifyLineItem : ShopifyObject
     {
+        /// <summary>
+        /// The amount available to fulfill. This is the quantity - max(refunded_quantity, fulfilled_quantity) - pending_fulfilled_quantity.
+        /// </summary>
+        [JsonProperty("fulfillable_quantity")]
+        public int FulfillableQuantity { get; set; }
 
+        /// <summary>
+        /// Service provider who is doing the fulfillment. Valid values are either "manual" or the name of the provider. eg: "amazon", "shipwire", etc.
+        /// </summary>
+        [JsonProperty("fulfillment_service")]
+        public string FulfillmentService { get; set; }
+
+        /// <summary>
+        /// The fulfillment status of this line item.
+        /// </summary>
+        [JsonProperty("fulfillment_status")]
+        public ShopifyFulfillmentStatus FulfillmentStatus { get; set; }
+
+        /// <summary>
+        /// The weight of the item in grams.
+        /// </summary>
+        [JsonProperty("grams")]
+        public int Grams { get; set; }
+
+        /// <summary>
+        /// The price of the item before discounts have been applied.
+        /// </summary>
+        /// <remarks>Shopify returns this value as a string.</remarks>
+        [JsonProperty("price")]
+        public double Price { get; set; }
+
+        /// <summary>
+        /// The unique numeric identifier for the product in the fulfillment. Can be null if the original product associated with the order is deleted at a later date
+        /// </summary>
+        [JsonProperty("product_id")]
+        public long? ProductId { get; set; }
+
+        /// <summary>
+        /// The number of products that were purchased.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// States whether or not the fulfillment requires shipping.
+        /// </summary>
+        [JsonProperty("requires_shipping")]
+        public bool RequiresShipping { get; set; }
+
+        /// <summary>
+        /// A unique identifier of the item in the fulfillment.
+        /// </summary>
+        [JsonProperty("sku")]
+        public string SKU { get; set; }
+
+        /// <summary>
+        /// The title of the product.
+        /// </summary>
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// The id of the product variant. Can be null if the product purchased is not a variant.
+        /// </summary>
+        [JsonProperty("variant_id")]
+        public long? VariantId { get; set; }
+
+        /// <summary>
+        /// The title of the product variant. Can be null if the product purchased is not a variant.
+        /// </summary>
+        [JsonProperty("variant_title")]
+        public string VariantTitle { get; set; }
+
+        /// <summary>
+        /// The name of the product variant.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The name of the supplier of the item.
+        /// </summary>
+        [JsonProperty("vendor")]
+        public string Vendor { get; set; }
+
+        /// <summary>
+        /// The name of the product variant.
+        /// </summary>
+        [JsonProperty("gift_card")]
+        public bool GiftCard { get; set; }
+
+        /// <summary>
+        /// States whether or not the product was taxable.
+        /// </summary>
+        [JsonProperty("taxable")]
+        public bool Taxable { get; set; }
+
+        /// <summary>
+        /// An array of <see cref="ShopifyTaxLine"/> objects, each of which details the taxes applicable to this <see cref="ShopifyLineItem"/>.
+        /// </summary>
+        [JsonProperty("tax_lines")]
+        public IEnumerable<ShopifyTaxLine> TaxLines { get; set; }
+
+        /// <summary>
+        /// The total discount amount applied to this line item. This value is not subtracted in the line item price.
+        /// </summary>
+        [JsonProperty("total_discount")]
+        public double TotalDiscount { get; set; }
     }
 }

--- a/ShopifySharp/Entities/ShopifyLineItem.cs
+++ b/ShopifySharp/Entities/ShopifyLineItem.cs
@@ -23,10 +23,10 @@ namespace ShopifySharp
         public string FulfillmentService { get; set; }
 
         /// <summary>
-        /// The fulfillment status of this line item.
+        /// The fulfillment status of this line item. Will be null if the line item has not been fulfilled or partially fulfilled.
         /// </summary>
         [JsonProperty("fulfillment_status")]
-        public ShopifyFulfillmentStatus FulfillmentStatus { get; set; }
+        public ShopifyFulfillmentStatus? FulfillmentStatus { get; set; }
 
         /// <summary>
         /// The weight of the item in grams.

--- a/ShopifySharp/Entities/ShopifyOrder.cs
+++ b/ShopifySharp/Entities/ShopifyOrder.cs
@@ -163,7 +163,7 @@ namespace ShopifySharp
         /// The type of payment processing method
         /// </summary>
         [JsonProperty("processing_method")]
-        public ShopifyProcessingMethod ProcessingMethod { get; set; }
+        public ShopifyProcessingMethod? ProcessingMethod { get; set; }
 
         /// <summary>
         /// The website that the customer clicked on to come to the shop.

--- a/ShopifySharp/Entities/ShopifyOrder.cs
+++ b/ShopifySharp/Entities/ShopifyOrder.cs
@@ -1,0 +1,260 @@
+﻿using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyOrder : ShopifyObject
+    {
+        /// <summary>
+        /// The mailing address associated with the payment method. This address is an optional field that will not be available on orders that do not require one. 
+        /// </summary>
+        [JsonProperty("billing_address")]
+        public ShopifyAddress BillingAddress { get; set; }
+
+        /// <summary>
+        /// The IP address of the browser used by the customer when placing the order.
+        /// </summary>
+        [JsonProperty("browser_ip")]
+        public string BrowserIp { get; set; }
+
+        /// <summary>
+        /// Indicates whether or not the person who placed the order would like to receive email updates from the shop. 
+        /// This is set when checking the "I want to receive occasional emails about new products, promotions and other news" checkbox during checkout.
+        /// </summary>
+        [JsonProperty("buyer_accepts_marketing")]
+        public bool BuyerAcceptsMarketing { get; set; }
+
+        /// <summary>
+        /// The reason why the order was cancelled. If the order was not cancelled, this value is null.
+        /// </summary>
+        [JsonProperty("cancel_reason")]
+        public ShopifyOrderCancelReason? CancelReason { get; set; }
+
+        /// <summary>
+        /// The date and time when the order was cancelled. If the order was not cancelled, this value is null.
+        /// </summary>
+        [JsonProperty("cancelled_at")]
+        public DateTime? CancelledAt { get; set; }
+
+        /// <summary>
+        /// Unique identifier for a particular cart that is attached to a particular order.
+        /// </summary>
+        [JsonProperty("cart_token")]
+        public string CartToken { get; set; }
+
+        /// <summary>
+        /// A <see cref="ShopifyClientDetails"/> object containing information about the client.
+        /// </summary>
+        [JsonProperty("client_details")]
+        public ShopifyClientDetails ClientDetails { get; set; }
+
+        /// <summary>
+        /// The date and time when the order was closed. If the order was not clsoed, this value is null.
+        /// </summary>
+        [JsonProperty("closed_at")]
+        public DateTime? ClosedAt { get; set; }
+
+        /// <summary>
+        /// The date and time when the order was created in Shopify.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// The three letter code (ISO 4217) for the currency used for the payment.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// A <see cref="ShopifyCustomer"/> object containing information about the customer. This value may be null if the order was created through Shopify POS.
+        /// </summary>
+        [JsonProperty("customer")]
+        public ShopifyCustomer Customer { get; set; }
+
+        /// <summary>
+        /// Applicable discount codes that can be applied to the order.
+        /// </summary>
+        [JsonProperty("discount_codes")]
+        public IEnumerable<ShopifyDiscountCode> DiscountCodes { get; set; }
+
+        /// <summary>
+        /// The customer's email address. Required when a billing address is present.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// The financial status of an order.
+        /// </summary>
+        [JsonProperty("financial_status")]
+        public ShopifyOrderFinancialStatus FinancialStatus { get; set; }
+
+        /// <summary>
+        /// An array of <see cref="ShopifyFulfillment"/> objects for this order.
+        /// </summary>
+        [JsonProperty("fulfillments")]
+        public IEnumerable<ShopifyFulfillment> Fulfillments { get; set; }
+
+        /// <summary>
+        /// The fulfillment status for this order.
+        /// </summary>
+        [JsonProperty("fulfillment_status")]
+        public ShopifyFulfillmentStatus FulfillmentStatus { get; set; }
+
+        /// <summary>
+        /// Tags are additional short descriptors, commonly used for filtering and searching, formatted as a string of comma-separated values.
+        /// </summary>
+        [JsonProperty("tags")]
+        public string Tags { get; set; }
+
+        /// <summary>
+        /// The URL for the page where the buyer landed when entering the shop.
+        /// </summary>
+        [JsonProperty("landing_site")]
+        public string LandingSite { get; set; }
+
+        /// <summary>
+        /// An array of <see cref="ShopifyLineItem"/> objects, each one containing information about an item in the order.
+        /// </summary>
+        [JsonProperty("line_items")]
+        public IEnumerable<ShopifyLineItem> LineItems { get; set; }
+
+        /// <summary>
+        /// The customer's order name as represented by a number, e.g. '#1001'.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The text of an optional note that a shop owner can attach to the order.
+        /// </summary>
+        [JsonProperty("note")]
+        public string Note { get; set; }
+
+        /// <summary>
+        /// Extra information that is added to the order. Each array entry must contain a hash with "name" and "value" keys.
+        /// </summary>
+        [JsonProperty("note_attributes")]
+        public IEnumerable<KeyValuePair<string, string>> NoteAttributes { get; set; }
+
+        /// <summary>
+        /// Numerical identifier unique to the shop. A number is sequential and starts at 1000.
+        /// </summary>
+        [JsonProperty("number")]
+        public int Number { get; set; }
+
+        /// <summary>
+        /// A unique numeric identifier for the order. This one is used by the shop owner and customer. 
+        /// This is different from the id property, which is also a unique numeric identifier for the order, but used for API purposes.
+        /// </summary>
+        [JsonProperty("order_number")]
+        public int OrderNumber { get; set; }
+
+        [JsonProperty("processed_at")]
+        public DateTime? ProcessedAt { get; set; }
+
+        /// <summary>
+        /// The type of payment processing method
+        /// </summary>
+        [JsonProperty("processing_method")]
+        public ShopifyProcessingMethod ProcessingMethod { get; set; }
+
+        /// <summary>
+        /// The website that the customer clicked on to come to the shop.
+        /// </summary>
+        [JsonProperty("referring_site")]
+        public string ReferringSite { get; set; }
+
+        /// <summary>
+        /// The mailing address to where the order will be shipped. This address is optional and will not be available on orders that do not require one.
+        /// </summary>
+        [JsonProperty("shipping_address")]
+        public ShopifyAddress ShippingAddress { get; set; }
+
+        /// <summary>
+        /// An array of <see cref="ShopifyShippingLine"/> objects, each of which details the shipping methods used.
+        /// </summary>
+        [JsonProperty("shipping_lines")]
+        public IEnumerable<ShopifyShippingLine> ShippingLines { get; set; }
+
+        /// <summary>
+        /// Where the order originated. May only be set during creation, and is not writeable thereafter.
+        /// Orders created via the API may be assigned any string of your choice except for "web", "pos", "iphone", and "android". 
+        /// Default is "api".
+        /// </summary>
+        [JsonProperty("source_name")]
+        public string SourceName { get; set; }
+
+        /// <summary>
+        /// Price of the order before shipping and taxes
+        /// </summary>
+        [JsonProperty("subtotal_price")]
+        public double SubtotalPrice { get; set; }
+
+        /// <summary>
+        /// An array of <see cref="ShopifyTaxLine"/> objects, each of which details the total taxes applicable to the order.
+        /// </summary>
+        [JsonProperty("tax_lines")]
+        public IEnumerable<ShopifyTaxLine> TaxLines { get; set; }
+
+        /// <summary>
+        /// States whether or not taxes are included in the order subtotal. 
+        /// </summary>
+        [JsonProperty("taxes_included")]
+        public bool TaxesIncluded { get; set; }
+
+        /// <summary>
+        /// Unique identifier for a particular order.
+        /// </summary>
+        [JsonProperty("token")]
+        public string Token { get; set; }
+
+        /// <summary>
+        /// The total amount of the discounts applied to the price of the order.
+        /// </summary>
+        [JsonProperty("total_discounts")]
+        public double TotalDiscounts { get; set; }
+
+        /// <summary>
+        /// The sum of all the prices of all the items in the order.
+        /// </summary>
+        [JsonProperty("total_line_items_price")]
+        public double TotalLineItemsPrice { get; set; }
+
+        /// <summary>
+        /// The sum of all the prices of all the items in the order, taxes and discounts included (must be positive).
+        /// </summary>
+        [JsonProperty("total_price")]
+        public double TotalPrice { get; set; }
+
+        /// <summary>
+        /// The sum of all the taxes applied to the order (must be positive).
+        /// </summary>
+        [JsonProperty("total_tax")]
+        public double TotalTax { get; set; }
+
+        /// <summary>
+        /// The sum of all the weights of the line items in the order, in grams.
+        /// </summary>
+        [JsonProperty("total_weight")]
+        public int TotalWeight { get; set; }
+
+        /// <summary>
+        /// The date and time when the order was last modified.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// An array of <see cref="ShopifyTransaction"/> objects that detail all of the transactions in this order.
+        /// </summary>
+        [JsonProperty("transactions")]
+        public IEnumerable<ShopifyTransaction> Transactions { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyOrder.cs
+++ b/ShopifySharp/Entities/ShopifyOrder.cs
@@ -102,10 +102,10 @@ namespace ShopifySharp
         public IEnumerable<ShopifyFulfillment> Fulfillments { get; set; }
 
         /// <summary>
-        /// The fulfillment status for this order.
+        /// The fulfillment status for this order. Will be null if none of the line items in the order have been fulfilled.
         /// </summary>
         [JsonProperty("fulfillment_status")]
-        public ShopifyFulfillmentStatus FulfillmentStatus { get; set; }
+        public ShopifyFulfillmentStatus? FulfillmentStatus { get; set; }
 
         /// <summary>
         /// Tags are additional short descriptors, commonly used for filtering and searching, formatted as a string of comma-separated values.

--- a/ShopifySharp/Entities/ShopifyPaymentDetails.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentDetails.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyPaymentDetails
+    {
+        [JsonProperty("avs_result_code")]
+        public string AvsResultCode { get; set; }
+
+        [JsonProperty("credit_card_bin")]
+        public string CreditCardBin { get; set; }
+
+        [JsonProperty("cvv_result_code")]
+        public string CvvResultCode { get; set; }
+
+        [JsonProperty("credit_card_number")]
+        public string CreditCardNumber { get; set; }
+
+        [JsonProperty("credit_card_company")]
+        public string CreditCardCompany { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyShippingLine.cs
+++ b/ShopifySharp/Entities/ShopifyShippingLine.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyShippingLine
+    {
+        /// <summary>
+        /// A reference to the shipping method.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// The price of this shipping method.
+        /// </summary>
+        [JsonProperty("price")]
+        public double Price { get; set; }
+
+        /// <summary>
+        /// The source of the shipping method.
+        /// </summary>
+        [JsonProperty("source")]
+        public string Source { get; set; }
+
+        /// <summary>
+        /// The title of the shipping method.
+        /// </summary>
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// A list of <see cref="ShopifyTaxLine"/> objects, each of which details the taxes applicable to this <see cref="ShopifyShippingLine"/>.
+        /// </summary>
+        [JsonProperty("tax_lines")]
+        public IEnumerable<ShopifyTaxLine> TaxLines { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyTaxLine.cs
+++ b/ShopifySharp/Entities/ShopifyTaxLine.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyTaxLine
+    {
+        /// <summary>
+        /// The amount of tax to be charged.    
+        /// </summary>
+        [JsonProperty("price")]
+        public double Price { get; set; }
+
+        /// <summary>
+        /// The rate of tax to be applied.
+        /// </summary>
+        [JsonProperty("rate")]
+        public double Rate { get; set; }
+
+        /// <summary>
+        /// The name of the tax.
+        /// </summary>
+        [JsonProperty("title")]
+        public string Title { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyTransaction.cs
+++ b/ShopifySharp/Entities/ShopifyTransaction.cs
@@ -1,0 +1,104 @@
+﻿using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyTransaction
+    {
+        /// <summary>
+        /// The amount of money that the transaction was for.
+        /// </summary>
+        /// <remarks>Like a lot of the Shopify API, the number is actually a string. Json.Net should be able to convert it to a double.</remarks>
+        [JsonProperty("amount")]
+        public double Amount { get; set; }
+
+        /// <summary>
+        /// The authorization code associated with the transaction.
+        /// </summary>
+        [JsonProperty("authorization")]
+        public string Authorization { get; set; }
+
+        /// <summary>
+        /// The date and time when the transaction was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// The unique identifier for the device.
+        /// </summary>
+        [JsonProperty("device_id")]
+        public string DeviceId { get; set; }
+
+        /// <summary>
+        /// The name of the gateway the transaction was issued through.
+        /// </summary>
+        [JsonProperty("gateway")]
+        public string Gateway { get; set; }
+
+        /// <summary>
+        /// The origin of the transaction. This is set by Shopify and cannot be overridden. Example values include: 'web', 'pos', 'iphone', 'android'.
+        /// </summary>
+        [JsonProperty("source_name")]
+        public string SourceName { get; private set; }
+
+        /// <summary>
+        /// An object containing information about the credit card used for this transaction.
+        /// </summary>
+        [JsonProperty("payment_details")]
+        public ShopifyPaymentDetails PaymentDetails { get; set; }
+
+        /// <summary>
+        /// The kind of transaction.
+        /// </summary>
+        [JsonProperty("kind")]
+        public ShopifyTransactionKind Kind { get; set; }
+
+        /// <summary>
+        /// A unique numeric identifier for the order.
+        /// </summary>
+        [JsonProperty("order_id")]
+        public long OrderId { get; set; }
+
+        /// <summary>
+        /// Shopify does not currently offer documentation for this object.
+        /// </summary>
+        [JsonProperty("receipt")]
+        public object Receipt { get; set; }
+
+        /// <summary>
+        /// A standardized error code, independent of the payment provider. Value can be null. 
+        /// </summary>
+        [JsonProperty("error_code")]
+        public ShopifyTransactionError ErrorCode { get; set; }
+
+        /// <summary>
+        /// The status of the transaction. Valid values are: pending, failure, success or error.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Whether the transaction is for testing purposes.
+        /// </summary>
+        [JsonProperty("test")]
+        public bool Test { get; set; }
+
+        /// <summary>
+        /// The unique identifier for the user.
+        /// </summary>
+        [JsonProperty("user_id")]
+        public long? UserId { get; set; }
+
+        /// <summary>
+        /// The three letter code (ISO 4217) for the currency used for the payment.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+    }
+}

--- a/ShopifySharp/Enums/ShopifyAuthorizationScope.cs
+++ b/ShopifySharp/Enums/ShopifyAuthorizationScope.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace ShopifySharp
+namespace ShopifySharp.Enums
 {
     public enum ShopifyAuthorizationScope
     {

--- a/ShopifySharp/Enums/ShopifyAuthorizationScope.cs
+++ b/ShopifySharp/Enums/ShopifyAuthorizationScope.cs
@@ -1,60 +1,64 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace ShopifySharp.Enums
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyAuthorizationScope
     {
-        [Description("read_content")]
+        [EnumMember(Value = "read_content")]
         ReadContent,
 
-        [Description("write_content")]
+        [EnumMember(Value = "write_content")]
         WriteContent,
 
-        [Description("read_themes")]
+        [EnumMember(Value = "read_themes")]
         ReadThemes,
 
-        [Description("write_themes")]
+        [EnumMember(Value = "write_themes")]
         WriteThemes,
 
-        [Description("read_products")]
+        [EnumMember(Value = "read_products")]
         ReadProducts,
 
-        [Description("write_products")]
+        [EnumMember(Value = "write_products")]
         WriteProducts,
 
-        [Description("read_customers")]
+        [EnumMember(Value = "read_customers")]
         ReadCustomers,
 
-        [Description("write_customers")]
+        [EnumMember(Value = "write_customers")]
         WriteCustomers,
 
-        [Description("read_orders")]
+        [EnumMember(Value = "read_orders")]
         ReadOrders,
 
-        [Description("write_orders")]
+        [EnumMember(Value = "write_orders")]
         WriteOrders,
 
-        [Description("read_script_tags")]
+        [EnumMember(Value = "read_script_tags")]
         ReadScriptTags,
 
-        [Description("write_script_tags")]
+        [EnumMember(Value = "write_script_tags")]
         WriteScriptTags,
 
-        [Description("read_fulfillments")]
+        [EnumMember(Value = "read_fulfillments")]
         ReadFulfillments,
 
-        [Description("write_fulfillments")]
+        [EnumMember(Value = "write_fulfillments")]
         WriteFulfillments,
 
-        [Description("read_shipping")]
+        [EnumMember(Value = "read_shipping")]
         ReadShipping,
 
-        [Description("write_shipping")]
+        [EnumMember(Value = "write_shipping")]
         WriteShipping
     }
 }

--- a/ShopifySharp/Enums/ShopifyDiscountCodeType.cs
+++ b/ShopifySharp/Enums/ShopifyDiscountCodeType.cs
@@ -4,21 +4,24 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace ShopifySharp.Enums
 {
     /// <summary>
     /// The type of discount.
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyDiscountCodeType
     {
-        [JsonProperty("percentage")]
+        [EnumMember(Value = "percentage")]
         Percentage,
 
-        [JsonProperty("shipping")]
+        [EnumMember(Value = "shipping")]
         Shipping,
 
-        [JsonProperty("fixed_amount")]
+        [EnumMember(Value = "fixed_amount")]
         FixedAmount
     }
 }

--- a/ShopifySharp/Enums/ShopifyDiscountCodeType.cs
+++ b/ShopifySharp/Enums/ShopifyDiscountCodeType.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// The type of discount.
+    /// </summary>
+    public enum ShopifyDiscountCodeType
+    {
+        [JsonProperty("percentage")]
+        Percentage,
+
+        [JsonProperty("shipping")]
+        Shipping,
+
+        [JsonProperty("fixed_amount")]
+        FixedAmount
+    }
+}

--- a/ShopifySharp/Enums/ShopifyFulfillmentStatus.cs
+++ b/ShopifySharp/Enums/ShopifyFulfillmentStatus.cs
@@ -4,12 +4,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using ShopifySharp.Converters;
 
 namespace ShopifySharp.Enums
 {
     /// <summary>
     /// The status of a fulfillment.
     /// </summary>
+    [JsonConverter(typeof(ShopifyFulfillmentStatusConverter))]
     public enum ShopifyFulfillmentStatus
     {
         /// <summary>
@@ -21,8 +24,8 @@ namespace ShopifySharp.Enums
         /// <summary>
         /// None of the line items in the order have been fulfilled.
         /// </summary>
-        [JsonProperty("null")]
-        Null,
+        [JsonProperty("none")]
+        None,
 
         /// <summary>
         /// At least one line item in the order has been fulfilled.

--- a/ShopifySharp/Enums/ShopifyFulfillmentStatus.cs
+++ b/ShopifySharp/Enums/ShopifyFulfillmentStatus.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// The status of a fulfillment.
+    /// </summary>
+    public enum ShopifyFulfillmentStatus
+    {
+        /// <summary>
+        /// Every line item in the order has been fulfilled.
+        /// </summary>
+        [JsonProperty("fulfilled")]
+        Fulfilled,
+
+        /// <summary>
+        /// None of the line items in the order have been fulfilled.
+        /// </summary>
+        [JsonProperty("null")]
+        Null,
+
+        /// <summary>
+        /// At least one line item in the order has been fulfilled.
+        /// </summary>
+        [JsonProperty("partial")]
+        Partial
+    }
+}

--- a/ShopifySharp/Enums/ShopifyFulfillmentStatus.cs
+++ b/ShopifySharp/Enums/ShopifyFulfillmentStatus.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using ShopifySharp.Converters;
+using System.Runtime.Serialization;
 
 namespace ShopifySharp.Enums
 {
@@ -18,19 +19,19 @@ namespace ShopifySharp.Enums
         /// <summary>
         /// Every line item in the order has been fulfilled.
         /// </summary>
-        [JsonProperty("fulfilled")]
+        [EnumMember(Value = "fulfilled")]
         Fulfilled,
 
         /// <summary>
         /// None of the line items in the order have been fulfilled.
         /// </summary>
-        [JsonProperty("none")]
+        [EnumMember(Value = "none")]
         None,
 
         /// <summary>
         /// At least one line item in the order has been fulfilled.
         /// </summary>
-        [JsonProperty("partial")]
+        [EnumMember(Value = "partial")]
         Partial
     }
 }

--- a/ShopifySharp/Enums/ShopifyInventoryBehavior.cs
+++ b/ShopifySharp/Enums/ShopifyInventoryBehavior.cs
@@ -1,30 +1,33 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace ShopifySharp.Enums
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyInventoryBehavior
     {
         /// <summary>
         /// Do not claim inventory. Default.
         /// </summary>
-        [JsonProperty("bypass")]
+        [EnumMember(Value = "bypass")]
         Bypass,
 
         /// <summary>
         /// Ignore the product's inventory policy and claim amounts no matter what.
         /// </summary>
-        [JsonProperty("decrement_ignoring_policy")]
+        [EnumMember(Value = "decrement_ignoring_policy")]
         DecrementIgnoringPolicy,
 
         /// <summary>
         /// Obey the product's inventory policy.
         /// </summary>
-        [JsonProperty("decrement_obeying_policy")]
+        [EnumMember(Value = "decrement_obeying_policy")]
         DecrementObeyingPolicy
     }
 }

--- a/ShopifySharp/Enums/ShopifyInventoryBehavior.cs
+++ b/ShopifySharp/Enums/ShopifyInventoryBehavior.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Enums
+{
+    public enum ShopifyInventoryBehavior
+    {
+        /// <summary>
+        /// Do not claim inventory. Default.
+        /// </summary>
+        [JsonProperty("bypass")]
+        Bypass,
+
+        /// <summary>
+        /// Ignore the product's inventory policy and claim amounts no matter what.
+        /// </summary>
+        [JsonProperty("decrement_ignoring_policy")]
+        DecrementIgnoringPolicy,
+
+        /// <summary>
+        /// Obey the product's inventory policy.
+        /// </summary>
+        [JsonProperty("decrement_obeying_policy")]
+        DecrementObeyingPolicy
+    }
+}

--- a/ShopifySharp/Enums/ShopifyOrderCancelReason.cs
+++ b/ShopifySharp/Enums/ShopifyOrderCancelReason.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// The reason why an order was cancelled.
+    /// </summary>
+    public enum ShopifyOrderCancelReason
+    {
+        /// <summary>
+        /// The customer changed or cancelled the order.
+        /// </summary>
+        [JsonProperty("customer")]
+        Customer,
+
+        /// <summary>
+        /// The order was fraudulent.
+        /// </summary>
+        [JsonProperty("fraud")]
+        Fraud,
+
+        /// <summary>
+        /// Items in the order were not in inventory.
+        /// </summary>
+        [JsonProperty("inventory")]
+        Inventory,
+
+        /// <summary>
+        /// The order was cancelled for a reason not in the list above.
+        /// </summary>
+        [JsonProperty("other")]
+        Other
+    }
+}

--- a/ShopifySharp/Enums/ShopifyOrderCancelReason.cs
+++ b/ShopifySharp/Enums/ShopifyOrderCancelReason.cs
@@ -4,36 +4,39 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace ShopifySharp.Enums
 {
     /// <summary>
     /// The reason why an order was cancelled.
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyOrderCancelReason
     {
         /// <summary>
         /// The customer changed or cancelled the order.
         /// </summary>
-        [JsonProperty("customer")]
+        [EnumMember(Value = "customer")]
         Customer,
 
         /// <summary>
         /// The order was fraudulent.
         /// </summary>
-        [JsonProperty("fraud")]
+        [EnumMember(Value = "fraud")]
         Fraud,
 
         /// <summary>
         /// Items in the order were not in inventory.
         /// </summary>
-        [JsonProperty("inventory")]
+        [EnumMember(Value = "inventory")]
         Inventory,
 
         /// <summary>
         /// The order was cancelled for a reason not in the list above.
         /// </summary>
-        [JsonProperty("other")]
+        [EnumMember(Value = "other")]
         Other
     }
 }

--- a/ShopifySharp/Enums/ShopifyOrderFinancialStatus.cs
+++ b/ShopifySharp/Enums/ShopifyOrderFinancialStatus.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// The financial status of an order.
+    /// </summary>
+    public enum ShopifyOrderFinancialStatus
+    {
+        /// <summary>
+        /// The finances are pending.
+        /// </summary>
+        [JsonProperty("pending")]
+        Pending,
+
+        /// <summary>
+        /// The finances have been authorized.
+        /// </summary>
+        [JsonProperty("authorized")]
+        Authorized,
+
+        /// <summary>
+        /// The finances have been partially paid.
+        /// </summary>
+        [JsonProperty("partially_paid")]
+        PartiallyPaid,
+
+        /// <summary>
+        /// The finances have been paid. (This is the default value.)
+        /// </summary>
+        [JsonProperty("paid")]
+        Paid,
+
+        /// <summary>
+        /// The finances have been partially refunded.
+        /// </summary>
+        [JsonProperty("partially_refunded")]
+        PartiallyRefunded,
+
+        /// <summary>
+        /// The finances have been refunded.
+        /// </summary>
+        [JsonProperty("refunded")]
+        Refunded,
+
+        /// <summary>
+        /// The finances have been voided.
+        /// </summary>
+        [JsonProperty("voided")]
+        Voided
+    }
+}

--- a/ShopifySharp/Enums/ShopifyOrderFinancialStatus.cs
+++ b/ShopifySharp/Enums/ShopifyOrderFinancialStatus.cs
@@ -4,54 +4,57 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace ShopifySharp.Enums
 {
     /// <summary>
     /// The financial status of an order.
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyOrderFinancialStatus
     {
         /// <summary>
         /// The finances are pending.
         /// </summary>
-        [JsonProperty("pending")]
+        [EnumMember(Value = "pending")]
         Pending,
 
         /// <summary>
         /// The finances have been authorized.
         /// </summary>
-        [JsonProperty("authorized")]
+        [EnumMember(Value = "authorized")]
         Authorized,
 
         /// <summary>
         /// The finances have been partially paid.
         /// </summary>
-        [JsonProperty("partially_paid")]
+        [EnumMember(Value = "partially_paid")]
         PartiallyPaid,
 
         /// <summary>
         /// The finances have been paid. (This is the default value.)
         /// </summary>
-        [JsonProperty("paid")]
+        [EnumMember(Value = "paid")]
         Paid,
 
         /// <summary>
         /// The finances have been partially refunded.
         /// </summary>
-        [JsonProperty("partially_refunded")]
+        [EnumMember(Value = "partially_refunded")]
         PartiallyRefunded,
 
         /// <summary>
         /// The finances have been refunded.
         /// </summary>
-        [JsonProperty("refunded")]
+        [EnumMember(Value = "refunded")]
         Refunded,
 
         /// <summary>
         /// The finances have been voided.
         /// </summary>
-        [JsonProperty("voided")]
+        [EnumMember(Value = "voided")]
         Voided
     }
 }

--- a/ShopifySharp/Enums/ShopifyOrderStatus.cs
+++ b/ShopifySharp/Enums/ShopifyOrderStatus.cs
@@ -1,24 +1,27 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace ShopifySharp.Enums
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyOrderStatus
     {
-        [JsonProperty("open")]
+        [EnumMember(Value = "open")]
         Open,
 
-        [JsonProperty("closed")]
+        [EnumMember(Value = "closed")]
         Closed,
 
-        [JsonProperty("cancelled")]
+        [EnumMember(Value = "cancelled")]
         Cancelled,
 
-        [JsonProperty("any")]
+        [EnumMember(Value = "any")]
         Any
     }
 }

--- a/ShopifySharp/Enums/ShopifyOrderStatus.cs
+++ b/ShopifySharp/Enums/ShopifyOrderStatus.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Enums
+{
+    public enum ShopifyOrderStatus
+    {
+        [JsonProperty("open")]
+        Open,
+
+        [JsonProperty("closed")]
+        Closed,
+
+        [JsonProperty("cancelled")]
+        Cancelled,
+
+        [JsonProperty("any")]
+        Any
+    }
+}

--- a/ShopifySharp/Enums/ShopifyProcessingMethod.cs
+++ b/ShopifySharp/Enums/ShopifyProcessingMethod.cs
@@ -4,27 +4,33 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using Newtonsoft.Json.Converters;
 
 namespace ShopifySharp.Enums
 {
     /// <summary>
     /// The type of payment processing method
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyProcessingMethod
     {
-        [JsonProperty("checkout")]
+        [EnumMember(Value = "checkout")]
         Checkout,
 
-        [JsonProperty("direct")]
+        [EnumMember(Value = "direct")]
         Direct,
 
-        [JsonProperty("manual")]
+        [EnumMember(Value = "manual")]
         Manual,
 
-        [JsonProperty("offsite")]
+        [EnumMember(Value = "offsite")]
         Offsite,
 
-        [JsonProperty("express")]
-        Express
+        [EnumMember(Value = "express")]
+        Express,
+
+        [EnumMember(Value = "none")]
+        None
     }
 }

--- a/ShopifySharp/Enums/ShopifyProcessingMethod.cs
+++ b/ShopifySharp/Enums/ShopifyProcessingMethod.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// The type of payment processing method
+    /// </summary>
+    public enum ShopifyProcessingMethod
+    {
+        [JsonProperty("checkout")]
+        Checkout,
+
+        [JsonProperty("direct")]
+        Direct,
+
+        [JsonProperty("manual")]
+        Manual,
+
+        [JsonProperty("offsite")]
+        Offsite,
+
+        [JsonProperty("express")]
+        Express
+    }
+}

--- a/ShopifySharp/Enums/ShopifyTransactionError.cs
+++ b/ShopifySharp/Enums/ShopifyTransactionError.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// A standardized error code, independent of the payment provider.
+    /// </summary>
+    public enum ShopifyTransactionError
+    {
+        [JsonProperty("incorrect_number")]
+        IncorrectNumber,
+
+        [JsonProperty("invalid_number")]
+        InvalidNumber,
+
+        [JsonProperty("invalid_expiry_date")]
+        InvalidExpiryDate,
+
+        [JsonProperty("invalid_cvc")]
+        InvalidCvc,
+
+        [JsonProperty("expired_card")]
+        ExpiredCard,
+
+        [JsonProperty("incorrect_cvc")]
+        IncorrectCvc,
+
+        [JsonProperty("incorrect_zip")]
+        IncorrectZip,
+
+        [JsonProperty("incorrect_address")]
+        IncorrectAddress,
+
+        [JsonProperty("card_declined")]
+        CardDeclined,
+
+        [JsonProperty("processing_error")]
+        ProcesingError,
+        
+        [JsonProperty("call_issuer")]
+        CallIssuer,
+
+        [JsonProperty("pick_up_card")]
+        PickUpCard
+    }
+}

--- a/ShopifySharp/Enums/ShopifyTransactionError.cs
+++ b/ShopifySharp/Enums/ShopifyTransactionError.cs
@@ -1,7 +1,9 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -10,42 +12,43 @@ namespace ShopifySharp.Enums
     /// <summary>
     /// A standardized error code, independent of the payment provider.
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyTransactionError
     {
-        [JsonProperty("incorrect_number")]
+        [EnumMember(Value = "incorrect_number")]
         IncorrectNumber,
 
-        [JsonProperty("invalid_number")]
+        [EnumMember(Value = "invalid_number")]
         InvalidNumber,
 
-        [JsonProperty("invalid_expiry_date")]
+        [EnumMember(Value = "invalid_expiry_date")]
         InvalidExpiryDate,
 
-        [JsonProperty("invalid_cvc")]
+        [EnumMember(Value = "invalid_cvc")]
         InvalidCvc,
 
-        [JsonProperty("expired_card")]
+        [EnumMember(Value = "expired_card")]
         ExpiredCard,
 
-        [JsonProperty("incorrect_cvc")]
+        [EnumMember(Value = "incorrect_cvc")]
         IncorrectCvc,
 
-        [JsonProperty("incorrect_zip")]
+        [EnumMember(Value = "incorrect_zip")]
         IncorrectZip,
 
-        [JsonProperty("incorrect_address")]
+        [EnumMember(Value = "incorrect_address")]
         IncorrectAddress,
 
-        [JsonProperty("card_declined")]
+        [EnumMember(Value = "card_declined")]
         CardDeclined,
 
-        [JsonProperty("processing_error")]
+        [EnumMember(Value = "processing_error")]
         ProcesingError,
         
-        [JsonProperty("call_issuer")]
+        [EnumMember(Value = "call_issuer")]
         CallIssuer,
 
-        [JsonProperty("pick_up_card")]
+        [EnumMember(Value = "pick_up_card")]
         PickUpCard
     }
 }

--- a/ShopifySharp/Enums/ShopifyTransactionKind.cs
+++ b/ShopifySharp/Enums/ShopifyTransactionKind.cs
@@ -1,7 +1,9 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -10,36 +12,37 @@ namespace ShopifySharp.Enums
     /// <summary>
     /// The kind of transaction.
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ShopifyTransactionKind
     {
         /// <summary>
         /// Money that the customer has agreed to pay. Authorization period lasts for up to 7 to 30 days (depending on your payment service) while a store awaits for a customer's capture.
         /// </summary>
-        [JsonProperty("authorization")] 
+        [EnumMember(Value = "authorization")] 
         Authorization,
 
         /// <summary>
         /// Transfer of money that was reserved during the authorization of a shop.
         /// </summary>
-        [JsonProperty("capture")]
+        [EnumMember(Value = "capture")]
         Capture,
 
         /// <summary>
         /// The combination of authorization and capture, performed in one single step.
         /// </summary>
-        [JsonProperty("sale")]
+        [EnumMember(Value = "sale")]
         Sale,
 
         /// <summary>
         /// The cancellation of a pending authorization or capture.
         /// </summary>
-        [JsonProperty("void")]
+        [EnumMember(Value = "void")]
         Void,
 
         /// <summary>
         /// The partial or full return of the captured money to the customer.
         /// </summary>
-        [JsonProperty("refund")]
+        [EnumMember(Value = "refund")]
         Refund
     }
 }

--- a/ShopifySharp/Enums/ShopifyTransactionKind.cs
+++ b/ShopifySharp/Enums/ShopifyTransactionKind.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// The kind of transaction.
+    /// </summary>
+    public enum ShopifyTransactionKind
+    {
+        /// <summary>
+        /// Money that the customer has agreed to pay. Authorization period lasts for up to 7 to 30 days (depending on your payment service) while a store awaits for a customer's capture.
+        /// </summary>
+        [JsonProperty("authorization")] 
+        Authorization,
+
+        /// <summary>
+        /// Transfer of money that was reserved during the authorization of a shop.
+        /// </summary>
+        [JsonProperty("capture")]
+        Capture,
+
+        /// <summary>
+        /// The combination of authorization and capture, performed in one single step.
+        /// </summary>
+        [JsonProperty("sale")]
+        Sale,
+
+        /// <summary>
+        /// The cancellation of a pending authorization or capture.
+        /// </summary>
+        [JsonProperty("void")]
+        Void,
+
+        /// <summary>
+        /// The partial or full return of the captured money to the customer.
+        /// </summary>
+        [JsonProperty("refund")]
+        Refund
+    }
+}

--- a/ShopifySharp/Extensions/EnumExtensions.cs
+++ b/ShopifySharp/Extensions/EnumExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.Serialization;
+
+namespace ShopifySharp
+{
+    public static class EnumExtensions
+    {
+        /// <summary>
+        /// Reads and uses the enum's <see cref="EnumMemberAttribute"/> for serialization. 
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string ToSerializedString(this Enum input)
+        {
+            string name = input.ToString();
+            MemberInfo[] info = input.GetType().GetMember(name);
+
+            if (info.Length > 0)
+            {
+                var attribute = info[0].GetCustomAttribute<EnumMemberAttribute>();
+
+                if(attribute != null)
+                {
+                    return attribute.Value;
+                }
+            }
+
+            return name.ToLower();
+        }
+    }
+}

--- a/ShopifySharp/GlobalSuppressions.cs
+++ b/ShopifySharp/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Language Usage Opportunities", "RECS0091:Use 'var' keyword when possible")]
+

--- a/ShopifySharp/Infrastructure/RequestEngine.cs
+++ b/ShopifySharp/Infrastructure/RequestEngine.cs
@@ -129,14 +129,7 @@ namespace ShopifySharp
 
                 if(parsed.Any(x => x.Path == "errors"))
                 {
-                    if(parsed["errors"].Type == JTokenType.String)
-                    {
-                        error.Errors = parsed.Value<string>("errors");
-                    }
-                    else
-                    {
-                        error.Errors = parsed["errors"].ToString(Formatting.Indented);
-                    }
+                    error.Errors = parsed["errors"].Type == JTokenType.String ? parsed.Value<string>("errors") : parsed["errors"].ToString(Formatting.Indented);
                 }
                 else
                 {

--- a/ShopifySharp/Infrastructure/RequestEngine.cs
+++ b/ShopifySharp/Infrastructure/RequestEngine.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-    internal static class RequestEngine
+    static class RequestEngine
     {
         /// <summary>
         /// Attempts to build a shop API <see cref="Uri"/> for the given shop.
@@ -119,7 +119,7 @@ namespace ShopifySharp
         /// Checks an <see cref="IRestResponse" /> for exceptions or invalid responses. Throws an exception when necessary.
         /// </summary>
         /// <param name="response">The response.</param>
-        private static void CheckResponseExceptions(IRestResponse response)
+        static void CheckResponseExceptions(IRestResponse response)
         {
             if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Created)
             {

--- a/ShopifySharp/Services/Authorization/ShopifyAuthorizationService.cs
+++ b/ShopifySharp/Services/Authorization/ShopifyAuthorizationService.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.IO;
 using RestSharp;
 using Newtonsoft.Json.Linq;
+using ShopifySharp.Enums;
 
 namespace ShopifySharp
 {

--- a/ShopifySharp/Services/Authorization/ShopifyAuthorizationService.cs
+++ b/ShopifySharp/Services/Authorization/ShopifyAuthorizationService.cs
@@ -11,6 +11,7 @@ using System.IO;
 using RestSharp;
 using Newtonsoft.Json.Linq;
 using ShopifySharp.Enums;
+using Newtonsoft.Json;
 
 namespace ShopifySharp
 {
@@ -122,7 +123,7 @@ namespace ShopifySharp
             List<KeyValuePair<string, string>> qs = new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>("client_id", shopifyApiKey),
-                new KeyValuePair<string, string>("scope", string.Join(",", scopes.Select(s => s.Humanize()))),
+                new KeyValuePair<string, string>("scope", string.Join(",", scopes.Select(s => s.ToSerializedString()))),
             };
 
             if (string.IsNullOrEmpty(redirectUrl) == false)

--- a/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
+++ b/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
@@ -117,7 +117,7 @@ namespace ShopifySharp
         {
             IRestRequest req = RequestEngine.CreateRequest("customers/{0}.json".FormatWith(customer.Id.Value), Method.PUT, "customer");
 
-            req.AddJsonBody(new { customer = customer });
+            req.AddJsonBody(new { customer });
 
             return await RequestEngine.ExecuteRequestAsync<ShopifyCustomer>(_RestClient, req);
         }

--- a/ShopifySharp/Services/Order/ShopifyOrderCreateOptions.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderCreateOptions.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyOrderCreateOptions : Parameterizable
+    {
+        [JsonProperty("send_webhooks")]
+        public bool? SendWebhooks { get; set; }
+
+        [JsonProperty("send_receipt")]
+        public bool? SendReceipt { get; set; }
+
+        [JsonProperty("send_fulfillment_receipt")]
+        public bool? SendFulfillmentReceipt { get; set; }
+
+        [JsonProperty("inventory_behavior")]
+        public ShopifyInventoryBehavior? InventoryBehavior {get; set;}
+    }
+}

--- a/ShopifySharp/Services/Order/ShopifyOrderFilterOptions.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderFilterOptions.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyOrderFilterOptions : ShopifyFilterOptions
+    {
+        /// <summary>
+        /// An optional array of order ids to retrieve. 
+        /// </summary>
+        public IEnumerable<long> Ids { get; set; }
+
+        /// <summary>
+        /// The status of orders to retrieve. Default is <see cref="ShopifyOrderStatus.Any"/>.
+        /// </summary>
+        [JsonProperty("status")]
+        public ShopifyOrderStatus Status { get; set; } = ShopifyOrderStatus.Any;
+
+        /// <summary>
+        /// The financial status of orders to retrieve. Leave this null to retrieve orders with any financial status.
+        /// </summary>
+        [JsonProperty("financial_status")]
+        public ShopifyOrderFinancialStatus FinancialStatus { get; set; }
+
+        /// <summary>
+        /// The fulfillment status of orders to retrieve. Leave this null to retrieve orders with any fulfillment status.
+        /// </summary>
+        [JsonProperty("fulfillment_status")]
+        public ShopifyFulfillmentStatus FulfillmentStatus { get; set; }
+    }
+}

--- a/ShopifySharp/Services/Order/ShopifyOrderService.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Humanizer;
+using Newtonsoft.Json.Linq;
+using RestSharp;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,55 +18,147 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
-        public ShopifyOrderService(string myShopifyUrl, string shopAccessToken): base(myShopifyUrl, shopAccessToken) { }
+        public ShopifyOrderService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
         #endregion
 
         #region Public, non-static methods
 
-        public async Task<int> CountAsync()
+        /// <summary>
+        /// Gets a count of all of the shop's orders.
+        /// </summary>
+        /// <param name="options">Options for filtering the count.</param>
+        /// <returns>The count of all orders for the shop.</returns>
+        public async Task<int> CountAsync(ShopifyOrderFilterOptions options = null)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders/count.json", Method.GET);
+
+            //Add optional parameters to request
+            if (options != null) req.Parameters.AddRange(options.ToParameters(ParameterType.GetOrPost));
+
+            JToken responseObject = await RequestEngine.ExecuteRequestAsync(_RestClient, req);
+
+            //Response looks like { "count" : 123 }. Does not warrant its own class.
+            return responseObject.Value<int>("count");
         }
 
-        public async Task<ShopifyOrder> ListAsync()
+        /// <summary>
+        /// Gets a list of up to 250 of the shop's orders.
+        /// </summary>
+        /// <param name="options">Options for filtering the list.</param>
+        /// <returns>The list of orders matching the filter.</returns>
+        public async Task<IEnumerable<ShopifyOrder>> ListAsync(ShopifyOrderFilterOptions options = null)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders.json", Method.GET, "orders");
+
+            //Add optional parameters to request
+            if (options != null) req.Parameters.AddRange(options.ToParameters(ParameterType.GetOrPost));
+
+            return await RequestEngine.ExecuteRequestAsync<List<ShopifyOrder>>(_RestClient, req);
         }
 
-        public async Task<IEnumerable<ShopifyOrder>> ListForCustomerAsync(long customerId)
+        /// <summary>
+        /// Gets a list of up to 250 of the customer's orders.
+        /// </summary>
+        /// <param name="options">Options for filtering the list.</param>
+        /// <returns>The list of orders matching the filter.</returns>
+        public async Task<IEnumerable<ShopifyOrder>> ListForCustomerAsync(long customerId, ShopifyOrderFilterOptions options = null)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders.json", Method.GET, "orders");
+
+            //Add the customer id to the filter
+            req.Parameters.Add(new Parameter() { Name = "customer_id", Value = customerId, Type = ParameterType.GetOrPost });
+
+            //Add optional parameters to request
+            if (options != null) req.Parameters.AddRange(options.ToParameters(ParameterType.GetOrPost));
+
+            return await RequestEngine.ExecuteRequestAsync<List<ShopifyOrder>>(_RestClient, req);
         }
 
-        public async Task<ShopifyOrder> GetAsync(long id)
+        /// <summary>
+        /// Retrieves the <see cref="ShopifyOrder"/> with the given id.
+        /// </summary>
+        /// <param name="orderId">The id of the order to retrieve.</param>
+        /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <returns>The <see cref="ShopifyOrder"/>.</returns>
+        public async Task<ShopifyOrder> GetAsync(long orderId, string fields = null)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders/{0}.json".FormatWith(orderId), Method.GET, "order");
+
+            if (string.IsNullOrEmpty(fields) == false)
+            {
+                req.AddParameter("fields", fields);
+            }
+
+            return await RequestEngine.ExecuteRequestAsync<ShopifyOrder>(_RestClient, req);
         }
 
-        public async Task<ShopifyOrder> CloseAsync(long id)
+        /// <summary>
+        /// Closes an order.
+        /// </summary>
+        /// <param name="id">The order's id.</param>
+        public async Task CloseAsync(long id)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders/{0}/close.json".FormatWith(id), Method.POST);
+
+            await RequestEngine.ExecuteRequestAsync(_RestClient, req);
         }
 
-        public async Task<ShopifyOrder> OpenAsync(long id)
+        /// <summary>
+        /// Opens an order.
+        /// </summary>
+        /// <param name="id">The order's id.</param>
+        public async Task OpenAsync(long id)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders/{0}/open.json".FormatWith(id), Method.POST);
+
+            await RequestEngine.ExecuteRequestAsync(_RestClient, req);
         }
 
-        public async Task<ShopifyOrder> CreateAsync(ShopifyOrder order)
+        /// <summary>
+        /// Creates a new <see cref="ShopifyOrder"/> on the store.
+        /// </summary>
+        /// <param name="order">A new <see cref="ShopifyOrder"/>. Id should be set to null.</param>
+        /// <param name="options">Options for creating the order.</param>
+        /// <returns>The new <see cref="ShopifyOrder"/>.</returns>
+        public async Task<ShopifyOrder> CreateAsync(ShopifyOrder order, ShopifyOrderCreateOptions options = null)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders.json", Method.POST, "order");
+
+            //Build the request body
+            Dictionary<string, object> body = new Dictionary<string, object>(options?.ToDictionary() ?? new Dictionary<string, object>())
+            {
+                { "order", order }
+            };
+
+            req.AddJsonBody(body);
+
+            return await RequestEngine.ExecuteRequestAsync<ShopifyOrder>(_RestClient, req);
         }
 
+        /// <summary>
+        /// Updates the given <see cref="ShopifyOrder"/>. Id must not be null.
+        /// </summary>
+        /// <param name="order">The <see cref="ShopifyOrder"/> to update.</param>
+        /// <returns>The updated <see cref="ShopifyOrder"/>.</returns>
         public async Task<ShopifyOrder> UpdateAsync(ShopifyOrder order)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders/{0}.json".FormatWith(order.Id.Value), Method.PUT, "order");
+
+            req.AddJsonBody(new { order });
+
+            return await RequestEngine.ExecuteRequestAsync<ShopifyOrder>(_RestClient, req);
         }
 
-        public async Task DeleteAsync(long id)
+        /// <summary>
+        /// Deletes an order with the given Id.
+        /// </summary>
+        /// <param name="orderId">The order object's Id.</param>
+        public async Task DeleteAsync(long orderId)
         {
-            throw new NotImplementedException();
+            IRestRequest req = RequestEngine.CreateRequest("orders/{0}.json".FormatWith(orderId), Method.DELETE);
+
+            await RequestEngine.ExecuteRequestAsync(_RestClient, req);
         }
 
         #endregion

--- a/ShopifySharp/Services/Order/ShopifyOrderService.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderService.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class ShopifyOrderService : ShopifyService
+    {
+        #region Constructor
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ShopifyOrderService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public ShopifyOrderService(string myShopifyUrl, string shopAccessToken): base(myShopifyUrl, shopAccessToken) { }
+
+        #endregion
+
+        #region Public, non-static methods
+
+        public async Task<int> CountAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ShopifyOrder> ListAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<IEnumerable<ShopifyOrder>> ListForCustomerAsync(long customerId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ShopifyOrder> GetAsync(long id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ShopifyOrder> CloseAsync(long id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ShopifyOrder> OpenAsync(long id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ShopifyOrder> CreateAsync(ShopifyOrder order)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ShopifyOrder> UpdateAsync(ShopifyOrder order)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task DeleteAsync(long id)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/ShopifySharp/Services/Order/ShopifyOrderService.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderService.cs
@@ -105,7 +105,7 @@ namespace ShopifySharp
         }
 
         /// <summary>
-        /// Opens an order.
+        /// Opens a closed order.
         /// </summary>
         /// <param name="id">The order's id.</param>
         public async Task OpenAsync(long id)

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
-        public ShopifyService(string myShopifyUrl, string shopAccessToken)
+        protected ShopifyService(string myShopifyUrl, string shopAccessToken)
         {
             _ShopUri = RequestEngine.BuildShopUri(myShopifyUrl);
             _RestClient = RequestEngine.CreateClient(_ShopUri, shopAccessToken);

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -68,6 +69,7 @@
     <Compile Include="Enums\ShopifyOrderFinancialStatus.cs" />
     <Compile Include="Enums\ShopifyOrderStatus.cs" />
     <Compile Include="Converters\ShopifyFulfillmentStatusConverter.cs" />
+    <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Serializers\JsonNetSerializer.cs" />
     <Compile Include="Entities\ShopifyAddress.cs" />

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -53,6 +53,18 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Entities\ShopifyClientDetails.cs" />
+    <Compile Include="Entities\ShopifyDiscountCode.cs" />
+    <Compile Include="Entities\ShopifyFulfillment.cs" />
+    <Compile Include="Entities\ShopifyLineItem.cs" />
+    <Compile Include="Entities\ShopifyOrder.cs" />
+    <Compile Include="Entities\ShopifyPaymentDetails.cs" />
+    <Compile Include="Entities\ShopifyShippingLine.cs" />
+    <Compile Include="Entities\ShopifyTaxLine.cs" />
+    <Compile Include="Entities\ShopifyTransaction.cs" />
+    <Compile Include="Enums\ShopifyDiscountCodeType.cs" />
+    <Compile Include="Enums\ShopifyFulfillmentStatus.cs" />
+    <Compile Include="Enums\ShopifyOrderFinancialStatus.cs" />
     <Compile Include="Serializers\JsonNetSerializer.cs" />
     <Compile Include="Entities\ShopifyAddress.cs" />
     <Compile Include="Entities\ShopifyCustomer.cs" />
@@ -64,20 +76,27 @@
     <Compile Include="Infrastructure\RequestEngine.cs" />
     <Compile Include="Infrastructure\ShopifyError.cs" />
     <Compile Include="Infrastructure\ShopifyException.cs" />
-    <Compile Include="Services\Authorization\ShopifyAuthorizationScope.cs" />
+    <Compile Include="Enums\ShopifyAuthorizationScope.cs" />
     <Compile Include="Services\Authorization\ShopifyAuthorizationService.cs" />
     <Compile Include="Services\Customer\ShopifyCustomerCreateOptions.cs" />
     <Compile Include="Services\Customer\ShopifyCustomerService.cs" />
+    <Compile Include="Enums\ShopifyOrderCancelReason.cs" />
+    <Compile Include="Services\Order\ShopifyOrderService.cs" />
+    <Compile Include="Enums\ShopifyProcessingMethod.cs" />
     <Compile Include="Services\ShopifyFilterOptions.cs" />
     <Compile Include="Services\ShopifyListOptions.cs" />
     <Compile Include="Services\ShopifyService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Shop\ShopifyShopService.cs" />
+    <Compile Include="Enums\ShopifyTransactionError.cs" />
+    <Compile Include="Enums\ShopifyTransactionKind.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Services\Transaction\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -64,7 +64,11 @@
     <Compile Include="Entities\ShopifyTransaction.cs" />
     <Compile Include="Enums\ShopifyDiscountCodeType.cs" />
     <Compile Include="Enums\ShopifyFulfillmentStatus.cs" />
+    <Compile Include="Enums\ShopifyInventoryBehavior.cs" />
     <Compile Include="Enums\ShopifyOrderFinancialStatus.cs" />
+    <Compile Include="Enums\ShopifyOrderStatus.cs" />
+    <Compile Include="Converters\ShopifyFulfillmentStatusConverter.cs" />
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Serializers\JsonNetSerializer.cs" />
     <Compile Include="Entities\ShopifyAddress.cs" />
     <Compile Include="Entities\ShopifyCustomer.cs" />
@@ -81,6 +85,8 @@
     <Compile Include="Services\Customer\ShopifyCustomerCreateOptions.cs" />
     <Compile Include="Services\Customer\ShopifyCustomerService.cs" />
     <Compile Include="Enums\ShopifyOrderCancelReason.cs" />
+    <Compile Include="Services\Order\ShopifyOrderCreateOptions.cs" />
+    <Compile Include="Services\Order\ShopifyOrderFilterOptions.cs" />
     <Compile Include="Services\Order\ShopifyOrderService.cs" />
     <Compile Include="Enums\ShopifyProcessingMethod.cs" />
     <Compile Include="Services\ShopifyFilterOptions.cs" />

--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,109 @@ IEnumerable<ShopifyCustomer> customers = await Service.SearchAsync("Jane country
 //indexing it for a search.
 ```
 
+## Orders
+
+### Creating an order
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+ShopifyOrder order = new ShopifyOrder()
+{
+    CreatedAt = DateTime.UtcNow,
+    BillingAddress = new ShopifyAddress()
+    {
+        Address1 = "123 4th Street",
+        City = "Minneapolis",
+        Province = "Minnesota",
+        ProvinceCode = "MN",
+        Zip = "55401",
+        Phone = "555-555-5555",
+        FirstName = "John",
+        LastName = "Doe",
+        Company = "Tomorrow Corporation",
+        Country = "United States",
+        CountryCode = "US",
+        Default = true,
+    },
+    LineItems = new List<ShopifyLineItem>()
+    {
+        new ShopifyLineItem()
+        {
+            Name = "Test Line Item",
+            Title = "Test Line Item Title"
+        }
+    },
+    FinancialStatus = Enums.ShopifyOrderFinancialStatus.Paid,
+    TotalPrice = 5.00,
+    Email = Guid.NewGuid().ToString() + "@example.com",
+    Note = "Test note about the customer.",
+};
+
+order = await service.CreateAsync(order);
+```
+
+### Retrieving an order
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+ShopifyOrder order = await service.GetAsync(orderId);
+```
+
+### Updating an order
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+ShopifyOrder order = await service.GetAsync(orderId);
+
+order.Notes = "Test notes.";
+order = await service.UpdateAsync(order);
+```
+
+### Deleting an order
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+
+await service.DeleteAsync(orderId);
+```
+
+### Counting orders
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+int orderCount = await service.CountAsync();
+```
+
+### Listing orders
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+IEnumerable<ShopifyOrder> orders = await service.ListAsync();
+```
+
+### List orders for a certain customer
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+IEnumerable<ShopifyOrder> orders = await service.ListForCustomerAsync(customerId);
+```
+
+### Close an order
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+
+await service.CloseAsync(orderId);
+```
+
+### Reopen a closed order
+
+```
+ShopifyOrderService service = new ShopifyOrderService(myShopifyUrl, shopAccessToken);
+
+await service.OpenAsync(orderId);
+```
+
 # Tests
 
 The test suite relies on your own Shopify credentials, including your Shopify API key, a shop's *.myshopify.com URL, and an access token with full permissions for that shop. [This blog post](https://nozzlegear.com/blog/generating-shopify-authorization-credentials) will show you exactly what you need to do to get a shop access token with full permissions.


### PR DESCRIPTION
This pull request merges the `ShopifyOrderService`  into master, which enables creating, retrieving, deleting, updating, listing, counting, closing and opening a shop's orders. Readme has been updated with usage examples.