### PR TITLE
Fixed json property typo for ShopifyShop.DisplayPlanName

### DIFF
--- a/ShopifySharp/Entities/ShopifyShop.cs
+++ b/ShopifySharp/Entities/ShopifyShop.cs
@@ -138,7 +138,7 @@ namespace ShopifySharp
         /// <summary>
         /// The display name of the Shopify plan the shop is on.
         /// </summary>
-        [JsonProperty("display_plan_name")]
+        [JsonProperty("plan_display_name")]
         public string DisplayPlanName { get; set; }
 
         /// <summary>


### PR DESCRIPTION
I didn't rename the property itself because it would be a breaking change.
Maybe in v4?