### PR TITLE
Updated the "password_enabled" field for the shop object making it nullable

### DIFF
--- a/ShopifySharp/Entities/ShopifyShop.cs
+++ b/ShopifySharp/Entities/ShopifyShop.cs
@@ -139,7 +139,7 @@ namespace ShopifySharp
         /// Indicates whether the Storefront password protection is enabled.
         /// </summary>
         [JsonProperty("password_enabled")]
-        public bool PasswordEnabled { get; set; }
+        public bool? PasswordEnabled { get; set; }
 
         /// <summary>
         /// The contact phone number for the shop.


### PR DESCRIPTION
Contrary to Shopify API documentation, the "password_enabled" for on a shop object is a nullable boolean value. Please correct me if I'm wrong :)