### PR TITLE
IRequestExecutionPolicy interface

### DIFF
--- a/ShopifySharp.Tests/ShopifyException Tests/When_reaching_the_rate_limit_with_retry_policy.cs
+++ b/ShopifySharp.Tests/ShopifyException Tests/When_reaching_the_rate_limit_with_retry_policy.cs
@@ -1,0 +1,46 @@
+﻿using Machine.Specifications;
+using ShopifySharp.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp.Tests.ShopifyException_Tests
+{
+    [Subject(typeof(ShopifyRateLimitException))]
+    class When_reaching_the_rate_limit_with_retry_policy
+    {
+        Establish context = () =>
+        {
+            RequestEngine.SetExecutionPolicy(new RetryExecutionPolicy());
+        };
+
+        Because of = () =>
+        {
+            try
+            {
+                // Reach the rate limit of 40 requests per second
+                var tasks = Enumerable.Range(0, 100)
+                                      .Select(_ => Service.ListAsync(new ShopifyEventListFilter { Limit = 1 }));
+                var result = Task.WhenAll(tasks).Await().AsTask.Result;
+            }
+            catch (Exception e)
+            {
+                Ex = e;
+            }
+        };
+
+        It should_not_throw_a_rate_limit_exception = () =>
+        {
+            Ex.ShouldBeNull();
+        };
+
+        Cleanup after = () =>
+        {
+        };
+
+        static ShopifyEventService Service = new ShopifyEventService(Utils.MyShopifyUrl, Utils.AccessToken);
+        static Exception Ex;
+    }
+}

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="ShopifyEventService Tests\When_counting_events.cs" />
     <Compile Include="ShopifyEventService Tests\When_listing_events_for_a_subject_type.cs" />
     <Compile Include="ShopifyException Tests\ShopifyExceptionService.cs" />
+    <Compile Include="ShopifyException Tests\When_reaching_the_rate_limit_with_retry_policy.cs" />
     <Compile Include="ShopifyException Tests\When_reaching_the_rate_limit.cs" />
     <Compile Include="ShopifyException Tests\When_receiving_an_error_array.cs" />
     <Compile Include="ShopifyException Tests\When_receiving_an_error_object.cs" />

--- a/ShopifySharp/Infrastructure/Policies/DefaultRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/DefaultRequestExecutionPolicy.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public class DefaultRequestExecutionPolicy : IRequestExecutionPolicy
+    {
+        public async Task<T> Run<T>(ExecuteRequestAsync<T> executeRequestAsync)
+        {
+            return (await executeRequestAsync()).Result;
+        }
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    public delegate Task<RequestResult<T>> ExecuteRequestAsync<T>();
+
+    /// <summary>
+    /// Used to specify centralized logic that should run when executing shopify requests.
+    /// It is most useful to implement retry logic, but it can also be used for other concerns (i.e. tracing)
+    /// </summary>
+    public interface IRequestExecutionPolicy
+    {
+        Task<T> Run<T>(ExecuteRequestAsync<T> executeRequestAsync);
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// See https://help.shopify.com/api/guides/api-call-limit
+    /// </summary>
+    public class RetryExecutionPolicy : IRequestExecutionPolicy
+    {
+        private static readonly TimeSpan RETRY_DELAY = TimeSpan.FromMilliseconds(500);
+
+        public async Task<T> Run<T>(ExecuteRequestAsync<T> executeRequestAsync)
+        {
+            Start:
+            try
+            {
+                return (await executeRequestAsync()).Result;
+            }
+            catch (ShopifyRateLimitException)
+            {
+                await Task.Delay(RETRY_DELAY);
+                goto Start;
+            }
+        }
+    }
+}

--- a/ShopifySharp/Infrastructure/RequestEngine.cs
+++ b/ShopifySharp/Infrastructure/RequestEngine.cs
@@ -13,6 +13,13 @@ namespace ShopifySharp
 {
     public static class RequestEngine
     {
+        private static IRequestExecutionPolicy _executionPolicy = new DefaultRequestExecutionPolicy();
+
+        public static void SetExecutionPolicy(IRequestExecutionPolicy executionPolicy)
+        {
+            _executionPolicy = executionPolicy;
+        }
+
         /// <summary>
         /// Attempts to build a shop API <see cref="Uri"/> for the given shop.
         /// </summary>
@@ -96,18 +103,22 @@ namespace ShopifySharp
         /// <returns>The <see cref="JToken"/> to be queried.</returns>
         public static async Task<JToken> ExecuteRequestAsync(RestClient client, IRestRequest request)
         {
-            //Make request
-            IRestResponse response = await client.ExecuteTaskAsync(request);
+            return await _executionPolicy.Run(async () =>
+            {
+                //Make request
+                IRestResponse response = await client.ExecuteTaskAsync(request);
 
-            //Check for and throw exception when necessary.
-            CheckResponseExceptions(response);
+                //Check for and throw exception when necessary.
+                CheckResponseExceptions(response);
 
-            //Get the raw response string
-            string respString = Encoding.UTF8.GetString(response.RawBytes);
+                //Get the raw response string
+                string respString = Encoding.UTF8.GetString(response.RawBytes);
 
-            //Parse the string if it exists, else parse an empty object. The empty object is expected when
-            //Shopify returns a 0-byte body in it's response (e.g. when deleting a charge). 
-            return JToken.Parse(string.IsNullOrEmpty(respString) ? "{}" : respString);
+                //Parse the string if it exists, else parse an empty object. The empty object is expected when
+                //Shopify returns a 0-byte body in it's response (e.g. when deleting a charge). 
+                var result = JToken.Parse(string.IsNullOrEmpty(respString) ? "{}" : respString);
+                return new RequestResult<JToken>(request, response, result);
+            });
         }
 
         /// <summary>
@@ -119,13 +130,17 @@ namespace ShopifySharp
         /// <returns>The data.</returns>
         public static async Task<T> ExecuteRequestAsync<T>(RestClient client, IRestRequest request) where T : new()
         {
-            //Make request
-            IRestResponse<T> response = await client.ExecuteTaskAsync<T>(request);
+            return await _executionPolicy.Run(async () =>
+            {
+                //Make request
+                IRestResponse<T> response = await client.ExecuteTaskAsync<T>(request);
 
-            //Check for and throw exception when necessary.
-            CheckResponseExceptions(response);
+                //Check for and throw exception when necessary.
+                CheckResponseExceptions(response);
 
-            return response.Data;
+                var result = response.Data;
+                return new RequestResult<T>(request, response, result);
+            });
         }
 
         /// <summary>

--- a/ShopifySharp/Infrastructure/RequestResult.cs
+++ b/ShopifySharp/Infrastructure/RequestResult.cs
@@ -1,0 +1,18 @@
+﻿using RestSharp;
+
+namespace ShopifySharp
+{
+    public class RequestResult<T>
+    {
+        public IRestRequest Request { get; }
+        public IRestResponse Response { get; }
+        public T Result { get; }
+
+        public RequestResult(IRestRequest request, IRestResponse response, T result)
+        {
+            this.Request = request;
+            this.Response = response;
+            this.Result = result;
+        }
+    }
+}

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -99,6 +99,10 @@
     <Compile Include="Filters\ShopifyPublishableCountFilter.cs" />
     <Compile Include="Filters\ShopifySmartCollectionFilter.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Infrastructure\Policies\IRequestExecutionPolicy.cs" />
+    <Compile Include="Infrastructure\Policies\RetryExecutionPolicy.cs" />
+    <Compile Include="Infrastructure\Policies\DefaultRequestExecutionPolicy.cs" />
+    <Compile Include="Infrastructure\RequestResult.cs" />
     <Compile Include="Infrastructure\ShopifyRateLimitException.cs" />
     <Compile Include="Serializers\JsonNetSerializer.cs" />
     <Compile Include="Entities\ShopifyAddress.cs" />


### PR DESCRIPTION
Introduced IRequestExecutionPolicy interface to specify centralized logic that should run when executing shopify requests.