### PR TITLE
Support for cancelling orders

### DIFF
--- a/ShopifySharp.Tests/ShopifyOrderService Tests/When_cancelling_an_order.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService Tests/When_cancelling_an_order.cs
@@ -1,0 +1,39 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_cancelling_an_order
+    {
+        Establish context = () =>
+        {
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Id = Service.CreateAsync(OrderCreation.GenerateOrder()).Await().AsTask.Result.Id.Value;
+        };
+
+        private Because of = () =>
+        {
+            Service.CancelAsync(Id).Await();
+            Order = Service.GetAsync(Id).Await().AsTask.Result;
+        };
+
+        It should_cancel_an_order = () =>
+        {
+            Order.ShouldNotBeNull();
+            Order.Id.ShouldEqual(Id);
+            Order.CancelledAt.HasValue.ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Id).Await();
+        };
+
+        static ShopifyOrderService Service;
+
+        static ShopifyOrder Order;
+
+        static long Id;
+    }
+}

--- a/ShopifySharp.Tests/ShopifyOrderService Tests/When_cancelling_an_order_with_options.cs
+++ b/ShopifySharp.Tests/ShopifyOrderService Tests/When_cancelling_an_order_with_options.cs
@@ -1,0 +1,48 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyOrderService))]
+    public class When_cancelling_an_order_with_options
+    {
+        private Establish context = () =>
+        {
+            var order = OrderCreation.GenerateOrder();
+
+            Service = new ShopifyOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+            Id = Service.CreateAsync(order).Await().AsTask.Result.Id.Value;
+
+            Options = new ShopifyOrderCancelOptions
+            {
+                Reason = "customer"
+            };
+        };
+
+        private Because of = () =>
+        {
+            Service.CancelAsync(Id, Options).Await();
+            Order = Service.GetAsync(Id).Await().AsTask.Result;
+        };
+
+        private It should_cancel_an_order = () =>
+        {
+            Order.ShouldNotBeNull();
+            Order.Id.ShouldEqual(Id);
+            Order.CancelReason.ShouldEqual(Options.Reason);
+        };
+
+        Cleanup after = () =>
+        {
+            Service.DeleteAsync(Id).Await();
+        };
+
+        static ShopifyOrderService Service;
+
+        static ShopifyOrder Order;
+
+        static long Id;
+
+        static ShopifyOrderCancelOptions Options;
+    }
+}

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -155,6 +155,8 @@
     <Compile Include="ShopifyOrderRiskService Tests\When_getting_a_risk.cs" />
     <Compile Include="ShopifyOrderRiskService Tests\When_listing_order_risks.cs" />
     <Compile Include="ShopifyOrderRiskService Tests\When_updating_a_risk.cs" />
+    <Compile Include="ShopifyOrderService Tests\When_cancelling_an_order_with_options.cs" />
+    <Compile Include="ShopifyOrderService Tests\When_cancelling_an_order.cs" />
     <Compile Include="ShopifyOrderService Tests\When_listing_orders_with_since_id.cs" />
     <Compile Include="ShopifyPageService_Tests\Test_Data\PageCreation.cs" />
     <Compile Include="ShopifyPageService_Tests\When_counting_pages.cs" />

--- a/ShopifySharp/Services/Order/ShopifyOrderCancelOptions.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderCancelOptions.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+
+namespace ShopifySharp
+{
+    public class ShopifyOrderCancelOptions
+    {
+        /// <summary>
+        /// Amount to refund (decimal ex: 21.20).
+        /// If set, Shopify will attempt to void/refund the payment depending on the status.
+        /// </summary>
+        [JsonProperty("amount")]
+        public double? RefundAmount { get; set; }
+
+        /// <summary>
+        /// Restock the items for this order back to your store.
+        /// </summary>
+        [JsonProperty("restock")]
+        public bool? Restock { get; set; }
+
+        /// <summary>
+        /// The reason for the order cancellation
+        /// Must be: customer, inventory, fraud or other.
+        /// </summary>
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        /// <summary>
+        /// Send an email to the customer notifying them of the cancellation.
+        /// </summary>
+        [JsonProperty("email")]
+        public bool? SendCancellationReceipt { get; set; }
+    }
+}

--- a/ShopifySharp/Services/Order/ShopifyOrderService.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderService.cs
@@ -1,10 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using RestSharp;
 using ShopifySharp.Filters;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ShopifySharp
@@ -161,6 +158,20 @@ namespace ShopifySharp
         public async Task DeleteAsync(long orderId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"orders/{orderId}.json", Method.DELETE);
+
+            await RequestEngine.ExecuteRequestAsync(_RestClient, req);
+        }
+
+        /// <summary>
+        /// Cancels an order.
+        /// </summary>
+        /// <param name="orderId">The order's id.</param>
+        /// <returns>The cancelled <see cref="ShopifyOrder"/>.</returns>
+        public async Task CancelAsync(long orderId, ShopifyOrderCancelOptions options = null)
+        {
+            IRestRequest req = RequestEngine.CreateRequest($"orders/{orderId}/cancel.json", Method.POST);
+
+            req.AddJsonBody(options);
 
             await RequestEngine.ExecuteRequestAsync(_RestClient, req);
         }

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Filters\ShopifyMetaFieldFilter.cs" />
     <Compile Include="Services\MetaField\ShopifyMetaFieldService.cs" />
     <Compile Include="Services\OrderRisk\ShopifyOrderRiskService.cs" />
+    <Compile Include="Services\Order\ShopifyOrderCancelOptions.cs" />
     <Compile Include="Services\Page\ShopifyPageService.cs" />
     <Compile Include="Filters\ShopifyPageFilter.cs" />
     <Compile Include="Services\Page\ShopifyPageCreateOptions.cs" />


### PR DESCRIPTION
Adds support for the [cancel order endpoint](https://help.shopify.com/api/reference/order#cancel).

While the `refund` option parameter works, there's no way of testing it because refund in general is unsupported in ShopifySharp.

While the endpoints returns an order, it appears not to be returning the cancelled order. E.g. the cancelled_at parameter is still null. Hence I'm not returning the order from the `CancelAsync` method to avoid confusion.

Resolves #85
