### PR TITLE
Feature: Change customer password using UpdateAsync

### DIFF
--- a/ShopifySharp.Tests/ShopifyCustomerService Tests/When_updating_a_customer_with_options.cs
+++ b/ShopifySharp.Tests/ShopifyCustomerService Tests/When_updating_a_customer_with_options.cs
@@ -1,0 +1,47 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Tests.Test_Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests
+{
+    [Subject(typeof(ShopifyCustomerService))]
+    public class When_updating_a_customer_with_options
+    {
+        Establish context = () =>
+        {
+            _Service = new ShopifyCustomerService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+            //Create a customer to update
+            _Customer = _Service.CreateAsync(CustomerCreation.CreateValidCustomer()).Await().AsTask.Result;
+
+            //Change the customer's email address
+            _Customer.Email = "test-update@example.com";
+        };
+
+        Because of = () =>
+        {
+            _Customer = _Service.UpdateAsync(_Customer, new ShopifyCustomerUpdateOptions()
+            {
+                Password = "loktarogar",
+                PasswordConfirmation = "loktarogar"
+            }).Await().AsTask.Result;
+        };
+
+        It should_update_the_customer = () =>
+        {
+            _Customer.Email.Equals("test-update@example.com").ShouldBeTrue();
+        };
+
+        Cleanup after = () =>
+        {
+            _Service.DeleteAsync(_Customer.Id.Value).Await();
+        };
+
+        static ShopifyCustomerService _Service;
+        static ShopifyCustomer _Customer;
+    }
+}

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="ShopifyCustomCollectionService Tests\When_listing_custom_collections.cs" />
     <Compile Include="ShopifyCustomCollectionService Tests\When_publishing_a_custom_collection.cs" />
     <Compile Include="ShopifyCustomCollectionService Tests\When_updating_a_custom_collection.cs" />
+    <Compile Include="ShopifyCustomerService Tests\When_updating_a_customer_with_options.cs" />
     <Compile Include="ShopifyEventService Tests\When_getting_an_event.cs" />
     <Compile Include="ShopifyEventService Tests\When_listing_events.cs" />
     <Compile Include="ShopifyEventService Tests\When_counting_events.cs" />

--- a/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
+++ b/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
@@ -121,12 +121,25 @@ namespace ShopifySharp
         /// Updates the given <see cref="ShopifyCustomer"/>. Id must not be null.
         /// </summary>
         /// <param name="customer">The <see cref="ShopifyCustomer"/> to update.</param>
+        /// <param name="options">Options for updating the customer.</param>
         /// <returns>The updated <see cref="ShopifyCustomer"/>.</returns>
-        public async Task<ShopifyCustomer> UpdateAsync(ShopifyCustomer customer)
+        public async Task<ShopifyCustomer> UpdateAsync(ShopifyCustomer customer, ShopifyCustomerUpdateOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"customers/{customer.Id.Value}.json", Method.PUT, "customer");
 
-            req.AddJsonBody(new { customer });
+            var customerBody = customer.ToDictionary();
+
+            if (options != null)
+            {
+                foreach (var keyValuePair in options.ToDictionary())
+                {
+                    customerBody.Add(keyValuePair);
+                }
+            }
+
+            var requestBody = new { customer = customerBody };
+
+            req.AddJsonBody(requestBody);
 
             return await RequestEngine.ExecuteRequestAsync<ShopifyCustomer>(_RestClient, req);
         }

--- a/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
+++ b/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
@@ -100,13 +100,19 @@ namespace ShopifySharp
         {
             IRestRequest req = RequestEngine.CreateRequest("customers.json", Method.POST, "customer");
 
-            //Build the request body
-            Dictionary<string, object> body = new Dictionary<string, object>(options?.ToDictionary() ?? new Dictionary<string, object>())
-            {
-                { "customer", customer }
-            };
+            var customerBody = customer.ToDictionary();
 
-            req.AddJsonBody(body);
+            if (options != null)
+            {
+                foreach (var keyValuePair in options.ToDictionary())
+                {
+                    customerBody.Add(keyValuePair);
+                }
+            }
+
+            var requestBody = new { customer = customerBody };
+
+            req.AddJsonBody(requestBody);
 
             return await RequestEngine.ExecuteRequestAsync<ShopifyCustomer>(_RestClient, req);
         }

--- a/ShopifySharp/Services/Customer/ShopifyCustomerUpdateOptions.cs
+++ b/ShopifySharp/Services/Customer/ShopifyCustomerUpdateOptions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ShopifySharp
+{
+    public class ShopifyCustomerUpdateOptions
+    {
+        /// <summary>
+        /// An optional password for the user. Default is null.
+        /// </summary>
+        [JsonProperty("password")]
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Should be set and match <see cref="Password"/>. Default is null.
+        /// </summary>
+        [JsonProperty("password_confirmation")]
+        public string PasswordConfirmation { get; set; }
+    }
+}

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Services\Collect\ShopifyCollectService.cs" />
     <Compile Include="Filters\ShopifyCustomCollectionFilter.cs" />
     <Compile Include="Services\CustomCollection\ShopifyCustomCollectionService.cs" />
+    <Compile Include="Services\Customer\ShopifyCustomerUpdateOptions.cs" />
     <Compile Include="Services\Event\ShopifyEventService.cs" />
     <Compile Include="Services\Fulfillment\ShopifyFulfillmentService.cs" />
     <Compile Include="Filters\ShopifyMetaFieldFilter.cs" />


### PR DESCRIPTION
Although the API documentation does not say anything about changing the customer password, you can do actually change the customer password using the PUT /admin/customers/#{id}.json endpoint. 

I have tested it, successfully changed the customer password and log in on the store with the new password. During my tests I used a private app and a normal app both with successful results.

Example:

```
PUT /admin/customers/5206361102.json

Body:

{
  "customer": {
    "id": 5206361102,
    "password": "mypass2",
    "password_confirmation": "mypass2"
  }
}
```

I have modified the UpdateAsync method and have created a new ShopifyCustomerUpdateOptions class so UpdateAsync has the same style as CreateAsync. A new test have also been included.

The new method looks like this:

`public async Task<ShopifyCustomer> UpdateAsync(ShopifyCustomer customer, ShopifyCustomerUpdateOptions options = null)`

The options parameter is optional so there are no breaking changes.

I have also written an answer on [stack overflow](http://stackoverflow.com/a/41233944/3915407) with the same information.

**How to use the new UpdateAsync**

```
string password = "mynewpassword";

var shopifyCustomer = new ShopifyCustomer()
{
    Id = 5206361102
};

var shopifyCustomerOptions = new ShopifyCustomerUpdateOptions()
{
    Password = password,
    PasswordConfirmation = password
};

var customerService = new ShopifyCustomerService("https://myshopifyurl", "myaccesstoken");

var updatedCustomer = await customerService.UpdateAsync(shopifyCustomer, shopifyCustomerOptions);
```


Because I need this feature in my project, I am currently using a custom build of ShopifySharp while I get (hopefully) accepted the pull request and get a new Nuget package.