### PR TITLE
Added the Dictionary and Raw Query String Abilities to IsAuthenticProxyRequest

### DIFF
--- a/ShopifySharp.Tests/Authorization_Tests.cs
+++ b/ShopifySharp.Tests/Authorization_Tests.cs
@@ -28,6 +28,34 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
+        public void Validates_Proxy_Requests_With_Dictionary_QueryString()
+        {
+            //Configure querystring
+            var qs = new Dictionary<string, string>()
+            {
+                {"shop", "stages-test-shop-2.myshopify.com"},
+                {"path_prefix", "/apps/stages-order-tracker"},
+                {"timestamp", "1459781841"},
+                {"signature", "239813a42e1164a9f52e85b2119b752774fafb26d0f730359c86572e1791854a"},
+            };
+
+            bool isValid = AuthorizationService.IsAuthenticProxyRequest(qs, Utils.SecretKey);
+
+            Assert.True(isValid);
+        }
+
+        [Fact]
+        public void Validates_Proxy_Requests_With_Raw_QueryString()
+        {
+            //Configure querystring
+            var qs = "shop=stages-test-shop-2.myshopify.com&path_prefix=/apps/stages-order-tracker&timestamp=1459781841&signature=239813a42e1164a9f52e85b2119b752774fafb26d0f730359c86572e1791854a";         
+
+            bool isValid = AuthorizationService.IsAuthenticProxyRequest(qs, Utils.SecretKey);
+
+            Assert.True(isValid);
+        }
+
+        [Fact]
         public void Validates_Web_Requests()
         {
             var qs = new Dictionary<string, StringValues>()

--- a/ShopifySharp/Services/Authorization/AuthorizationService.cs
+++ b/ShopifySharp/Services/Authorization/AuthorizationService.cs
@@ -166,6 +166,32 @@ namespace ShopifySharp
         }
 
         /// <summary>
+        /// Determines if an incoming proxy page request is authentic. Conceptually similar to <see cref="IsAuthenticRequest(NameValueCollection, string)"/>,
+        /// except that proxy requests use HMACSHA256 rather than MD5.
+        /// </summary>
+        /// <param name="querystring">A dictionary containing the keys and values from the request's querystring.</param>
+        /// <param name="shopifySecretKey">Your app's secret key.</param>
+        /// <returns>A boolean indicating whether the request is authentic or not.</returns>
+        public static bool IsAuthenticProxyRequest(IDictionary<string, string> querystring, string shopifySecretKey)
+        {
+            var qs = querystring.Select(kvp => new KeyValuePair<string, StringValues>(kvp.Key, kvp.Value));
+
+            return IsAuthenticProxyRequest(qs, shopifySecretKey);
+        }
+
+        /// <summary>
+        /// Determines if an incoming proxy page request is authentic. Conceptually similar to <see cref="IsAuthenticRequest(NameValueCollection, string)"/>,
+        /// except that proxy requests use HMACSHA256 rather than MD5.
+        /// </summary>
+        /// <param name="querystring">The request's raw querystring.</param>
+        /// <param name="shopifySecretKey">Your app's secret key.</param>
+        /// <returns>A boolean indicating whether the request is authentic or not.</returns>
+        public static bool IsAuthenticProxyRequest(string querystring, string shopifySecretKey)
+        {
+            return IsAuthenticProxyRequest(ParseRawQuerystring(querystring), shopifySecretKey);
+        }
+
+        /// <summary>
         /// Determines if an incoming webhook request is authentic.
         /// </summary>
         /// <param name="requestHeaders">The request's headers. Hint: use Request.Headers if you're calling this from an ASP.NET MVC controller.</param>


### PR DESCRIPTION
Mostly so I can stop writing AuthorizationService.IsAuthenticProxyRequest(AuthorizationService.ParseRawQuerystring(queryString).Select(kvp => new KeyValuePair<string, StringValues>(kvp.Key, kvp.Value)), skey);