### PR TITLE
Add virtual modifier to service class methods

### DIFF
--- a/ShopifySharp/Services/ApplicationCredit/ShopifyApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ShopifyApplicationCreditService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// Gets a list of all past and present application credits. 
         /// </summary>
         /// <param name="fields">A comma-separated list of fields to include in the response.</param>
-        public async Task<IEnumerable<ShopifyApplicationCredit>> ListAsync(string fields = null)
+        public virtual async Task<IEnumerable<ShopifyApplicationCredit>> ListAsync(string fields = null)
         {
             var req = RequestEngine.CreateRequest($"application_credits.json", Method.GET, "application_credits");
 
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The application credit's id.</param>
         /// <param name="fields">A comma-separated list of fields to include in the response.</param>
-        public async Task<ShopifyApplicationCredit> GetAsync(long id, string fields = null)
+        public virtual async Task<ShopifyApplicationCredit> GetAsync(long id, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"application_credits/{id}.json", Method.GET, "application_credit");
 
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="ShopifyApplicationCredit"/>.
         /// </summary>
         /// <param name="credit">A new <see cref="ShopifyApplicationCredit"/>. Id should be set to null.</param>
-        public async Task<ShopifyApplicationCredit> CreateAsync(ShopifyApplicationCredit credit)
+        public virtual async Task<ShopifyApplicationCredit> CreateAsync(ShopifyApplicationCredit credit)
         {
             var req = RequestEngine.CreateRequest($"application_credits.json", Method.POST, "application_credit");
 

--- a/ShopifySharp/Services/Article/ShopifyArticleService.cs
+++ b/ShopifySharp/Services/Article/ShopifyArticleService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the articles belong to.</param>
         /// <param name="filter">Options for filtering the result.</param>
-        public async Task<IEnumerable<ShopifyArticle>> ListAsync(long blogId, ShopifyArticleFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyArticle>> ListAsync(long blogId, ShopifyArticleFilter filter = null)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles.json", Method.GET, "articles");
 
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the articles belong to.</param>
         /// <param name="filter">Options for filtering the result.</param>
-        public async Task<int> CountAsync(long blogId, ShopifyPublishableCountFilter filter = null)
+        public virtual async Task<int> CountAsync(long blogId, ShopifyPublishableCountFilter filter = null)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles/count.json", Method.GET, "count");
 
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="articleId">The article's id.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
-        public async Task<ShopifyArticle> GetAsync(long blogId, long articleId, string fields = null)
+        public virtual async Task<ShopifyArticle> GetAsync(long blogId, long articleId, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles/{articleId}.json", Method.GET, "article");
 
@@ -75,7 +75,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article will belong to.</param>
         /// <param name="article">The article being created. Id should be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="ShopifyMetaFieldService"/>.</param>
-        public async Task<ShopifyArticle> CreateAsync(long blogId, ShopifyArticle article, IEnumerable<ShopifyMetaField> metafields = null)
+        public virtual async Task<ShopifyArticle> CreateAsync(long blogId, ShopifyArticle article, IEnumerable<ShopifyMetaField> metafields = null)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles.json", Method.POST, "article");
             var body = article.ToDictionary();
@@ -99,7 +99,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="article">The article being updated. Id should not be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="ShopifyMetaFieldService"/>.</param>
-        public async Task<ShopifyArticle> UpdateAsync(long blogId, ShopifyArticle article, IEnumerable<ShopifyMetaField> metafields = null)
+        public virtual async Task<ShopifyArticle> UpdateAsync(long blogId, ShopifyArticle article, IEnumerable<ShopifyMetaField> metafields = null)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles/{article.Id}.json", Method.PUT, "article");
             var body = article.ToDictionary();
@@ -122,7 +122,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="articleId">The article benig deleted.</param>
-        public async Task DeleteAsync(long blogId, long articleId)
+        public virtual async Task DeleteAsync(long blogId, long articleId)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles/{articleId}.json", Method.DELETE);
 
@@ -132,7 +132,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of all article authors.
         /// </summary>
-        public async Task<IEnumerable<string>> ListAuthorsAsync()
+        public virtual async Task<IEnumerable<string>> ListAuthorsAsync()
         {
             var req = RequestEngine.CreateRequest($"articles/authors.json", Method.GET, "authors");
 
@@ -144,7 +144,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="limit">The number of tags to return</param>
         /// <param name="popular">A flag to indicate only to a certain number of the most popular tags.</param>
-        public async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null)
+        public virtual async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null)
         {
             var req = RequestEngine.CreateRequest($"articles/tags.json", Method.GET, "tags");
 
@@ -167,7 +167,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the tags belong to.</param>
         /// <param name="limit">The number of tags to return</param>
         /// <param name="popular">A flag to indicate only to a certain number of the most popular tags.</param>
-        public async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null)
+        public virtual async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null)
         {
             var req = RequestEngine.CreateRequest($"blogs/{blogId}/articles/tags.json", Method.GET, "tags");
 

--- a/ShopifySharp/Services/Asset/ShopifyAssetService.cs
+++ b/ShopifySharp/Services/Asset/ShopifyAssetService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <param name="key">The key value of the asset, e.g. 'templates/index.liquid' or 'assets/bg-body.gif'.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyAsset"/>.</returns>
-        public async Task<ShopifyAsset> GetAsync(long themeId, string key, string fields = null)
+        public virtual async Task<ShopifyAsset> GetAsync(long themeId, string key, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{themeId}/assets.json", Method.GET, "asset");
 
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The list of <see cref="ShopifyAsset"/> objects.</returns>
-        public async Task<IEnumerable<ShopifyAsset>> ListAsync(long themeId, string fields = null)
+        public virtual async Task<IEnumerable<ShopifyAsset>> ListAsync(long themeId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{themeId}/assets.json", Method.GET, "assets");
 
@@ -79,7 +79,7 @@ namespace ShopifySharp
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="asset">The asset.</param>
         /// <returns>The created or updated asset.</returns>
-        public async Task<ShopifyAsset> CreateOrUpdateAsync(long themeId, ShopifyAsset asset)
+        public virtual async Task<ShopifyAsset> CreateOrUpdateAsync(long themeId, ShopifyAsset asset)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{themeId}/assets.json", Method.PUT, "asset");
 
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="key">The key value of the asset, e.g. 'templates/index.liquid' or 'assets/bg-body.gif'.</param>
-        public async Task DeleteAsync(long themeId, string key)
+        public virtual async Task DeleteAsync(long themeId, string key)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{themeId}/assets.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Blog/ShopifyBlogService.cs
+++ b/ShopifySharp/Services/Blog/ShopifyBlogService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <param name="sinceId">Restrict results to after the specified ID</param>
         /// <param name="handle">Filter by Blog handle</param>
         /// <param name="fields">comma-separated list of fields to include in the response</param>
-        public async Task<IEnumerable<ShopifyBlog>> ListAsync(long? sinceId = null, string handle = null, string fields = null)
+        public virtual async Task<IEnumerable<ShopifyBlog>> ListAsync(long? sinceId = null, string handle = null, string fields = null)
         {
             var request = RequestEngine.CreateRequest("blogs.json", RestSharp.Method.GET, "blogs");
 
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a count of all blogs.
         /// </summary>
-        public async Task<int> CountAsync()
+        public virtual async Task<int> CountAsync()
         {
             var request = RequestEngine.CreateRequest("blogs/count.json", RestSharp.Method.GET, "count");
 
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blog">The blog being created. Id should be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="ShopifyMetaFieldService"/>.</param>
-        public async Task<ShopifyBlog> CreateAsync(ShopifyBlog blog, IEnumerable<ShopifyMetaField> metafields = null)
+        public virtual async Task<ShopifyBlog> CreateAsync(ShopifyBlog blog, IEnumerable<ShopifyMetaField> metafields = null)
         {
             var request = RequestEngine.CreateRequest("blogs.json", RestSharp.Method.POST, "blog");
             var body = blog.ToDictionary();
@@ -82,7 +82,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blog">The updated blog. Id should not be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="ShopifyMetaFieldService"/>.</param>
-        public async Task<ShopifyBlog> UpdateAsync(ShopifyBlog blog, IEnumerable<ShopifyMetaField> metafields = null)
+        public virtual async Task<ShopifyBlog> UpdateAsync(ShopifyBlog blog, IEnumerable<ShopifyMetaField> metafields = null)
         {
             var request = RequestEngine.CreateRequest($"blogs/{blog.Id.Value}.json", RestSharp.Method.PUT, "blog");
             var body = blog.ToDictionary();
@@ -104,7 +104,7 @@ namespace ShopifySharp
         /// Gets a blog with the given id.
         /// </summary>
         /// <param name="id">The id of the blog you want to retrieve.</param>
-        public async Task<ShopifyBlog> GetAsync(long id)
+        public virtual async Task<ShopifyBlog> GetAsync(long id)
         {
             var request = RequestEngine.CreateRequest($"blogs/{id}.json", RestSharp.Method.GET, "blog");
 
@@ -115,7 +115,7 @@ namespace ShopifySharp
         /// Deletes a blog with the given id.
         /// </summary>
         /// <param name="id">The id of the blog you want to delete.</param>
-        public async Task DeleteAsync(long id)
+        public virtual async Task DeleteAsync(long id)
         {
             var request = RequestEngine.CreateRequest($"blogs/{id}.json", RestSharp.Method.DELETE);
 

--- a/ShopifySharp/Services/Charge/ShopifyChargeService.cs
+++ b/ShopifySharp/Services/Charge/ShopifyChargeService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="charge">The <see cref="ShopifyCharge"/> to create.</param>
         /// <returns>The new <see cref="ShopifyCharge"/>.</returns>
-        public async Task<ShopifyCharge> CreateAsync(ShopifyCharge charge)
+        public virtual async Task<ShopifyCharge> CreateAsync(ShopifyCharge charge)
         {
             IRestRequest req = RequestEngine.CreateRequest("application_charges.json", Method.POST, "application_charge");
 
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyCharge"/>.</returns>
-        public async Task<ShopifyCharge> GetAsync(long id, string fields = null)
+        public virtual async Task<ShopifyCharge> GetAsync(long id, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"application_charges/{id}.json", Method.GET, "application_charge");
 
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <param name="sinceId">Restricts results to any charge after the given id.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The list of <see cref="ShopifyCharge"/> objects.</returns>
-        public async Task<IEnumerable<ShopifyCharge>> ListAsync(long? sinceId = null, string fields = null)
+        public virtual async Task<IEnumerable<ShopifyCharge>> ListAsync(long? sinceId = null, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("application_charges.json", Method.GET, "application_charges");
 
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// Activates a <see cref="ShopifyCharge"/> that the shop owner has accepted.
         /// </summary>
         /// <param name="id">The id of the charge to activate.</param>
-        public async Task ActivateAsync(long id)
+        public virtual async Task ActivateAsync(long id)
         {
             IRestRequest req = RequestEngine.CreateRequest($"application_charges/{id}/activate.json", Method.POST);
 

--- a/ShopifySharp/Services/Collect/ShopifyCollectService.cs
+++ b/ShopifySharp/Services/Collect/ShopifyCollectService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// Gets a count of all of the collects (product-collection mappings).
         /// </summary>
         /// <returns>The count of all collects for the shop.</returns>
-        public async Task<int> CountAsync(ShopifyCollectFilter filter = null)
+        public virtual async Task<int> CountAsync(ShopifyCollectFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("collects/count.json", Method.GET, "count");
 
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's collects.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyCollect>> ListAsync(ShopifyCollectFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyCollect>> ListAsync(ShopifyCollectFilter options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("collects.json", Method.GET, "collects");
 
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <param name="collectId">The id of the collect to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyCollect"/>.</returns>
-        public async Task<ShopifyCollect> GetAsync(long collectId, string fields = null)
+        public virtual async Task<ShopifyCollect> GetAsync(long collectId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"collects/{collectId}.json", Method.GET, "collect");
 
@@ -78,7 +78,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="collect">A new <see cref="ShopifyCollect"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="ShopifyCollect"/>.</returns>
-        public async Task<ShopifyCollect> CreateAsync(ShopifyCollect collect)
+        public virtual async Task<ShopifyCollect> CreateAsync(ShopifyCollect collect)
         {
             IRestRequest req = RequestEngine.CreateRequest("collects.json", RestSharp.Method.POST, "collect");
 
@@ -96,7 +96,7 @@ namespace ShopifySharp
         /// Deletes a collect with the given Id.
         /// </summary>
         /// <param name="collectId">The product object's Id.</param>
-        public async Task DeleteAsync(long collectId)
+        public virtual async Task DeleteAsync(long collectId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"collects/{collectId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/CustomCollection/ShopifyCustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/ShopifyCustomCollectionService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">The <see cref="ShopifyCustomCollection"/>. used to filter results</param>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyCustomCollection>> ListAsync(ShopifyCustomCollectionFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyCustomCollection>> ListAsync(ShopifyCustomCollectionFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("/custom_collections.json", Method.GET, "custom_collections");
 
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customCollection">A new <see cref="ShopifyCustomCollection"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="ShopifyCustomCollection"/>.</returns>
-        public async Task<ShopifyCustomCollection> CreateAsync(ShopifyCustomCollection customCollection)
+        public virtual async Task<ShopifyCustomCollection> CreateAsync(ShopifyCustomCollection customCollection)
         {
             string reqPath = "custom_collections.json";
 
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// Gets a count of all of the custom collections
         /// </summary>
         /// <returns>The count of all collects for the shop.</returns>
-        public async Task<int> CountAsync(ShopifyCustomCollectionFilter options = null)
+        public virtual async Task<int> CountAsync(ShopifyCustomCollectionFilter options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("custom_collections/count.json", Method.GET, "count");
 
@@ -77,7 +77,7 @@ namespace ShopifySharp
         /// <param name="customCollectionId">The id of the custom collection to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyCustomCollection"/>.</returns>
-        public async Task<ShopifyCustomCollection> GetAsync(long customCollectionId, string fields = null)
+        public virtual async Task<ShopifyCustomCollection> GetAsync(long customCollectionId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"custom_collections/{customCollectionId}.json", Method.GET, "custom_collection");
 
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// Deletes a custom collection with the given Id.
         /// </summary>
         /// <param name="customCollectionId">The custom collection's Id.</param>
-        public async Task DeleteAsync(long customCollectionId)
+        public virtual async Task DeleteAsync(long customCollectionId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"custom_collections/{customCollectionId}.json", Method.DELETE);
 
@@ -105,7 +105,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customCollection">The <see cref="ShopifyCustomCollection"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyCustomCollection"/>.</returns>
-        public async Task<ShopifyCustomCollection> UpdateAsync(ShopifyCustomCollection customCollection)
+        public virtual async Task<ShopifyCustomCollection> UpdateAsync(ShopifyCustomCollection customCollection)
         {
             IRestRequest req = RequestEngine.CreateRequest($"custom_collections/{customCollection.Id.Value}.json", Method.PUT, "custom_collection");
 

--- a/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
+++ b/ShopifySharp/Services/Customer/ShopifyCustomerService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's customers.
         /// </summary>
         /// <returns>The count of all customers for the shop.</returns>
-        public async Task<int> CountAsync()
+        public virtual async Task<int> CountAsync()
         {
             IRestRequest req = RequestEngine.CreateRequest("customers/count.json", Method.GET);
             JToken responseObject = await RequestEngine.ExecuteRequestAsync(_RestClient, req);
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's customers.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyCustomer>> ListAsync(ShopifyListFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyCustomer>> ListAsync(ShopifyListFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("customers.json", Method.GET, "customers");
 
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <param name="customerId">The id of the customer to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyCustomer"/>.</returns>
-        public async Task<ShopifyCustomer> GetAsync(long customerId, string fields = null)
+        public virtual async Task<ShopifyCustomer> GetAsync(long customerId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"customers/{customerId}.json", Method.GET, "customer");
 
@@ -79,7 +79,7 @@ namespace ShopifySharp
         /// <param name="order">An optional string to order the results, in format of 'field_name DESC'. Default is 'last_order_date DESC'.</param>
         /// <param name="filter">Options for filtering the results.</param>
         /// <returns>A list of matching customers.</returns>
-        public async Task<IEnumerable<ShopifyCustomer>> SearchAsync(string query, string order = null, ShopifyListFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyCustomer>> SearchAsync(string query, string order = null, ShopifyListFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("customers/search.json", Method.GET, "customers");
             req.AddQueryParameter("query", query);
@@ -96,7 +96,7 @@ namespace ShopifySharp
         /// <param name="customer">A new <see cref="ShopifyCustomer"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the customer.</param>
         /// <returns>The new <see cref="ShopifyCustomer"/>.</returns>
-        public async Task<ShopifyCustomer> CreateAsync(ShopifyCustomer customer, ShopifyCustomerCreateOptions options = null)
+        public virtual async Task<ShopifyCustomer> CreateAsync(ShopifyCustomer customer, ShopifyCustomerCreateOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("customers.json", Method.POST, "customer");
 
@@ -123,7 +123,7 @@ namespace ShopifySharp
         /// <param name="customer">The <see cref="ShopifyCustomer"/> to update.</param>
         /// <param name="options">Options for updating the customer.</param>
         /// <returns>The updated <see cref="ShopifyCustomer"/>.</returns>
-        public async Task<ShopifyCustomer> UpdateAsync(ShopifyCustomer customer, ShopifyCustomerUpdateOptions options = null)
+        public virtual async Task<ShopifyCustomer> UpdateAsync(ShopifyCustomer customer, ShopifyCustomerUpdateOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"customers/{customer.Id.Value}.json", Method.PUT, "customer");
 
@@ -148,7 +148,7 @@ namespace ShopifySharp
         /// Deletes a customer with the given Id.
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
-        public async Task DeleteAsync(long customerId)
+        public virtual async Task DeleteAsync(long customerId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"customers/{customerId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Event/ShopifyEventService.cs
+++ b/ShopifySharp/Services/Event/ShopifyEventService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Supports CreatedAtMin and CreatedAtMax Properties</param>
         /// <returns>The count of all site events.</returns>
-        public async Task<int> CountAsync(ShopifyCountFilter filter = null)
+        public virtual async Task<int> CountAsync(ShopifyCountFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("events/count.json", Method.GET);
 
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <param name="eventId">The id of the event to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyEvent"/>.</returns>
-        public async Task<ShopifyEvent> GetAsync(long eventId, string fields = null)
+        public virtual async Task<ShopifyEvent> GetAsync(long eventId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"events/{eventId}.json", Method.GET, "event");
 
@@ -67,7 +67,7 @@ namespace ShopifySharp
         /// <param name="options">Options for filtering the result.</param>
         /// <param name="subjectId">Restricts results to just one subject item, e.g. all changes on a product.</param>
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
-        public async Task<IEnumerable<ShopifyEvent>> ListAsync(long subjectId, string subjectType, ShopifyEventListFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyEvent>> ListAsync(long subjectId, string subjectType, ShopifyEventListFilter options = null)
         {
             // Ensure the subject type is plural
             if (! subjectType.Substring(subjectType.Length - 1).Equals("s", System.StringComparison.OrdinalIgnoreCase))
@@ -90,7 +90,7 @@ namespace ShopifySharp
         /// Returns a list of events.
         /// </summary>
         /// <param name="options">Options for filtering the result.</param>
-        public async Task<IEnumerable<ShopifyEvent>> ListAsync(ShopifyEventListFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyEvent>> ListAsync(ShopifyEventListFilter options = null)
         {
             var req = RequestEngine.CreateRequest("events.json", Method.GET, "events");
             

--- a/ShopifySharp/Services/Fulfillment/ShopifyFulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/ShopifyFulfillmentService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the count.</param>
         /// <returns>The count of all fulfillments for the shop.</returns>
-        public async Task<int> CountAsync(long orderId, ShopifyCountFilter filter = null)
+        public virtual async Task<int> CountAsync(long orderId, ShopifyCountFilter filter = null)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments/count.json", Method.GET);
 
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="options">Options for filtering the list.</param>
         /// <returns>The list of fulfillments matching the filter.</returns>
-        public async Task<IEnumerable<ShopifyFulfillment>> ListAsync(long orderId, ShopifyListFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyFulfillment>> ListAsync(long orderId, ShopifyListFilter options = null)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments.json", Method.GET, "fulfillments");
 
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentId">The id of the Fulfillment to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyFulfillment"/>.</returns>
-        public async Task<ShopifyFulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null)
+        public virtual async Task<ShopifyFulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments/{fulfillmentId}.json", Method.GET, "fulfillment");
 
@@ -83,7 +83,7 @@ namespace ShopifySharp
         /// <param name="notifyCustomer">Whether the customer should be notified that the fulfillment 
         /// has been created.</param>
         /// <returns>The new <see cref="ShopifyFulfillment"/>.</returns>
-        public async Task<ShopifyFulfillment> CreateAsync(long orderId, ShopifyFulfillment fulfillment, bool notifyCustomer)
+        public virtual async Task<ShopifyFulfillment> CreateAsync(long orderId, ShopifyFulfillment fulfillment, bool notifyCustomer)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments.json", Method.POST, "fulfillment");
             
@@ -102,7 +102,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillment">The <see cref="ShopifyFulfillment"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyFulfillment"/>.</returns>
-        public async Task<ShopifyFulfillment> UpdateAsync(long orderId, ShopifyFulfillment fulfillment)
+        public virtual async Task<ShopifyFulfillment> UpdateAsync(long orderId, ShopifyFulfillment fulfillment)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments/{fulfillment.Id.Value}.json", Method.PUT, "fulfillment");
 
@@ -116,7 +116,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
-        public async Task<ShopifyFulfillment> CompleteAsync(long orderId, long fulfillmentId)
+        public virtual async Task<ShopifyFulfillment> CompleteAsync(long orderId, long fulfillmentId)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/complete.json", Method.POST, "fulfillment");
 
@@ -128,7 +128,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
-        public async Task<ShopifyFulfillment> CancelAsync(long orderId, long fulfillmentId)
+        public virtual async Task<ShopifyFulfillment> CancelAsync(long orderId, long fulfillmentId)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/cancel.json", Method.POST, "fulfillment");
 

--- a/ShopifySharp/Services/Location/ShopifyLocationService.cs
+++ b/ShopifySharp/Services/Location/ShopifyLocationService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <returns>The <see cref="ShopifyLocation"/>.</returns>
-        public async Task<ShopifyLocation> GetAsync(long id)
+        public virtual async Task<ShopifyLocation> GetAsync(long id)
         {
             var req = RequestEngine.CreateRequest($"locations/{id}.json", Method.GET, "location");           
 
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// Retrieves a list of all <see cref="ShopifyLocation"/> objects.
         /// </summary>
         /// <returns>The list of <see cref="ShopifyLocation"/> objects.</returns>
-        public async Task<IEnumerable<ShopifyLocation>> ListAsync()
+        public virtual async Task<IEnumerable<ShopifyLocation>> ListAsync()
         {
             var req = RequestEngine.CreateRequest($"locations.json", Method.GET, "locations");
 

--- a/ShopifySharp/Services/MetaField/ShopifyMetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/ShopifyMetaFieldService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">The <see cref="ShopifyMetaFieldFilter"/> used to filter results</param>
         /// <returns>The count of all metafields for the given entity and filter options.</returns>
-        public async Task<int> CountAsync(long? resourceId, string resourceType = null, ShopifyMetaFieldFilter filter = null)
+        public virtual async Task<int> CountAsync(long? resourceId, string resourceType = null, ShopifyMetaFieldFilter filter = null)
         {
             string reqPath = "metafields/count.json";
             if (resourceType != null && resourceId != null)
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="options">The <see cref="ShopifyMetaFieldFilter"/> used to filter results</param>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyMetaField>> ListAsync(long? resourceId, string resourceType = null, ShopifyMetaFieldFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyMetaField>> ListAsync(long? resourceId, string resourceType = null, ShopifyMetaFieldFilter options = null)
         {
             string reqPath = "metafields.json";
             if (resourceType != null && resourceId != null)
@@ -80,7 +80,7 @@ namespace ShopifySharp
         /// <param name="metafieldId">The id of the metafield to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyMetaField"/>.</returns>
-        public async Task<ShopifyMetaField> GetAsync(long metafieldId, string fields = null)
+        public virtual async Task<ShopifyMetaField> GetAsync(long metafieldId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"metafields/{metafieldId}.json", Method.GET, "metafield");
 
@@ -99,7 +99,7 @@ namespace ShopifySharp
         /// <param name="resourceId">The Id of the resource the metafield will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
         /// <param name="resourceType">The resource type the metaifeld will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
         /// <returns>The new <see cref="ShopifyMetaField"/>.</returns>
-        public async Task<ShopifyMetaField> CreateAsync(ShopifyMetaField metafield, long? resourceId, string resourceType = null)
+        public virtual async Task<ShopifyMetaField> CreateAsync(ShopifyMetaField metafield, long? resourceId, string resourceType = null)
         {
             string reqPath = "metafields.json";
             if (resourceType != null && resourceId != null)
@@ -124,7 +124,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="metafield">The <see cref="ShopifyMetaField"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyMetaField"/>.</returns>
-        public async Task<ShopifyMetaField> UpdateAsync(ShopifyMetaField metafield)
+        public virtual async Task<ShopifyMetaField> UpdateAsync(ShopifyMetaField metafield)
         {
             IRestRequest req = RequestEngine.CreateRequest($"metafields/{metafield.Id.Value}.json", Method.PUT, "metafield");
 
@@ -137,7 +137,7 @@ namespace ShopifySharp
         /// Deletes a metafield with the given Id.
         /// </summary>
         /// <param name="metafieldId">The metafield object's Id.</param>
-        public async Task DeleteAsync(long metafieldId)
+        public virtual async Task DeleteAsync(long metafieldId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"metafields/{metafieldId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Order/ShopifyOrderService.cs
+++ b/ShopifySharp/Services/Order/ShopifyOrderService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
         /// <returns>The count of all orders for the shop.</returns>
-        public async Task<int> CountAsync(ShopifyOrderFilter filter = null)
+        public virtual async Task<int> CountAsync(ShopifyOrderFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("orders/count.json", Method.GET);
 
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="options">Options for filtering the list.</param>
         /// <returns>The list of orders matching the filter.</returns>
-        public async Task<IEnumerable<ShopifyOrder>> ListAsync(ShopifyOrderFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyOrder>> ListAsync(ShopifyOrderFilter options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("orders.json", Method.GET, "orders");
 
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// <param name="customerId">The id of the customer to list orders for.</param>
         /// <param name="options">Options for filtering the list.</param>
         /// <returns>The list of orders matching the filter.</returns>
-        public async Task<IEnumerable<ShopifyOrder>> ListForCustomerAsync(long customerId, ShopifyOrderFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyOrder>> ListForCustomerAsync(long customerId, ShopifyOrderFilter options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("orders.json", Method.GET, "orders");
 
@@ -82,7 +82,7 @@ namespace ShopifySharp
         /// <param name="orderId">The id of the order to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyOrder"/>.</returns>
-        public async Task<ShopifyOrder> GetAsync(long orderId, string fields = null)
+        public virtual async Task<ShopifyOrder> GetAsync(long orderId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"orders/{orderId}.json", Method.GET, "order");
 
@@ -98,7 +98,7 @@ namespace ShopifySharp
         /// Closes an order.
         /// </summary>
         /// <param name="id">The order's id.</param>
-        public async Task<ShopifyOrder> CloseAsync(long id)
+        public virtual async Task<ShopifyOrder> CloseAsync(long id)
         {
             var req = RequestEngine.CreateRequest($"orders/{id}/close.json", Method.POST, "order");
 
@@ -109,7 +109,7 @@ namespace ShopifySharp
         /// Opens a closed order.
         /// </summary>
         /// <param name="id">The order's id.</param>
-        public async Task<ShopifyOrder> OpenAsync(long id)
+        public virtual async Task<ShopifyOrder> OpenAsync(long id)
         {
             var req = RequestEngine.CreateRequest($"orders/{id}/open.json", Method.POST, "order");
 
@@ -122,7 +122,7 @@ namespace ShopifySharp
         /// <param name="order">A new <see cref="ShopifyOrder"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the order.</param>
         /// <returns>The new <see cref="ShopifyOrder"/>.</returns>
-        public async Task<ShopifyOrder> CreateAsync(ShopifyOrder order, ShopifyOrderCreateOptions options = null)
+        public virtual async Task<ShopifyOrder> CreateAsync(ShopifyOrder order, ShopifyOrderCreateOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("orders.json", Method.POST, "order");
 
@@ -142,7 +142,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="order">The <see cref="ShopifyOrder"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyOrder"/>.</returns>
-        public async Task<ShopifyOrder> UpdateAsync(ShopifyOrder order)
+        public virtual async Task<ShopifyOrder> UpdateAsync(ShopifyOrder order)
         {
             IRestRequest req = RequestEngine.CreateRequest($"orders/{order.Id.Value}.json", Method.PUT, "order");
 
@@ -155,7 +155,7 @@ namespace ShopifySharp
         /// Deletes an order with the given Id.
         /// </summary>
         /// <param name="orderId">The order object's Id.</param>
-        public async Task DeleteAsync(long orderId)
+        public virtual async Task DeleteAsync(long orderId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"orders/{orderId}.json", Method.DELETE);
 
@@ -167,7 +167,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order's id.</param>
         /// <returns>The cancelled <see cref="ShopifyOrder"/>.</returns>
-        public async Task CancelAsync(long orderId, ShopifyOrderCancelOptions options = null)
+        public virtual async Task CancelAsync(long orderId, ShopifyOrderCancelOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"orders/{orderId}/cancel.json", Method.POST);
 

--- a/ShopifySharp/Services/OrderRisk/ShopifyOrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/ShopifyOrderRiskService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// Gets a list of all order risks for an order.
         /// </summary>
         /// <param name="orderId">The order the risks belong to.</param>
-        public async Task<IEnumerable<ShopifyOrderRisk>> ListAsync(long orderId)
+        public virtual async Task<IEnumerable<ShopifyOrderRisk>> ListAsync(long orderId)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/risks.json", Method.GET, "risks");
             
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="riskId">The id of the risk to retrieve.</param>
-        public async Task<ShopifyOrderRisk> GetAsync(long orderId, long riskId)
+        public virtual async Task<ShopifyOrderRisk> GetAsync(long orderId, long riskId)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/risks/{riskId}.json", Method.GET, "risk");
             
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="risk">A new <see cref="ShopifyOrderRisk"/>. Id should be set to null.</param>
-        public async Task<ShopifyOrderRisk> CreateAsync(long orderId, ShopifyOrderRisk risk)
+        public virtual async Task<ShopifyOrderRisk> CreateAsync(long orderId, ShopifyOrderRisk risk)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/risks.json", Method.POST, "risk");
 
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="risk">The risk to update.</param>
-        public async Task<ShopifyOrderRisk> UpdateAsync(long orderId, ShopifyOrderRisk risk)
+        public virtual async Task<ShopifyOrderRisk> UpdateAsync(long orderId, ShopifyOrderRisk risk)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/risks/{risk.Id.Value}.json", Method.PUT, "risk");
 
@@ -72,7 +72,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="riskId">The risk's id.</param>
-        public async Task DeleteAsync(long orderId, long riskId)
+        public virtual async Task DeleteAsync(long orderId, long riskId)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/risks/{riskId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Page/ShopifyPageService.cs
+++ b/ShopifySharp/Services/Page/ShopifyPageService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's pages.
         /// </summary>
         /// <returns>The count of all pages for the shop.</returns>
-        public async Task<int> CountAsync(ShopifyPageFilter filter = null)
+        public virtual async Task<int> CountAsync(ShopifyPageFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("pages/count.json", Method.GET);
 
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's pages.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyPage>> ListAsync(ShopifyPageFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyPage>> ListAsync(ShopifyPageFilter options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("pages.json", Method.GET, "pages");
 
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <param name="pageId">The id of the page to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyPage"/>.</returns>
-        public async Task<ShopifyPage> GetAsync(long pageId, string fields = null)
+        public virtual async Task<ShopifyPage> GetAsync(long pageId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"pages/{pageId}.json", Method.GET, "page");
 
@@ -82,7 +82,7 @@ namespace ShopifySharp
         /// <param name="page">A new <see cref="ShopifyPage"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the page.</param>
         /// <returns>The new <see cref="ShopifyPage"/>.</returns>
-        public async Task<ShopifyPage> CreateAsync(ShopifyPage page, ShopifyPageCreateOptions options = null)
+        public virtual async Task<ShopifyPage> CreateAsync(ShopifyPage page, ShopifyPageCreateOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("pages.json", Method.POST, "page");
 
@@ -102,7 +102,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="page">The <see cref="ShopifyPage"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyPage"/>.</returns>
-        public async Task<ShopifyPage> UpdateAsync(ShopifyPage page)
+        public virtual async Task<ShopifyPage> UpdateAsync(ShopifyPage page)
         {
             IRestRequest req = RequestEngine.CreateRequest($"pages/{page.Id.Value}.json", Method.PUT, "page");
 
@@ -115,7 +115,7 @@ namespace ShopifySharp
         /// Deletes a page with the given Id.
         /// </summary>
         /// <param name="pageId">The page object's Id.</param>
-        public async Task DeleteAsync(long pageId)
+        public virtual async Task DeleteAsync(long pageId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"pages/{pageId}.json", Method.DELETE);
 
@@ -128,7 +128,7 @@ namespace ShopifySharp
         /// <param name="pageId">The <see cref="ShopifyPage"/> pageId to update.</param>
         /// <param name="metafield">The <see cref="ShopifyMetaField"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyMetaField"/>.</returns>
-        public async Task<ShopifyMetaField> UpdateMetafieldAsync(long pageId, ShopifyMetaField metafield)
+        public virtual async Task<ShopifyMetaField> UpdateMetafieldAsync(long pageId, ShopifyMetaField metafield)
         {
             var requestPath = $"pages/{pageId}/metafields.json";
             var method = Method.POST;
@@ -151,7 +151,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="pageId">The id of the page to retrieve.</param>
         /// <returns>The <see cref="ShopifyPage"/>.</returns>
-        public async Task<List<ShopifyMetaField>> GetMetaFieldsAsync(long pageId)
+        public virtual async Task<List<ShopifyMetaField>> GetMetaFieldsAsync(long pageId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"pages/{pageId}/metafields.json", Method.GET,"metafields");
             

--- a/ShopifySharp/Services/Product/ShopifyProductService.cs
+++ b/ShopifySharp/Services/Product/ShopifyProductService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's products.
         /// </summary>
         /// <returns>The count of all products for the shop.</returns>
-        public async Task<int> CountAsync(ShopifyProductFilter filter = null)
+        public virtual async Task<int> CountAsync(ShopifyProductFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("products/count.json", Method.GET);
 
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's products.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyProduct>> ListAsync(ShopifyProductFilter options = null)
+        public virtual async Task<IEnumerable<ShopifyProduct>> ListAsync(ShopifyProductFilter options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("products.json", Method.GET, "products");
 
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyProduct"/>.</returns>
-        public async Task<ShopifyProduct> GetAsync(long productId, string fields = null)
+        public virtual async Task<ShopifyProduct> GetAsync(long productId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"products/{productId}.json", Method.GET, "product");
 
@@ -82,7 +82,7 @@ namespace ShopifySharp
         /// <param name="product">A new <see cref="ShopifyProduct"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the product.</param>
         /// <returns>The new <see cref="ShopifyProduct"/>.</returns>
-        public async Task<ShopifyProduct> CreateAsync(ShopifyProduct product, ShopifyProductCreateOptions options = null)
+        public virtual async Task<ShopifyProduct> CreateAsync(ShopifyProduct product, ShopifyProductCreateOptions options = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("products.json", Method.POST, "product");
 
@@ -110,7 +110,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="product">The <see cref="ShopifyProduct"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyProduct"/>.</returns>
-        public async Task<ShopifyProduct> UpdateAsync(ShopifyProduct product)
+        public virtual async Task<ShopifyProduct> UpdateAsync(ShopifyProduct product)
         {
             IRestRequest req = RequestEngine.CreateRequest($"products/{product.Id.Value}.json", Method.PUT, "product");
 
@@ -123,7 +123,7 @@ namespace ShopifySharp
         /// Deletes a product with the given Id.
         /// </summary>
         /// <param name="productId">The product object's Id.</param>
-        public async Task DeleteAsync(long productId)
+        public virtual async Task DeleteAsync(long productId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"products/{productId}.json", Method.DELETE);
 
@@ -135,7 +135,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The product's id.</param>
         /// <returns>The published <see cref="ShopifyProduct"/></returns>
-        public async Task<ShopifyProduct> PublishAsync(long id)
+        public virtual async Task<ShopifyProduct> PublishAsync(long id)
         {
             IRestRequest req = RequestEngine.CreateRequest($"products/{id}.json", Method.PUT, "product");
 
@@ -156,7 +156,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The product's id.</param>
         /// <returns>The unpublished <see cref="ShopifyProduct"/></returns>
-        public async Task<ShopifyProduct> UnpublishAsync(long id)
+        public virtual async Task<ShopifyProduct> UnpublishAsync(long id)
         {
             IRestRequest req = RequestEngine.CreateRequest($"products/{id}.json", Method.PUT, "product");
 

--- a/ShopifySharp/Services/ProductImage/ShopifyProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ShopifyProductImageService.cs
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="filter">An optional filter that restricts the results.</param>
         /// <returns>The count of all ProductImages for the shop.</returns>
-        public async Task<int> CountAsync(long productId, ShopifyPublishableCountFilter filter = null)
+        public virtual async Task<int> CountAsync(long productId, ShopifyPublishableCountFilter filter = null)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/images/count.json", Method.GET);
 
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <remarks>
         /// Unlike most list commands, this one only accepts the since_id and fields filters.
         /// </remarks>
-        public async Task<IEnumerable<ShopifyProductImage>> ListAsync(long productId, long? sinceId = null, string fields = null)
+        public virtual async Task<IEnumerable<ShopifyProductImage>> ListAsync(long productId, long? sinceId = null, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/images.json", Method.GET, "images");
 
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// <param name="imageId">The id of the ProductImage to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyProductImage"/>.</returns>
-        public async Task<ShopifyProductImage> GetAsync(long productId, long imageId, string fields = null)
+        public virtual async Task<ShopifyProductImage> GetAsync(long productId, long imageId, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/images/{imageId}.json", Method.GET, "image");
 
@@ -105,7 +105,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="image">The new <see cref="ShopifyProductImage"/>.</param>
         /// <returns>The new <see cref="ShopifyProductImage"/>.</returns>
-        public async Task<ShopifyProductImage> CreateAsync(long productId, ShopifyProductImage image)
+        public virtual async Task<ShopifyProductImage> CreateAsync(long productId, ShopifyProductImage image)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/images.json", Method.POST, "image");
 
@@ -120,7 +120,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="image">The <see cref="ShopifyProductImage"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyProductImage"/>.</returns>
-        public async Task<ShopifyProductImage> UpdateAsync(long productId, ShopifyProductImage image)
+        public virtual async Task<ShopifyProductImage> UpdateAsync(long productId, ShopifyProductImage image)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/images/{image.Id.Value}.json", Method.PUT, "image");
 
@@ -134,7 +134,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="imageId">The ProductImage object's Id.</param>
-        public async Task DeleteAsync(long productId, long imageId)
+        public virtual async Task DeleteAsync(long productId, long imageId)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/images/{imageId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/ProductVariant/ShopifyProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ShopifyProductVariantService.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp
         /// Gets a count of all variants belonging to the given product.
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
-        public async Task<int> CountAsync(long productId)
+        public virtual async Task<int> CountAsync(long productId)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/variants/count.json", Method.GET, "count");            
 
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
         /// <param name="filterOptions">Options for filtering the result.</param>
-        public async Task<IEnumerable<ShopifyProductVariant>> ListAsync(long productId, ShopifyListFilter filterOptions = null)
+        public virtual async Task<IEnumerable<ShopifyProductVariant>> ListAsync(long productId, ShopifyListFilter filterOptions = null)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/variants.json", Method.GET, "variants");
 
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="ShopifyProductVariant"/> with the given id.
         /// </summary>
         /// <param name="variantId">The id of the product variant to retrieve.</param>
-        public async Task<ShopifyProductVariant> GetAsync(long variantId)
+        public virtual async Task<ShopifyProductVariant> GetAsync(long variantId)
         {
             var req = RequestEngine.CreateRequest($"variants/{variantId}.json", Method.GET, "variant");
             
@@ -61,7 +61,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the new variant will belong to.</param>
         /// <param name="variant">A new <see cref="ShopifyProductVariant"/>. Id should be set to null.</param>
-        public async Task<ShopifyProductVariant> CreateAsync(long productId, ShopifyProductVariant variant)
+        public virtual async Task<ShopifyProductVariant> CreateAsync(long productId, ShopifyProductVariant variant)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/variants.json", Method.POST, "variant");
 
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// Updates the given <see cref="ShopifyProductVariant"/>. Id must not be null.
         /// </summary>
         /// <param name="variant">The variant to update.</param>
-        public async Task<ShopifyProductVariant> UpdateAsync(ShopifyProductVariant variant)
+        public virtual async Task<ShopifyProductVariant> UpdateAsync(ShopifyProductVariant variant)
         {
             var req = RequestEngine.CreateRequest($"variants/{variant.Id.Value}.json", Method.PUT, "variant");
 
@@ -88,7 +88,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the variant belongs to.</param>
         /// <param name="variantId">The product variant's id.</param>
-        public async Task DeleteAsync(long productId, long variantId)
+        public virtual async Task DeleteAsync(long productId, long variantId)
         {
             var req = RequestEngine.CreateRequest($"products/{productId}/variants/{variantId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/RecurringCharge/ShopifyRecurringChargeService.cs
+++ b/ShopifySharp/Services/RecurringCharge/ShopifyRecurringChargeService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="charge">The <see cref="ShopifyRecurringCharge"/> to create.</param>
         /// <returns>The new <see cref="ShopifyRecurringCharge"/>.</returns>
-        public async Task<ShopifyRecurringCharge> CreateAsync(ShopifyRecurringCharge charge)
+        public virtual async Task<ShopifyRecurringCharge> CreateAsync(ShopifyRecurringCharge charge)
         {
             IRestRequest req = RequestEngine.CreateRequest("recurring_application_charges.json", Method.POST, "recurring_application_charge");
 
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyRecurringCharge"/>.</returns>
-        public async Task<ShopifyRecurringCharge> GetAsync(long id, string fields = null)
+        public virtual async Task<ShopifyRecurringCharge> GetAsync(long id, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"recurring_application_charges/{id}.json", Method.GET, "recurring_application_charge");
 
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <param name="sinceId">Restricts results to any charge after the given id.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The list of <see cref="ShopifyRecurringCharge"/> objects.</returns>
-        public async Task<IEnumerable<ShopifyRecurringCharge>> ListAsync(long? sinceId = null, string fields = null)
+        public virtual async Task<IEnumerable<ShopifyRecurringCharge>> ListAsync(long? sinceId = null, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("recurring_application_charges.json", Method.GET, "recurring_application_charges");
 
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// Activates a <see cref="ShopifyRecurringCharge"/> that the shop owner has accepted.
         /// </summary>
         /// <param name="id">The id of the charge to activate.</param>
-        public async Task ActivateAsync(long id)
+        public virtual async Task ActivateAsync(long id)
         {
             IRestRequest req = RequestEngine.CreateRequest($"recurring_application_charges/{id}/activate.json", Method.POST);
 
@@ -96,7 +96,7 @@ namespace ShopifySharp
         /// Deletes a <see cref="ShopifyRecurringCharge"/>.
         /// </summary>
         /// <param name="id">The id of the charge to delete.</param>
-        public async Task DeleteAsync(long id)
+        public virtual async Task DeleteAsync(long id)
         {
             IRestRequest req = RequestEngine.CreateRequest($"recurring_application_charges/{id}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Redirect/ShopifyRedirectService.cs
+++ b/ShopifySharp/Services/Redirect/ShopifyRedirectService.cs
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// <param name="path">An optional parameter that filters the result to redirects with the given path.</param>
         /// <param name="target">An optional parameter that filters the result to redirects with the given target.</param>
         /// <returns>The count of all redirects for the shop.</returns>
-        public async Task<int> CountAsync(string path = null, string target = null)
+        public virtual async Task<int> CountAsync(string path = null, string target = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("redirects/count.json", Method.GET);
 
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">An optional filter that restricts the results.</param>
         /// <returns>The list of <see cref="ShopifyRedirect"/>.</returns>
-        public async Task<IEnumerable<ShopifyRedirect>> ListAsync(ShopifyRedirectFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyRedirect>> ListAsync(ShopifyRedirectFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("redirects.json", Method.GET, "redirects");
 
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <param name="redirectId">The id of the redirect to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyRedirect"/>.</returns>
-        public async Task<ShopifyRedirect> GetAsync(long redirectId, string fields = null)
+        public virtual async Task<ShopifyRedirect> GetAsync(long redirectId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"redirects/{redirectId}.json", Method.GET, "redirect");
 
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="redirect">The new <see cref="ShopifyRedirect"/>.</param>
         /// <returns>The new <see cref="ShopifyRedirect"/>.</returns>
-        public async Task<ShopifyRedirect> CreateAsync(ShopifyRedirect redirect)
+        public virtual async Task<ShopifyRedirect> CreateAsync(ShopifyRedirect redirect)
         {
             IRestRequest req = RequestEngine.CreateRequest("redirects.json", Method.POST, "redirect");
 
@@ -107,7 +107,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="redirect">The <see cref="ShopifyRedirect"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyRedirect"/>.</returns>
-        public async Task<ShopifyRedirect> UpdateAsync(ShopifyRedirect redirect)
+        public virtual async Task<ShopifyRedirect> UpdateAsync(ShopifyRedirect redirect)
         {
             IRestRequest req = RequestEngine.CreateRequest($"redirects/{redirect.Id.Value}.json", Method.PUT, "redirect");
 
@@ -120,7 +120,7 @@ namespace ShopifySharp
         /// Deletes a redirect with the given Id.
         /// </summary>
         /// <param name="redirectId">The redirect object's Id.</param>
-        public async Task DeleteAsync(long redirectId)
+        public virtual async Task DeleteAsync(long redirectId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"redirects/{redirectId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/ScriptTag/ShopifyScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ShopifyScriptTagService.cs
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// <param name="src">Optionally filters the count to only those <see cref="ShopifyScriptTag"/>s with the 
         /// given <see cref="ShopifyScriptTag.Src"/> value.</param>
         /// <returns>The count.</returns>
-        public async Task<int> CountAsync(string src = null)
+        public virtual async Task<int> CountAsync(string src = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("script_tags/count.json", Method.GET);
 
@@ -50,7 +50,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's <see cref="ShopifyScriptTag"/>s.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyScriptTag>> ListAsync(ShopifyScriptTagFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyScriptTag>> ListAsync(ShopifyScriptTagFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("script_tags.json", Method.GET, "script_tags");
 
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <param name="tagId">The id of the <see cref="ShopifyScriptTag"/> to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyScriptTag"/>.</returns>
-        public async Task<ShopifyScriptTag> GetAsync(long tagId, string fields = null)
+        public virtual async Task<ShopifyScriptTag> GetAsync(long tagId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"script_tags/{tagId}.json", Method.GET, "script_tag");
 
@@ -83,7 +83,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="tag">A new <see cref="ShopifyScriptTag"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="ShopifyScriptTag"/>.</returns>
-        public async Task<ShopifyScriptTag> CreateAsync(ShopifyScriptTag tag)
+        public virtual async Task<ShopifyScriptTag> CreateAsync(ShopifyScriptTag tag)
         {
             IRestRequest req = RequestEngine.CreateRequest("script_tags.json", Method.POST, "script_tag");
 
@@ -103,7 +103,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="tag">The <see cref="ShopifyScriptTag"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyScriptTag"/>.</returns>
-        public async Task<ShopifyScriptTag> UpdateAsync(ShopifyScriptTag tag)
+        public virtual async Task<ShopifyScriptTag> UpdateAsync(ShopifyScriptTag tag)
         {
             IRestRequest req = RequestEngine.CreateRequest($"script_tags/{tag.Id.Value}.json", Method.PUT, "script_tag");
 
@@ -116,7 +116,7 @@ namespace ShopifySharp
         /// Deletes the <see cref="ShopifyScriptTag"/> with the given Id.
         /// </summary>
         /// <param name="tagId">The tag's Id.</param>
-        public async Task DeleteAsync(long tagId)
+        public virtual async Task DeleteAsync(long tagId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"script_tags/{tagId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Shop/ShopifyShopService.cs
+++ b/ShopifySharp/Services/Shop/ShopifyShopService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// Returns the shop's <see cref="ShopifyShop"/> information.
         /// </summary>
         /// <returns></returns>
-        public async Task<ShopifyShop> GetAsync()
+        public virtual async Task<ShopifyShop> GetAsync()
         {
             IRestRequest request = RequestEngine.CreateRequest("shop.json", Method.GET, "shop");
 
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// <summary>
         /// Forces the shop to uninstall your Shopify app. Uninstalling an application is an irreversible operation. Be entirely sure that you no longer need to make API calls for the shop in which the application has been installed.
         /// </summary>
-        public async Task UninstallAppAsync()
+        public virtual async Task UninstallAppAsync()
         {
             var request = RequestEngine.CreateRequest("api_permissions/current.json", Method.DELETE);
 

--- a/ShopifySharp/Services/SmartCollection/ShopifySmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/ShopifySmartCollectionService.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp
         /// Gets a count of all smart collections on the store.
         /// </summary>
         /// <param name="filterOptions">Options for filtering the count.</param>
-        public async Task<int> CountAsync(ShopifySmartCollectionFilter filterOptions = null)
+        public virtual async Task<int> CountAsync(ShopifySmartCollectionFilter filterOptions = null)
         {
             var req = RequestEngine.CreateRequest("smart_collections/count.json", Method.GET, "count");
 
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 smart collections.
         /// </summary>
         /// <param name="filterOptions">Options for filtering the result.</param>
-        public async Task<IEnumerable<ShopifySmartCollection>> ListAsync(ShopifySmartCollectionFilter filterOptions = null)
+        public virtual async Task<IEnumerable<ShopifySmartCollection>> ListAsync(ShopifySmartCollectionFilter filterOptions = null)
         {
             var req = RequestEngine.CreateRequest($"smart_collections.json", Method.GET, "smart_collections");
 
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="ShopifySmartCollection"/> with the given id.
         /// </summary>
         /// <param name="collectionId">The id of the smart collection to retrieve.</param>
-        public async Task<ShopifySmartCollection> GetAsync(long collectionId)
+        public virtual async Task<ShopifySmartCollection> GetAsync(long collectionId)
         {
             var req = RequestEngine.CreateRequest($"smart_collections/{collectionId}.json", Method.GET, "smart_collection");
             
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="ShopifySmartCollection"/>.
         /// </summary>
         /// <param name="collection">A new <see cref="ShopifySmartCollection"/>. Id should be set to null.</param>
-        public async Task<ShopifySmartCollection> CreateAsync(ShopifySmartCollection collection)
+        public virtual async Task<ShopifySmartCollection> CreateAsync(ShopifySmartCollection collection)
         {
             var req = RequestEngine.CreateRequest($"smart_collections.json", Method.POST, "smart_collection");
 
@@ -77,7 +77,7 @@ namespace ShopifySharp
         /// Updates the given <see cref="ShopifySmartCollection"/>. Id must not be null.
         /// </summary>
         /// <param name="collection">The smart collection to update.</param>
-        public async Task<ShopifySmartCollection> UpdateAsync(ShopifySmartCollection collection)
+        public virtual async Task<ShopifySmartCollection> UpdateAsync(ShopifySmartCollection collection)
         {
             var req = RequestEngine.CreateRequest($"smart_collections/{collection.Id.Value}.json", Method.PUT, "smart_collection");
 
@@ -90,7 +90,7 @@ namespace ShopifySharp
         /// Deletes a smart collection with the given Id.
         /// </summary>
         /// <param name="collectionId">The smart collection's id.</param>
-        public async Task DeleteAsync(long collectionId)
+        public virtual async Task DeleteAsync(long collectionId)
         {
             var req = RequestEngine.CreateRequest($"smart_collections/{collectionId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Theme/ShopifyThemeService.cs
+++ b/ShopifySharp/Services/Theme/ShopifyThemeService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's themes.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<ShopifyTheme>> ListAsync(ShopifyListFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyTheme>> ListAsync(ShopifyListFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("themes.json", Method.GET, "themes");
 
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// <param name="themeId">The id of the theme to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyTheme"/>.</returns>
-        public async Task<ShopifyTheme> GetAsync(long themeId, string fields = null)
+        public virtual async Task<ShopifyTheme> GetAsync(long themeId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{themeId}.json", Method.GET, "theme");
 
@@ -67,7 +67,7 @@ namespace ShopifySharp
         /// <param name="theme">The new <see cref="ShopifyTheme"/>.</param>
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
         /// <returns>The new <see cref="ShopifyTheme"/>.</returns>
-        public async Task<ShopifyTheme> CreateAsync(ShopifyTheme theme, string sourceUrl)
+        public virtual async Task<ShopifyTheme> CreateAsync(ShopifyTheme theme, string sourceUrl)
         {
             IRestRequest req = RequestEngine.CreateRequest("themes.json", Method.POST, "theme");
 
@@ -89,7 +89,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="theme">The <see cref="ShopifyTheme"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyTheme"/>.</returns>
-        public async Task<ShopifyTheme> UpdateAsync(ShopifyTheme theme)
+        public virtual async Task<ShopifyTheme> UpdateAsync(ShopifyTheme theme)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{theme.Id.Value}.json", Method.PUT, "theme");
 
@@ -102,7 +102,7 @@ namespace ShopifySharp
         /// Deletes a Theme with the given Id.
         /// </summary>
         /// <param name="themeId">The Theme object's Id.</param>
-        public async Task DeleteAsync(long themeId)
+        public virtual async Task DeleteAsync(long themeId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"themes/{themeId}.json", Method.DELETE);
 

--- a/ShopifySharp/Services/Transaction/ShopifyTransactionService.cs
+++ b/ShopifySharp/Services/Transaction/ShopifyTransactionService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <returns>The count of all fulfillments for the shop.</returns>
-        public async Task<int> CountAsync(long orderId)
+        public virtual async Task<int> CountAsync(long orderId)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/transactions/count.json", Method.GET);
             var responseObject = await RequestEngine.ExecuteRequestAsync(_RestClient, req);
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="sinceId">Filters the results to after the specified id.</param>
         /// <returns>The list of transactions.</returns>
-        public async Task<IEnumerable<ShopifyTransaction>> ListAsync(long orderId, long? sinceId = null)
+        public virtual async Task<IEnumerable<ShopifyTransaction>> ListAsync(long orderId, long? sinceId = null)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/transactions.json", Method.GET, "transactions");
 
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <param name="transactionId">The id of the Transaction to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyTransaction"/>.</returns>
-        public async Task<ShopifyTransaction> GetAsync(long orderId, long transactionId, string fields = null)
+        public virtual async Task<ShopifyTransaction> GetAsync(long orderId, long transactionId, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/transactions/{transactionId}.json", Method.GET, "transaction");
 
@@ -80,7 +80,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="transaction">The transaction.</param>
         /// <returns>The new <see cref="ShopifyTransaction"/>.</returns>
-        public async Task<ShopifyTransaction> CreateAsync(long orderId, ShopifyTransaction transaction)
+        public virtual async Task<ShopifyTransaction> CreateAsync(long orderId, ShopifyTransaction transaction)
         {
             var req = RequestEngine.CreateRequest($"orders/{orderId}/transactions.json", Method.POST, "transaction");
 

--- a/ShopifySharp/Services/UsageCharge/ShopifyUsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/ShopifyUsageChargeService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="description">The name or description of the usage charge.</param>
         /// <param name="price">The price of the usage charge.</param>
         /// <returns>The new <see cref="ShopifyUsageCharge"/>.</returns>
-        public async Task<ShopifyUsageCharge> CreateAsync(long recurringChargeId, string description, double price)
+        public virtual async Task<ShopifyUsageCharge> CreateAsync(long recurringChargeId, string description, double price)
         {
             var req = RequestEngine.CreateRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json", Method.POST, "usage_charge");
             
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyUsageCharge"/>.</returns>
-        public async Task<ShopifyUsageCharge> GetAsync(long recurringChargeId, long id, string fields = null)
+        public virtual async Task<ShopifyUsageCharge> GetAsync(long recurringChargeId, long id, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"recurring_application_charges/{recurringChargeId}/usage_charges/{id}.json", Method.GET, "usage_charge");
 
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// <param name="recurringChargeId">The id of the recurring charge that these usage charges belong to.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The list of <see cref="ShopifyUsageCharge"/> objects.</returns>
-        public async Task<IEnumerable<ShopifyUsageCharge>> ListAsync(long recurringChargeId, string fields = null)
+        public virtual async Task<IEnumerable<ShopifyUsageCharge>> ListAsync(long recurringChargeId, string fields = null)
         {
             var req = RequestEngine.CreateRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json", Method.GET, "usage_charges");
 

--- a/ShopifySharp/Services/Webhook/ShopifyWebhookService.cs
+++ b/ShopifySharp/Services/Webhook/ShopifyWebhookService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <param name="address">An optional filter for the address property. When used, this method will only count webhooks with the given address.</param>
         /// <param name="topic">An optional filter for the topic property. When used, this method will only count webhooks with the given topic. A full list of topics can be found at https://help.shopify.com/api/reference/webhook. </param>
         /// <returns>The count of all webhooks for the shop.</returns>
-        public async Task<int> CountAsync(string address = null, string topic = null)
+        public virtual async Task<int> CountAsync(string address = null, string topic = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("webhooks/count.json", Method.GET);
 
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
         /// <returns>The list of webhooks matching the filter.</returns>
-        public async Task<IEnumerable<ShopifyWebhook>> ListAsync(ShopifyWebhookFilter filter = null)
+        public virtual async Task<IEnumerable<ShopifyWebhook>> ListAsync(ShopifyWebhookFilter filter = null)
         {
             IRestRequest req = RequestEngine.CreateRequest("webhooks.json", Method.GET, "webhooks");
 
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <param name="webhookId">The id of the webhook to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ShopifyWebhook"/>.</returns>
-        public async Task<ShopifyWebhook> GetAsync(long webhookId, string fields = null)
+        public virtual async Task<ShopifyWebhook> GetAsync(long webhookId, string fields = null)
         {
             IRestRequest req = RequestEngine.CreateRequest($"webhooks/{webhookId}.json", Method.GET, "webhook");
 
@@ -86,7 +86,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="webhook">A new <see cref="ShopifyWebhook"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="ShopifyWebhook"/>.</returns>
-        public async Task<ShopifyWebhook> CreateAsync(ShopifyWebhook webhook)
+        public virtual async Task<ShopifyWebhook> CreateAsync(ShopifyWebhook webhook)
         {
             IRestRequest req = RequestEngine.CreateRequest("webhooks.json", Method.POST, "webhook");
 
@@ -101,7 +101,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="webhook">The <see cref="ShopifyWebhook"/> to update.</param>
         /// <returns>The updated <see cref="ShopifyWebhook"/>.</returns>
-        public async Task<ShopifyWebhook> UpdateAsync(ShopifyWebhook webhook)
+        public virtual async Task<ShopifyWebhook> UpdateAsync(ShopifyWebhook webhook)
         {
             IRestRequest req = RequestEngine.CreateRequest($"webhooks/{webhook.Id.Value}.json", Method.PUT, "webhook");
 
@@ -114,7 +114,7 @@ namespace ShopifySharp
         /// Deletes the webhook with the given Id.
         /// </summary>
         /// <param name="webhookId">The order object's Id.</param>
-        public async Task DeleteAsync(long webhookId)
+        public virtual async Task DeleteAsync(long webhookId)
         {
             IRestRequest req = RequestEngine.CreateRequest($"webhooks/{webhookId}.json", Method.DELETE);
 


### PR DESCRIPTION
I was originally going to submit an issue for this but figured I'd
implement the changes and see what you think @nozzlegear.

This will allow developers to easily write unit tests for code that
is dependent on these service classes without having to define
their own test seams and/or wrapper classes. Other usages could
include using dynamic proxies for logging/automated retries/ect...

I figured this was the safest, easiest, most low-risk solution, and initial
inspection of the service classes did not reveal any potential technical
risks associated with overriding one method vs another, as these methods,
at least from the spot-checking I did, don't have inter-dependencies.

As always, I'm open to any and all comments/criticisms and other potential
solutions :)
### Commit Summary
#### Update service methods to virtual
>This change updates all public methods of the shopify rest service
classes to have the virtual modifier. This change will allow easier
unit testing by enabling dynamic proxies to work easily with these
types.
