### PR TITLE
Shopify payments service + multi currency properties

### DIFF
--- a/ShopifySharp.Tests/ShopifyPayments_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyPayments_Tests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using EmptyAssert = ShopifySharp.Tests.Extensions.EmptyExtensions;
+
+namespace ShopifySharp.Tests
+{
+
+    /// <remarks>
+    /// For the tests below to pass, the required permissions must be granted AND Shopify payments must be set as a payment provider in the store's settings
+    /// </remarks>
+    [Trait("Category", "Shopify payments")]
+    public class ShopifyPayments_Tests
+    {
+        private ShopifyPaymentsService _Service { get; } = new ShopifyPaymentsService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+        [Fact]
+        public async Task GetBalance()
+        {
+            var balances = await _Service.GetBalanceAsync();
+            Assert.NotNull(balances);
+        }
+
+        [Fact]
+        public async Task GetPayouts()
+        {
+            var payouts = await _Service.ListPayoutsAsync();
+            Assert.NotNull(payouts);
+        }
+
+        [Fact]
+        public async Task GetDisputes()
+        {
+            var disputes = await _Service.ListDisputesAsync();
+            Assert.NotNull(disputes);
+        }
+
+        [Fact]
+        public async Task GetTransactions()
+        {
+            var transactions = await _Service.ListTransactionsAsync();
+            Assert.NotNull(transactions);
+        }
+    }
+}

--- a/ShopifySharp/Entities/Customer.cs
+++ b/ShopifySharp/Entities/Customer.cs
@@ -28,6 +28,12 @@ namespace ShopifySharp
         public DateTimeOffset? CreatedAt { get; set; }
 
         /// <summary>
+        /// Currency used for customer's last order
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
         /// The default address for the customer.
         /// </summary>
         [JsonProperty("default_address")]

--- a/ShopifySharp/Entities/Shop.cs
+++ b/ShopifySharp/Entities/Shop.cs
@@ -76,6 +76,12 @@ namespace ShopifySharp
         public string Email { get; set; }
 
         /// <summary>
+        /// Enabled currencies
+        /// </summary>
+        [JsonProperty("enabled_presentment_currencies")]
+        public string[] EnabledPresentmentCurrencies { get; set; }
+
+        /// <summary>
         /// Indicates whether the shop forces requests made to its resources to be made over SSL, using the HTTPS protocol. If true, HTTP requests will be redirected to HTTPS.
         /// </summary>
         [JsonProperty("force_ssl")]

--- a/ShopifySharp/Entities/ShopifyPaymentsBalance.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsBalance.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify payments balance.
+    /// </summary>
+    public class ShopifyPaymentsBalance
+    {
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("amount")]
+        public decimal? Amount { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDispute.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDispute.cs
@@ -1,0 +1,43 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify payments dispute.
+    /// </summary>
+    public class ShopifyPaymentsDispute : ShopifyObject
+    {
+        [JsonProperty("order_id")]
+        public long? OrderId { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("amount")]
+        public decimal? Amount { get; set; }
+
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        [JsonProperty("network_reason_code")]
+        public string NetworkReasonCcode { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("evidence_due_by")]
+        public DateTimeOffset? EvidenceDueBy { get; set; }
+
+        [JsonProperty("evidence_sent_on")]
+        public DateTimeOffset? EvidenceSentOn { get; set; }
+
+        [JsonProperty("finalized_on")]
+        public DateTimeOffset? FinalizedOn { get; set; }
+
+
+    }
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsPayout.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsPayout.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify payments payout.
+    /// </summary>
+    public class ShopifyPaymentsPayout : ShopifyObject
+    {
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("amount")]
+        public decimal? Amount { get; set; }
+
+        [JsonProperty("summary")]
+        public ShopifyPaymentsPayoutSummary Summary { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsPayoutSummary.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsPayoutSummary.cs
@@ -1,0 +1,41 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify payments payout summary.
+    /// </summary>
+    public class ShopifyPaymentsPayoutSummary
+    {
+        [JsonProperty("adjustments_fee_amount")]
+        public decimal? AdjustmentsFeeAmount { get; set; }
+
+        [JsonProperty("adjustments_gross_amount")]
+        public decimal? AdjustmentsGrossAmount { get; set; }
+
+        [JsonProperty("charges_fee_amount")]
+        public decimal? ChargesFeeAmount { get; set; }
+
+        [JsonProperty("charges_gross_amount")]
+        public decimal? ChargesGrossAmount { get; set; }
+
+        [JsonProperty("refunds_fee_amount")]
+        public decimal? RefundsFeeAmount { get; set; }
+
+        [JsonProperty("refunds_gross_amount")]
+        public decimal? RefundsGrossAmount { get; set; }
+
+        [JsonProperty("reserved_funds_fee_amount")]
+        public decimal? ReservedFundsFeeAmount { get; set; }
+
+        [JsonProperty("reserved_funds_gross_amount")]
+        public decimal? ReservedFundsGrossAmount { get; set; }
+
+        [JsonProperty("retried_payouts_fee_amount")]
+        public decimal? RetriedPayoutsFeeAmount { get; set; }
+
+        [JsonProperty("retried_payouts_gross_amount")]
+        public decimal? RetriedPayoutsGrossAmount { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsTransaction.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsTransaction.cs
@@ -1,0 +1,52 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify payments transction.
+    /// </summary>
+    public class ShopifyPaymentsTransaction : ShopifyObject
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("test")]
+        public bool Test { get; set; }
+
+        [JsonProperty("payout_id")]
+        public long? PayoutId { get; set; }
+
+        [JsonProperty("payout_status")]
+        public string PayoutStatus { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("amount")]
+        public decimal? Amount { get; set; }
+
+        [JsonProperty("fee")]
+        public decimal? Fee { get; set; }
+
+        [JsonProperty("net")]
+        public decimal? Net { get; set; }
+
+        [JsonProperty("source_id")]
+        public long? SourceId { get; set; }
+
+        [JsonProperty("source_type")]
+        public string SourceType { get; set; }
+
+        [JsonProperty("source_order_transaction_id")]
+        public long? SourceOrderTransactionId { get; set; }
+
+        [JsonProperty("source_order_id")]
+        public long? SourceOrderId { get; set; }
+
+        [JsonProperty("processed_at")]
+        public DateTimeOffset? ProcessedAt { get; set; }
+
+
+    }
+}

--- a/ShopifySharp/Filters/ShopifyPaymentsDisputeFilter.cs
+++ b/ShopifySharp/Filters/ShopifyPaymentsDisputeFilter.cs
@@ -1,0 +1,32 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp.Filters 
+{
+    public class ShopifyPaymentsDisputeFilter : Parameterizable 
+    {
+        /// <summary>
+        /// Return only disputes after the specified ID.
+        /// </summary>
+        [JsonProperty("since_id")]
+        public long? SinceId { get; set; }
+
+        /// <summary>
+        /// Return only disputes before the specified ID.
+        /// </summary>
+        [JsonProperty("last_id")]
+        public long? LastId { get; set; }
+
+        /// <summary>
+        /// Return only disputes with the specified status.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Return only disputes with the specified initiated_at date.
+        /// </summary>
+        [JsonProperty("initiated_at ")]
+        public DateTimeOffset? InitiatedAt { get; set; }
+    }
+}

--- a/ShopifySharp/Filters/ShopifyPaymentsPayoutFilter.cs
+++ b/ShopifySharp/Filters/ShopifyPaymentsPayoutFilter.cs
@@ -1,0 +1,44 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp.Filters 
+{
+    public class ShopifyPaymentsPayoutFilter : Parameterizable 
+    {
+        /// <summary>
+        /// Filter response to payouts exclusively after the specified ID.
+        /// </summary>
+        [JsonProperty("since_id")]
+        public long? SinceId { get; set; }
+
+        /// <summary>
+        /// Filter response to payouts exclusively before the specified ID
+        /// </summary>
+        [JsonProperty("last_id")]
+        public long? LastId { get; set; }
+
+        /// <summary>
+        /// Filter response to payouts inclusively after the specified date.
+        /// </summary>
+        [JsonProperty("date_min")]
+        public DateTimeOffset? DateMin { get; set; }
+
+        /// <summary>
+        /// Filter response to payouts inclusively before the specified date.
+        /// </summary>
+        [JsonProperty("date_max")]
+        public DateTimeOffset? DateMax { get; set; }
+
+        /// <summary>
+        /// Filter response to payouts on the specified date.
+        /// </summary>
+        [JsonProperty("date")]
+        public DateTimeOffset? Date { get; set; }
+
+        /// <summary>
+        /// Filter response to payouts with the specified status
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/ShopifySharp/Filters/ShopifyPaymentsTransactionFilter.cs
+++ b/ShopifySharp/Filters/ShopifyPaymentsTransactionFilter.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp.Filters 
+{
+    public class ShopifyPaymentsTransactionFilter : Parameterizable 
+    {
+        /// <summary>
+        /// Filter response to transactions exclusively after the specified ID.
+        /// </summary>
+        [JsonProperty("since_id")]
+        public long? SinceId { get; set; }
+
+        /// <summary>
+        /// Filter response to transactions exclusively before the specified ID
+        /// </summary>
+        [JsonProperty("last_id")]
+        public long? LastId { get; set; }
+
+        /// <summary>
+        /// Filter response to transactions placed in test mode.
+        /// </summary>
+        [JsonProperty("test")]
+        public bool Test { get; set; }
+
+        /// <summary>
+        /// Filter response to transactions paid out in the specified payout.
+        /// </summary>
+        [JsonProperty("payout_id")]
+        public string PayoutId { get; set; }
+
+        /// <summary>
+        /// Filter response to transactions with the specified payout status
+        /// </summary>
+        [JsonProperty("payout_status")]
+        public string PayoutStatus { get; set; }
+    }
+}

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -1,0 +1,81 @@
+﻿using System.Net.Http;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+using ShopifySharp.Filters;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// A service for manipulating Shopify payments.
+    /// </summary>
+    public class ShopifyPaymentsService : ShopifyService
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ShopifyPaymentsService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public ShopifyPaymentsService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
+
+        /// <summary>
+        /// Gets a count of all of the shop's transactions.
+        /// </summary>
+        /// <param name="orderId">The order id to which the fulfillments belong.</param>
+        /// <returns>The count of all fulfillments for the shop.</returns>
+        public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync()
+        {
+            var req = PrepareRequest($"shopify_payments/balance.json");
+
+            return await ExecuteRequestAsync<List<ShopifyPaymentsBalance>>(req, HttpMethod.Get, rootElement: "balance");
+        }
+
+        public virtual async Task<IEnumerable<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutFilter options = null)
+        {
+            var req = PrepareRequest("shopify_payments/payouts.json");
+
+            if (options != null)
+            {
+                req.QueryParams.AddRange(options.ToParameters());
+            }
+
+            return await ExecuteRequestAsync<List<ShopifyPaymentsPayout>>(req, HttpMethod.Get, rootElement: "payouts");
+        }
+
+        public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId)
+        {
+            var req = PrepareRequest($"shopify_payments/payouts/{payoutId}.json");
+            return await ExecuteRequestAsync<ShopifyPaymentsPayout>(req, HttpMethod.Get, rootElement: "payout");
+        }
+
+        public virtual async Task<IEnumerable<ShopifyPaymentsPayout>> ListDisputesAsync(ShopifyPaymentsDisputeFilter options = null)
+        {
+            var req = PrepareRequest("shopify_payments/disputes.json");
+
+            if (options != null)
+            {
+                req.QueryParams.AddRange(options.ToParameters());
+            }
+
+            return await ExecuteRequestAsync<List<ShopifyPaymentsPayout>>(req, HttpMethod.Get, rootElement: "disputes");
+        }
+
+        public virtual async Task<ShopifyPaymentsPayout> GetDisputeAsync(long disputeId)
+        {
+            var req = PrepareRequest($"shopify_payments/disputes/{disputeId}.json");
+            return await ExecuteRequestAsync<ShopifyPaymentsPayout>(req, HttpMethod.Get, rootElement: "dispute");
+        }
+
+        public virtual async Task<IEnumerable<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionFilter options = null)
+        {
+            var req = PrepareRequest("shopify_payments/balance/transactions.json");
+
+            if (options != null)
+            {
+                req.QueryParams.AddRange(options.ToParameters());
+            }
+
+            return await ExecuteRequestAsync<List<ShopifyPaymentsTransaction>>(req, HttpMethod.Get, rootElement: "transactions");
+        }
+    }
+}

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -35,13 +35,17 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="sinceId">Filters the results to after the specified id.</param>
         /// <returns>The list of transactions.</returns>
-        public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, long? sinceId = null)
+        public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, long? sinceId = null, bool? inShopCurrency = null)
         {
             var req = PrepareRequest($"orders/{orderId}/transactions.json");
 
             if (sinceId.HasValue)
             {
                 req.QueryParams.Add("since_id", sinceId.Value);
+            }
+            if (inShopCurrency.HasValue)
+            {
+                req.QueryParams.Add("in_shop_currency", inShopCurrency.Value);
             }
 
             return await ExecuteRequestAsync<List<Transaction>>(req, HttpMethod.Get, rootElement: "transactions");
@@ -54,13 +58,17 @@ namespace ShopifySharp
         /// <param name="transactionId">The id of the Transaction to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Transaction"/>.</returns>
-        public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, string fields = null)
+        public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, string fields = null, bool? inShopCurrency = null)
         {
             var req = PrepareRequest($"orders/{orderId}/transactions/{transactionId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
                 req.QueryParams.Add("fields", fields);
+            }
+            if (inShopCurrency.HasValue)
+            {
+                req.QueryParams.Add("in_shop_currency", inShopCurrency.Value);
             }
 
             return await ExecuteRequestAsync<Transaction>(req, HttpMethod.Get, rootElement: "transaction");

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netcoreapp2.1;netstandard1.4;net45</TargetFrameworks>
     <AssemblyName>ShopifySharp</AssemblyName>
     <RootNamespace>ShopifySharp</RootNamespace>
-    <Version>4.18.0</Version>
+    <Version>4.19.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Description>ShopifySharp is a C# and .NET library that helps developers easily authenticate with and manage Shopify stores.</Description>

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netcoreapp2.1;netstandard1.4;net45</TargetFrameworks>
     <AssemblyName>ShopifySharp</AssemblyName>
     <RootNamespace>ShopifySharp</RootNamespace>
-    <Version>4.17.3</Version>
+    <Version>4.18.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Description>ShopifySharp is a C# and .NET library that helps developers easily authenticate with and manage Shopify stores.</Description>


### PR DESCRIPTION
Added Shopify Payments service + tests to fetch payouts, balance, transactions and disputes.
Added few properties related to multi-currency support.
Incremented version.

Docs:
https://help.shopify.com/en/api/guides/multi-currency-migration-guide
https://help.shopify.com/en/api/reference/shopify_payments