### PR TITLE
Add support to AdjustInventoryLevel in InventoryLevelService

### DIFF
--- a/ShopifySharp.Tests/InventoryLevel_Tests.cs
+++ b/ShopifySharp.Tests/InventoryLevel_Tests.cs
@@ -53,6 +53,32 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
+        public async Task Adjust_InventoryLevel()
+        {
+            var availableAdjustment = 1;
+            var invLevel = (await Fixture.Service.ListAsync(new InventoryLevelFilter
+            {
+                InventoryItemIds = new long[] { Fixture.InventoryItemId }
+            })).First();
+
+            var adjustInventoryLevel = new InventoryLevelAdjust()
+            {
+                AvailableAdjustment = availableAdjustment,
+                InventoryItemId = invLevel.InventoryItemId,
+                LocationId = invLevel.LocationId
+            };
+
+            int newQty, currQty;
+            currQty = invLevel.Available ?? 0;
+            newQty = currQty + availableAdjustment;
+
+            var updated = await Fixture.Service.AdjustAsync(adjustInventoryLevel);
+
+            Assert.Equal(newQty, updated.Available);
+            Assert.NotEqual(currQty, updated.Available);
+        }
+
+        [Fact]
         public async Task Deletes_InventoryLevel()
         {
             var currentInvLevel = (await Fixture.Service.ListAsync(new InventoryLevelFilter { InventoryItemIds = new[] { Fixture.InventoryItemId } })).First();

--- a/ShopifySharp/Entities/InventoryLevelAdjust.cs
+++ b/ShopifySharp/Entities/InventoryLevelAdjust.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ShopifySharp.Enums;
+using ShopifySharp.Converters;
+
+namespace ShopifySharp
+{
+    public class InventoryLevelAdjust
+    {
+        /// <summary>
+        /// The unique identifier of the inventory item that the inventory level belongs to.
+        /// </summary>
+        [JsonProperty("inventory_item_id")]
+        public long? InventoryItemId { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the location that the inventory level belongs to.
+        /// </summary>
+        [JsonProperty("location_id")]
+        public long? LocationId { get; set; }
+
+        /// <summary>
+        /// The quantity adjust of inventory items.
+        /// </summary>
+        [JsonProperty("available_adjustment")]
+        public int? AvailableAdjustment { get; set; }
+    }
+}

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -60,6 +60,19 @@ namespace ShopifySharp
         }
 
         /// <summary>
+        /// Adjusts the given <see cref="InventoryLevel"/>.
+        /// </summary>
+        /// <param name="updatedInventoryLevel">The updated <see cref="InventoryLevel"/></param>
+        /// <returns>The updated <see cref="InventoryLevel"/></returns>
+        public virtual async Task<InventoryLevel> AdjustAsync(InventoryLevelAdjust adjustInventoryLevel)
+        {
+            var req = PrepareRequest($"inventory_levels/adjust.json");
+            var body = adjustInventoryLevel.ToDictionary();
+            JsonContent content = new JsonContent(body);
+            return await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level");
+        }
+
+        /// <summary>
         /// Connect an inventory item to a location
         /// </summary>
         /// <param name="inventoryItemId">The ID of the inventory item</param>


### PR DESCRIPTION
There is no support for the adjust.json endpoint within inventory_levels: https://help.shopify.com/en/api/reference/inventory/inventorylevel#adjust . This PR is to give support for that endpoint.