### PR TITLE
ShopifyScriptTagService: Create, get, list, count, update and delete script tags.

### DIFF
--- a/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_counting_script_tags.cs
+++ b/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_counting_script_tags.cs
@@ -1,0 +1,60 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyScriptTagService_Tests
+{
+    [Subject(typeof(ShopifyScriptTagService))]
+    class When_counting_script_tags
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyScriptTagService(Utils.MyShopifyUrl, Utils.AccessToken);
+            FilteredSrc = string.Format("https://nozzlegear.com/{0}/even.js", Guid.NewGuid().ToString());
+
+            for (int i = 0; i < 5; i++)
+            {
+                string src = i % 2 == 0 ? FilteredSrc : "https://nozzlegear.com/odd.js";
+
+                Tags.Add(Service.CreateAsync(new ShopifyScriptTag()
+                {
+                    Event = Enums.ShopifyScriptTagEvent.Onload,
+                    Src = src
+                }).Await().AsTask.Result);
+            }
+        };
+
+        Because of = () =>
+        {
+            Count = Service.CountAsync().Await().AsTask.Result;
+            FilteredCount = Service.CountAsync(FilteredSrc).Await().AsTask.Result;
+        };
+
+        It should_count_script_tags = () =>
+        {
+            Count.ShouldBeGreaterThanOrEqualTo(3);
+            FilteredCount.ShouldEqual(3);
+        };
+        
+        Cleanup after = () =>
+        {
+            foreach (var tag in Tags)
+            {
+                Service.DeleteAsync(tag.Id.Value).Await();
+            }
+        };
+
+        static string FilteredSrc;
+
+        static int Count;
+
+        static int FilteredCount;
+
+        static ShopifyScriptTagService Service;
+
+        static List<ShopifyScriptTag> Tags = new List<ShopifyScriptTag>();
+    }
+}

--- a/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_creating_a_script_tag.cs
+++ b/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_creating_a_script_tag.cs
@@ -1,0 +1,42 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyScriptTagService_Tests
+{
+    [Subject(typeof(ShopifyScriptTagService))]
+    class When_creating_a_script_tag
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyScriptTagService(Utils.MyShopifyUrl, Utils.AccessToken);
+        };
+
+        Because of = () =>
+        {
+            Tag = Service.CreateAsync(new ShopifyScriptTag()
+            {
+                Event = Enums.ShopifyScriptTagEvent.Onload,
+                Src  = "https://nozzlegear.com/test.js"
+            }).Await().AsTask.Result;
+        };
+
+        It should_create_a_script_tag = () =>
+        {
+            Tag.ShouldNotBeNull();
+            Tag.Src.ShouldEqual("https://nozzlegear.com/test.js");
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Tag.Id.Value).Await();
+        };
+
+        static ShopifyScriptTagService Service;
+
+        static ShopifyScriptTag Tag;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_deleting_a_script_tag.cs
+++ b/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_deleting_a_script_tag.cs
@@ -1,0 +1,51 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyScriptTagService_Tests
+{
+    [Subject(typeof(ShopifyScriptTagService))]
+    class When_deleting_a_script_tag
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyScriptTagService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Tag = Service.CreateAsync(new ShopifyScriptTag()
+            {
+                Event = Enums.ShopifyScriptTagEvent.Onload,
+                Src = "https://nozzlegear.com/test.js"
+            }).Await().AsTask.Result;
+        };
+
+        Because of = () =>
+        {
+            try
+            {
+                Service.DeleteAsync(Tag.Id.Value).Await();
+            }
+            catch(Exception e)
+            {
+                Ex = e;
+            }
+        };
+
+        It should_delete_a_script_tag = () =>
+        {
+            Ex.ShouldBeNull();
+        };
+
+        Cleanup after = () =>
+        {
+
+        };
+
+        static ShopifyScriptTagService Service;
+
+        static ShopifyScriptTag Tag;
+
+        static Exception Ex;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_getting_a_script_tag.cs
+++ b/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_getting_a_script_tag.cs
@@ -1,0 +1,45 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyScriptTagService_Tests
+{
+    [Subject(typeof(ShopifyScriptTagService))]
+    class When_getting_a_script_tag
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyScriptTagService(Utils.MyShopifyUrl, Utils.AccessToken);
+            TagId = Service.CreateAsync(new ShopifyScriptTag()
+            {
+                Event = Enums.ShopifyScriptTagEvent.Onload,
+                Src = "https://nozzlegear.com/test.js"
+            }).Await().AsTask.Result.Id.Value;
+        };
+
+        Because of = () =>
+        {
+            Tag = Service.GetAsync(TagId).Await().AsTask.Result;
+        };
+
+        It should_get_a_script_tag = () =>
+        {
+            Tag.ShouldNotBeNull();
+            Tag.Id.ShouldEqual(TagId);
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(TagId).Await();
+        };
+
+        static ShopifyScriptTagService Service;
+
+        static ShopifyScriptTag Tag;
+
+        static long TagId;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_listing_script_tags.cs
+++ b/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_listing_script_tags.cs
@@ -1,0 +1,59 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyScriptTagService_Tests
+{
+    [Subject(typeof(ShopifyScriptTagService))]
+    class When_listing_script_tags
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyScriptTagService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+            for (int i = 0; i < 5; i++)
+            {
+                string src = i % 2 == 0 ? FilteredSrc : "https://nozzlegear.com/odd.js";
+
+                Service.CreateAsync(new ShopifyScriptTag()
+                {
+                    Event = Enums.ShopifyScriptTagEvent.Onload,
+                    Src = src
+                }).Await();
+            }
+        };
+
+        Because of = () =>
+        {
+            Tags = Service.ListAsync().Await().AsTask.Result;
+            FilteredTags = Service.ListAsync(new ShopifyScriptTagListOptions() {
+                Src = FilteredSrc
+            }).Await().AsTask.Result;
+        };
+
+        It should_list_script_tags = () =>
+        {
+            Tags.Count().ShouldBeGreaterThanOrEqualTo(5);
+            FilteredTags.All(x => x.Src == FilteredSrc).ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            foreach (var tag in Tags)
+            {
+                Service.DeleteAsync(tag.Id.Value).Await();
+            }
+        };
+
+        static string FilteredSrc = "https://nozzlegear.com/even.js";
+
+        static ShopifyScriptTagService Service;
+
+        static IEnumerable<ShopifyScriptTag> Tags;
+
+        static IEnumerable<ShopifyScriptTag> FilteredTags;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_updating_a_script_tag.cs
+++ b/ShopifySharp.Tests/ShopifyScriptTagService Tests/When_updating_a_script_tag.cs
@@ -1,0 +1,47 @@
+﻿using Machine.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyScriptTagService_Tests
+{
+    [Subject(typeof(ShopifyScriptTagService))]
+    class When_updating_a_script_tag
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyScriptTagService(Utils.MyShopifyUrl, Utils.AccessToken);
+            OriginalTag = Service.CreateAsync(new ShopifyScriptTag()
+            {
+                Event = Enums.ShopifyScriptTagEvent.Onload,
+                Src = "https://nozzlegear.com/test.js"
+            }).Await().AsTask.Result;
+
+            OriginalTag.Src = "https://nozzlegear.com/updated.js";
+        };
+
+        Because of = () =>
+        {
+            UpdatedTag = Service.UpdateAsync(OriginalTag).Await().AsTask.Result;
+        };
+
+        It should_update_a_script_tag = () =>
+        {
+            UpdatedTag.ShouldNotBeNull();
+            UpdatedTag.Src.ShouldEqual("https://nozzlegear.com/updated.js");
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(OriginalTag.Id.Value).Await();
+        };
+
+        static ShopifyScriptTagService Service;
+
+        static ShopifyScriptTag OriginalTag;
+
+        static ShopifyScriptTag UpdatedTag;
+    }
+}

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -107,6 +107,12 @@
     <Compile Include="ShopifyOrderService Tests\When_opening_an_order.cs" />
     <Compile Include="ShopifyOrderService Tests\When_updating_an_order.cs" />
     <Compile Include="ShopifyAuthorizationService Tests\When_validating_shop_url.cs" />
+    <Compile Include="ShopifyScriptTagService Tests\When_counting_script_tags.cs" />
+    <Compile Include="ShopifyScriptTagService Tests\When_deleting_a_script_tag.cs" />
+    <Compile Include="ShopifyScriptTagService Tests\When_creating_a_script_tag.cs" />
+    <Compile Include="ShopifyScriptTagService Tests\When_getting_a_script_tag.cs" />
+    <Compile Include="ShopifyScriptTagService Tests\When_listing_script_tags.cs" />
+    <Compile Include="ShopifyScriptTagService Tests\When_updating_a_script_tag.cs" />
     <Compile Include="ShopifyWebhookService Tests\Test_Data\WebhookCreation.cs" />
     <Compile Include="ShopifyWebhookService Tests\When_counting_webhooks.cs" />
     <Compile Include="ShopifyWebhookService Tests\When_counting_webhooks_with_a_filter.cs" />
@@ -127,6 +133,13 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
+    <None Include="Playlists\Authorization.playlist" />
+    <None Include="Playlists\Charges.playlist" />
+    <None Include="Playlists\Customers.playlist" />
+    <None Include="Playlists\FalseToNullConverter.playlist" />
+    <None Include="Playlists\Orders.playlist" />
+    <None Include="Playlists\RecurringCharges.playlist" />
+    <None Include="Playlists\Webhooks.playlist" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShopifySharp\ShopifySharp.csproj">

--- a/ShopifySharp/Entities/ShopifyScriptTag.cs
+++ b/ShopifySharp/Entities/ShopifyScriptTag.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using ShopifySharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing remote javascript tags that are loaded into the pages of a shop's storefront.
+    /// </summary>
+    public class ShopifyScriptTag: ShopifyObject
+    {
+        /// <summary>
+        /// The date and time when the <see cref="ShopifyScriptTag"/> was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// DOM event which triggers the loading of the script. Valid values are: <see cref="ShopifyScriptTagEvent.Onload"/>.
+        /// </summary>
+        [JsonProperty("event"), JsonConverter(typeof(StringEnumConverter))]
+        public ShopifyScriptTagEvent Event { get; set; }
+
+        /// <summary>
+        /// Specifies the location of the ScriptTag.
+        /// </summary>
+        [JsonProperty("src")]
+        public string Src { get; set; }
+
+        /// <summary>
+        /// The date and time when the <see cref="ShopifyScriptTag"/> was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/ShopifySharp/Enums/ShopifyScriptTagEvent.cs
+++ b/ShopifySharp/Enums/ShopifyScriptTagEvent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Enums
+{
+    /// <summary>
+    /// An enum representing the type of <see cref="ShopifyScriptTag.Event"/>.
+    /// </summary>
+    public enum ShopifyScriptTagEvent
+    {
+        /// <summary>
+        /// The script tag is triggered when the DOM fires the "Onload" event.
+        /// </summary>
+        [EnumMember(Value = "onload")]
+        Onload
+    }
+}

--- a/ShopifySharp/Properties/AssemblyInfo.cs
+++ b/ShopifySharp/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShopifySharp/Services/ScriptTag/ShopifyScriptTagListOptions.cs
+++ b/ShopifySharp/Services/ScriptTag/ShopifyScriptTagListOptions.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// Filters the results of <see cref="ShopifyScriptTagService.ListAsync()"/>.
+    /// </summary>
+    public class ShopifyScriptTagListOptions : ShopifyListOptions
+    {
+        /// <summary>
+        /// Returns only those <see cref="ShopifyScriptTag"/>s with the given <see cref="ShopifyScriptTag.Src"/> value.
+        /// </summary>
+        [JsonProperty("src")]
+        public string Src { get; set; }
+    }
+}

--- a/ShopifySharp/Services/ScriptTag/ShopifyScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ShopifyScriptTagService.cs
@@ -1,0 +1,128 @@
+﻿using Humanizer;
+using Newtonsoft.Json.Linq;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// A service for manipulating Shopify's ScriptTag API.
+    /// </summary>
+    public class ShopifyScriptTagService : ShopifyService
+    {
+        #region Constructor
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ShopifyScriptTagService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public ShopifyScriptTagService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
+
+        #endregion
+
+        #region Public, non-static methods
+
+        /// <summary>
+        /// Gets a count of all of the shop's <see cref="ShopifyScriptTag"/>s.
+        /// </summary>
+        /// <param name="src">Optionally filters the count to only those <see cref="ShopifyScriptTag"/>s with the 
+        /// given <see cref="ShopifyScriptTag.Src"/> value.</param>
+        /// <returns>The count.</returns>
+        public async Task<int> CountAsync(string src = null)
+        {
+            IRestRequest req = RequestEngine.CreateRequest("script_tags/count.json", Method.GET);
+
+            //Filter the count where necessary.
+            if (string.IsNullOrEmpty(src) == false) req.AddQueryParameter("src", src);
+
+            JToken responseObject = await RequestEngine.ExecuteRequestAsync(_RestClient, req);
+
+            //Response looks like { "count" : 123 }. Does not warrant its own class.
+            return responseObject.Value<int>("count");
+        }
+
+        /// <summary>
+        /// Gets a list of up to 250 of the shop's <see cref="ShopifyScriptTag"/>s.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<IEnumerable<ShopifyScriptTag>> ListAsync(ShopifyScriptTagListOptions options = null)
+        {
+            IRestRequest req = RequestEngine.CreateRequest("script_tags.json", Method.GET, "script_tags");
+
+            //Add optional parameters to request
+            if (options != null) req.Parameters.AddRange(options.ToParameters(ParameterType.GetOrPost));
+
+            return await RequestEngine.ExecuteRequestAsync<List<ShopifyScriptTag>>(_RestClient, req);
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="ShopifyScriptTag"/> with the given id.
+        /// </summary>
+        /// <param name="tagId">The id of the <see cref="ShopifyScriptTag"/> to retrieve.</param>
+        /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <returns>The <see cref="ShopifyScriptTag"/>.</returns>
+        public async Task<ShopifyScriptTag> GetAsync(long tagId, string fields = null)
+        {
+            IRestRequest req = RequestEngine.CreateRequest("script_tags/{0}.json".FormatWith(tagId), Method.GET, "script_tag");
+
+            if (string.IsNullOrEmpty(fields) == false)
+            {
+                req.AddParameter("fields", fields);
+            }
+
+            return await RequestEngine.ExecuteRequestAsync<ShopifyScriptTag>(_RestClient, req);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ShopifyScriptTag"/> on the store.
+        /// </summary>
+        /// <param name="tag">A new <see cref="ShopifyScriptTag"/>. Id should be set to null.</param>
+        /// <returns>The new <see cref="ShopifyScriptTag"/>.</returns>
+        public async Task<ShopifyScriptTag> CreateAsync(ShopifyScriptTag tag)
+        {
+            IRestRequest req = RequestEngine.CreateRequest("script_tags.json", Method.POST, "script_tag");
+
+            //Build the request body
+            var body = new Dictionary<string, object>()
+            {
+                { "script_tag", tag }
+            };
+
+            req.AddJsonBody(body);
+
+            return await RequestEngine.ExecuteRequestAsync<ShopifyScriptTag>(_RestClient, req);
+        }
+
+        /// <summary>
+        /// Updates the given <see cref="ShopifyScriptTag"/>. Id must not be null.
+        /// </summary>
+        /// <param name="tag">The <see cref="ShopifyScriptTag"/> to update.</param>
+        /// <returns>The updated <see cref="ShopifyScriptTag"/>.</returns>
+        public async Task<ShopifyScriptTag> UpdateAsync(ShopifyScriptTag tag)
+        {
+            IRestRequest req = RequestEngine.CreateRequest("script_tags/{0}.json".FormatWith(tag.Id.Value), Method.PUT, "script_tag");
+
+            req.AddJsonBody(new { script_tag = tag });
+
+            return await RequestEngine.ExecuteRequestAsync<ShopifyScriptTag>(_RestClient, req);
+        }
+
+        /// <summary>
+        /// Deletes the <see cref="ShopifyScriptTag"/> with the given Id.
+        /// </summary>
+        /// <param name="tagId">The tag's Id.</param>
+        public async Task DeleteAsync(long tagId)
+        {
+            IRestRequest req = RequestEngine.CreateRequest("script_tags/{0}.json".FormatWith(tagId), Method.DELETE);
+
+            await RequestEngine.ExecuteRequestAsync(_RestClient, req);
+        }
+
+        #endregion
+    }
+}

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Entities\ShopifyOrder.cs" />
     <Compile Include="Entities\ShopifyPaymentDetails.cs" />
     <Compile Include="Entities\ShopifyRecurringCharge.cs" />
+    <Compile Include="Entities\ShopifyScriptTag.cs" />
     <Compile Include="Entities\ShopifyShippingLine.cs" />
     <Compile Include="Entities\ShopifyTaxLine.cs" />
     <Compile Include="Entities\ShopifyTransaction.cs" />
@@ -80,6 +81,7 @@
     <Compile Include="Converters\ShopifyFulfillmentStatusConverter.cs" />
     <Compile Include="Enums\ShopifyChargeStatus.cs" />
     <Compile Include="Enums\ShopifyRecurringChargeStatus.cs" />
+    <Compile Include="Enums\ShopifyScriptTagEvent.cs" />
     <Compile Include="Enums\ShopifyWebhookTopic.cs" />
     <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
@@ -103,6 +105,8 @@
     <Compile Include="Services\Order\ShopifyOrderFilterOptions.cs" />
     <Compile Include="Services\Order\ShopifyOrderService.cs" />
     <Compile Include="Enums\ShopifyProcessingMethod.cs" />
+    <Compile Include="Services\ScriptTag\ShopifyScriptTagListOptions.cs" />
+    <Compile Include="Services\ScriptTag\ShopifyScriptTagService.cs" />
     <Compile Include="Services\ShopifyFilterOptions.cs" />
     <Compile Include="Services\ShopifyListOptions.cs" />
     <Compile Include="Services\ShopifyService.cs" />

--- a/ShopifySharp/ShopifySharp.nuspec
+++ b/ShopifySharp/ShopifySharp.nuspec
@@ -11,6 +11,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ShopifySharp is a .NET library that enables you to authenticate and make API calls to Shopify.</description>
     <releaseNotes> 
+  1.7.0
+  =====
+  - New feature: ShopifyScriptTagService. Script tags let you add remote javascript tags that are loaded into the page's of a shop's storefront, letting you dynamically change the functionality of their shop without editing the store's template.
+      
 	1.6.0
 	=====
 	- New feature: ShopifyChargeService. Create, retrieve, list and activate a one-time application charge.

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ ShopifySharp is a .NET library that enables you to authenticate and make API cal
 
 Currently, the only other .NET library for Shopify is [Shopify.net](https://github.com/cmcdonaldca/shopify.net), which hasn't been updated in over 3 years and requires that you know the exact URL paths of the Shopify API, along with creating your own entity classes for each resource. That's why I'm building ShopifySharp — .NET developers need a fully-featured library for interacting with Shopify and building Shopify apps.
 
-With that said, this library is brand new. It currently only supports **OAuth authentication**, the **billing** API, the **Customers** resource, the **Orders** resource, the **Webhooks** resource, and the **Shop** resource. More functionality will be added each week until it reachs full parity with Shopify's REST API.
+With that said, this library is brand new. It currently only supports **OAuth authentication**, the **billing** API, the **Customers** resource, the **Orders** resource, the **Webhooks** resource, the **Script Tags** resource, and the **Shop** resource. More functionality will be added each week until it reachs full parity with Shopify's REST API.
 
 ![imgur](http://i.imgur.com/WJKJI9D.png)
 
@@ -509,6 +509,70 @@ int webhookCount = await service.CountAsync();
 ```c#
 var service = new ShopifyWebhookService(myShopifyUrl, shopAccessToken);
 IEnumerable<ShopifyWebhook> webhooks = await service.ListAsync();
+```
+
+## Script Tags
+
+Script tags let you add remote javascript tags that are loaded into the pages of a shop's storefront, letting you dynamically change the functionality of their shop without manually editing their store's template.
+
+### Creating a script tag
+
+```c#
+var service = new ShopifyScriptTagService(myShopifyUrl, shopAccessToken);
+var tag = new ShopifyScriptTag()
+{
+    Event = ShopifyScriptTagEvent.Onload,
+    Src  = "https://example.com/my-javascript-file.js"
+}
+
+tag = await service.CreateAsync(tag);
+```
+
+### Retrieving a script tag
+
+```c#
+var service = new ShopifyScriptTagService(myShopifyUrl, shopAccessToken);
+var tag = await service.GetAsync(tagId);
+```
+
+### Updating a script tag
+
+```c#
+var service = new ShopifyScriptTagService(myShopifyUrl, shopAccessToken);
+var tag = await service.GetAsync(tagId);
+
+tag.Src = "https://example.com/my-new-javascript-file.js";
+tag = await service.UpdateAsync(tag);
+```
+
+### Deleting a script tag
+
+```c#
+var service = new ShopifyScriptTagService(myShopifyUrl, shopAccessToken);
+
+await service.DeleteAsync(tagId);
+```
+
+### Counting script tags
+
+```c#
+var service = new ShopifyScriptTagService(myShopifyUrl, shopAccessToken);
+int tagCount = await service.CountAsync();
+
+//Optionally filter the count to only those tags with a specific Src
+int filteredTagCount = await service.CountAsync("https://example.com/my-filtered-url.js");
+```
+
+### Listing script tags
+
+```c#
+var service = new ShopifyScriptTagService(myShopifyUrl, shopAccessToken);
+var tags = await service.ListAsync();
+
+//Optionally filter the list to only those tags with a specific Src
+var filteredTags = await service.ListAsync(new ShopifyScriptTagListOptions() {
+    Src = FilteredSrc
+});
 ```
 
 # Tests


### PR DESCRIPTION
- Merges the `ShopifyScriptTagService` into master, which enables creating, retrieving, listing, counting, updating and deleting script tags. Readme has been updated with usage examples and all tests are passing.
- Bumps the version to 1.7.0.