### PR TITLE
Proposal: GraphExtensions

### DIFF
--- a/ShopifySharp/Entities/GraphKeyValuePair.cs
+++ b/ShopifySharp/Entities/GraphKeyValuePair.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp
+{
+    public class GraphKeyValuePair
+    {
+        /// <summary>
+        /// In the format gid://...
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Will be the most important value for whatever you are calling, i.e. the metafield value in a metafield call.
+        /// </summary>
+        public object Value { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/GraphMutationResponse.cs
+++ b/ShopifySharp/Entities/GraphMutationResponse.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp
+{
+    public class GraphMutationResponse
+    {
+        /// <summary>
+        /// List of returned values with the mutation call.
+        /// </summary>
+        public IEnumerable<GraphKeyValuePair> Values { get; set; }
+
+        /// <summary>
+        /// List of errors returned by the mutation call. Will be an empty list if none.
+        /// </summary>
+        public IEnumerable<GraphUserError> UserErrors { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/GraphUserError.cs
+++ b/ShopifySharp/Entities/GraphUserError.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp
+{
+    public class GraphUserError
+    {
+        /// <summary>
+        /// The field associated with the error.
+        /// </summary>
+        [JsonProperty("field")]
+        public string Field { get; set; }
+
+        /// <summary>
+        /// The error message.
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+}

--- a/ShopifySharp/Extensions/GraphExtensions/Mutations/InventoryAdjustQuantity.cs
+++ b/ShopifySharp/Extensions/GraphExtensions/Mutations/InventoryAdjustQuantity.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace ShopifySharp
+{
+    public static partial class GraphExtensions
+    {
+        /// <summary>
+        /// Adjust inventory quantity for a single Inventory Level item.
+        /// </summary>
+        /// <param name="graphService">The GraphService.</param>
+        /// <param name="graphInventoryLevelId">The ID for the inventory level item, in format: gid://shopify/InventoryLevel/11111?inventory_item_id=11111</param>
+        /// <param name="availableDelta">The amount to adjust inventory by, may be positive or negative.</param>
+        /// <returns>The data object including the new quantity</returns>
+        public static async Task<GraphMutationResponse> InventoryAdjustQuantityAsync(this GraphService graphService, string graphInventoryLevelId, int availableDelta)
+        {
+            string body = @"
+                mutation {
+                  inventoryAdjustQuantity(input: {
+                inventoryLevelId: """ + graphInventoryLevelId + @""",
+                        availableDelta: " + availableDelta + @"
+                  }) {
+                    userErrors {field, message
+                    },
+                    inventoryLevel { available
+                }
+                  }  
+                }
+                ";            
+
+            JToken response = await graphService.PostAsync(body);
+
+            GraphMutationResponse mutationResponse = new GraphMutationResponse();
+            GraphKeyValuePair valuePair = new GraphKeyValuePair();
+
+            valuePair.Id = graphInventoryLevelId;
+            valuePair.Value = (int?)response.SelectToken("inventoryAdjustQuantity.inventoryLevel.available");
+            mutationResponse.Values = new List<GraphKeyValuePair> { valuePair };
+
+            mutationResponse.UserErrors = new List<GraphUserError>();
+            JArray userErrors = (JArray)response.SelectToken("inventoryAdjustQuantity.userErrors");
+
+            if (userErrors.Count > 0)
+            {
+                mutationResponse.UserErrors = userErrors.ToObject<IEnumerable<GraphUserError>>();
+            }
+
+            return mutationResponse;
+        }
+    }
+}

--- a/ShopifySharp/Extensions/GraphExtensions/Queries/InventoryQuantity.cs
+++ b/ShopifySharp/Extensions/GraphExtensions/Queries/InventoryQuantity.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace ShopifySharp
+{
+    public static partial class GraphExtensions
+    {
+        public static async Task<GraphKeyValuePair> InventoryQuantityGetAsync(this GraphService graphService, long variantId, long locationId)
+        {
+            string body = @"
+                query {
+                  productVariant (id: ""gid://shopify/ProductVariant/" + variantId + @""" ) {
+                            inventoryItem {
+                                inventoryLevel(locationId: ""gid://shopify/Location/" + locationId + @""") {     
+                        id,
+                        available
+                               }
+                            }
+                        }
+                    }";
+
+            JToken response = await graphService.PostAsync(body);
+
+            GraphKeyValuePair inventory = new GraphKeyValuePair();
+
+            if (response["productVariant"] != null)
+            {
+                if (response["productVariant"]["inventoryItem"] != null)
+                {
+                    if (response["productVariant"]["inventoryItem"]["inventoryLevel"] != null)
+                    {
+                        inventory.Value = (int?)response.SelectToken("productVariant.inventoryItem.inventoryLevel.available");
+                        inventory.Id = (string)response.SelectToken("productVariant.inventoryItem.inventoryLevel.id");
+                    }
+                }
+            }
+
+            return inventory;
+        }
+    }
+}

--- a/ShopifySharp/Extensions/GraphExtensions/Queries/InventoryQuantity.cs
+++ b/ShopifySharp/Extensions/GraphExtensions/Queries/InventoryQuantity.cs
@@ -8,6 +8,13 @@ namespace ShopifySharp
 {
     public static partial class GraphExtensions
     {
+        /// <summary>
+        /// Get a single inventory quantity for a variant/location combination.
+        /// </summary>
+        /// <param name="graphService">The GraphService</param>
+        /// <param name="variantId">The normal (long) variant ID.</param>
+        /// <param name="locationId">The normal (long) location ID.</param>
+        /// <returns>The Graph Inventory Level ID and the integer inventory value.</returns>
         public static async Task<GraphKeyValuePair> InventoryQuantityGetAsync(this GraphService graphService, long variantId, long locationId)
         {
             string body = @"

--- a/ShopifySharp/Extensions/GraphExtensions/Queries/InventoryQuantity.cs
+++ b/ShopifySharp/Extensions/GraphExtensions/Queries/InventoryQuantity.cs
@@ -25,18 +25,9 @@ namespace ShopifySharp
             JToken response = await graphService.PostAsync(body);
 
             GraphKeyValuePair inventory = new GraphKeyValuePair();
-
-            if (response["productVariant"] != null)
-            {
-                if (response["productVariant"]["inventoryItem"] != null)
-                {
-                    if (response["productVariant"]["inventoryItem"]["inventoryLevel"] != null)
-                    {
-                        inventory.Value = (int?)response.SelectToken("productVariant.inventoryItem.inventoryLevel.available");
-                        inventory.Id = (string)response.SelectToken("productVariant.inventoryItem.inventoryLevel.id");
-                    }
-                }
-            }
+            
+            inventory.Value = (int?)response.SelectToken("productVariant.inventoryItem.inventoryLevel.available");
+            inventory.Id = (string)response.SelectToken("productVariant.inventoryItem.inventoryLevel.id");              
 
             return inventory;
         }

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -1,0 +1,71 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Net.Http;
+using ShopifySharp.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// A service for using or manipulating Shopify's Graph API.
+    /// </summary>
+    public class GraphService : ShopifyService
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="GraphService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public GraphService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }        
+
+        /// <summary>
+        /// Executes a Graph API Call.
+        /// </summary>
+        /// <param name="body">The query you would like to execute. Please see documentation for formatting.</param>
+        /// <returns>A JToken containing the data from the request.</returns>
+        public virtual async Task<JToken> PostAsync(string body)
+        {
+            var req = PrepareRequest("api/graphql.json"); 
+
+            var content = new StringContent(body, Encoding.UTF8, "application/graphql");
+
+            JToken response = await ExecuteRequestAsync(req, HttpMethod.Post, content);
+
+            await CheckForErrorsAsync(response);
+
+            return response["data"];
+        }
+
+        /// <summary>
+        /// Since Graph API Errors come back with error code 200, checking for them in a way similar to the REST API doesn't work well without potentially throwing unnecessary errors. This loses the requestId, but otherwise is capable of passing along the message.
+        /// </summary>
+        /// <param name="response">The JToken response from ExecuteRequestAsync.</param>
+        /// <returns>Task.</returns>
+        private async Task CheckForErrorsAsync(JToken response)
+        {
+            if (response["errors"] != null)
+            {
+                var errorList = new List<string>();
+                foreach (var error in response["errors"])
+                {
+                    errorList.Add(error["message"].ToString());
+                }
+
+                var message = response["errors"].FirstOrDefault()["message"].ToString();
+
+                var errors = new Dictionary<string, IEnumerable<string>>()
+                {
+                    {"Error", errorList}
+                };
+
+                throw new ShopifyException(HttpStatusCode.OK, errors, message, JsonConvert.SerializeObject(response), "");
+            }
+        }
+    }
+}

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard1.4;net45</TargetFrameworks>
     <AssemblyName>ShopifySharp</AssemblyName>
     <RootNamespace>ShopifySharp</RootNamespace>
     <Version>4.16.4</Version>


### PR DESCRIPTION
Since the Graph API is a lot more flexible on how it responds, and the possible permutations on what people may do is vast, the simple implementation and flexible response was the right way to start.

But, there are some very powerful and likely to be common uses of the Graph API that I feel warrant their own extension methods.

The format for these, and exactly how to implement them is definitely debatable, but here is an example of how I implemented Inventory calls for one of my apps.  Very open to recommendations, but these two methods and 3 entities are tested as working and are about to head into production.