### PR TITLE
Add read_all_orders oAuth scope

### DIFF
--- a/ShopifySharp/Enums/ShopifyAuthorizationScope.cs
+++ b/ShopifySharp/Enums/ShopifyAuthorizationScope.cs
@@ -31,6 +31,9 @@ namespace ShopifySharp.Enums
         [EnumMember(Value = "write_customers")]
         WriteCustomers,
 
+        [EnumMember(Value = "read_all_orders")]
+        ReadAllOrders,
+
         [EnumMember(Value = "read_orders")]
         ReadOrders,
 


### PR DESCRIPTION
There is a new oAuth scope: **read_all_orders**.

The documentation: [Shopify oAuth Scopes](https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes).

In order to use the scope, the developer must ask for permission for each app on the Shopify Developer Portal. 

The documentation says:
> read_all_orders
> Grants access to all orders rather than the default window of 60 days worth of orders. This OAuth scope is used in conjunction with read_orders, or write_orders. You need to request this scope from your Partner Dashboard before adding it to your app.

Could you please add this change to **ShopifySharp v3** and v4.