### PR TITLE
Bugfix: ShopifyCustomerService.CreateAsync was including the CustomerCreateOptions into the wrong part of the request body

### DIFF
--- a/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
+++ b/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
@@ -100,13 +100,19 @@ namespace ShopifySharp
         {
             IRestRequest req = RequestEngine.CreateRequest("customers.json", Method.POST, "customer");
 
-            //Build the request body
-            Dictionary<string, object> body = new Dictionary<string, object>(options?.ToDictionary() ?? new Dictionary<string, object>())
-            {
-                { "customer", customer }
-            };
+            var customerBody = customer.ToDictionary();
 
-            req.AddJsonBody(body);
+            if (options != null)
+            {
+                foreach (var keyValuePair in options.ToDictionary())
+                {
+                    customerBody.Add(keyValuePair);
+                }
+            }
+
+            var requestBody = new { customer = customerBody };
+
+            req.AddJsonBody(requestBody);
 
             return await RequestEngine.ExecuteRequestAsync<ShopifyCustomer>(_RestClient, req);
         }


### PR DESCRIPTION
The ShopifyCustomerService.CreateAsync has an optional parameter "options" of type CustomerCreateOptions, this contains additional parameters to include into the customer object.

The CreateAsync method was including the parameters outside of the customer object when serializing this to Json, as a result from this, Shopify was accepting the json and creating the customer but without the parameters included in CustomerCreateOptions like the password so there was no way to create a new customer and set the password. [See Create Customer Docs](https://help.shopify.com/api/reference/customer#create).

I based the fix looking into the ShopifyProductService.CreateAsync code and modified it to be used in the ShopifyCustomerService.

I have tested without and with the fix and these are the results:
- Before: The customer was created but without a password set. Shopify gave the state "disabled".
Login into the Shopify store using the email and password gave an invalid credentials error message.
```
{
   "customer":{
      "first_name":"My First Name",
      "last_name":"My Last Name",
      .... other parameters ....
   },
   "password":"mypass",
   "password_confirmation":"mypass",
   "send_email_welcome":false,
   "send_email_invite": false
}
```


- After: The customer was created with a password and Shopify gave the state "enabled".
Login into the Shopify store using the email and password was successful. 



```
{
   "customer":{
      "first_name":"My First Name",
      "last_name":"My Last Name",
      .... other parameters ....
      "password":"mypass",
      "password_confirmation":"mypass",
      "send_email_welcome":false,
      "send_email_invite": false
   }
}
```