### PR TITLE
Adds support for the TaxCode attribute for Product Variants

### DIFF
--- a/ShopifySharp.Tests/ProductVariant_Tests.cs
+++ b/ShopifySharp.Tests/ProductVariant_Tests.cs
@@ -64,6 +64,7 @@ namespace ShopifySharp.Tests
             Assert.True(created.Id.HasValue);
             Assert.Equal(Fixture.Price, created.Price);
             EmptyAssert.NotNullOrEmpty(created.Option1);
+            Assert.Equal(Fixture.TaxCode, created.TaxCode);
         }
 
         [Fact]
@@ -75,16 +76,19 @@ namespace ShopifySharp.Tests
             Assert.True(created.Id.HasValue);
             Assert.Equal(Fixture.Price, created.Price);
             EmptyAssert.NotNullOrEmpty(created.Option1);
+            Assert.Equal(Fixture.TaxCode, created.TaxCode);
         }
 
         [Fact]
         public async Task Updates_Variants()
         {
             decimal newPrice = (decimal) 11.22;
+            string newTaxCode = "Updated Tax Code";
             var created = await Fixture.Create();
             long id = created.Id.Value;
 
             created.Price = newPrice;
+            created.TaxCode = newTaxCode;
             created.Id = null;
 
             var updated = await Fixture.Service.UpdateAsync(id, created);
@@ -93,6 +97,7 @@ namespace ShopifySharp.Tests
             created.Id = id;
 
             Assert.Equal(newPrice, updated.Price);
+            Assert.Equal(newTaxCode, updated.TaxCode);
         }
     }
 
@@ -105,6 +110,8 @@ namespace ShopifySharp.Tests
         public decimal Price => 123.45m;
 
         public long ProductId { get; set; }
+
+        public string TaxCode => "A1234";
 
         public async Task InitializeAsync()
         {
@@ -150,6 +157,7 @@ namespace ShopifySharp.Tests
             {
                 Option1 = Guid.NewGuid().ToString(),
                 Price = Price,
+                TaxCode = TaxCode
             });
 
             if (! skipAddToCreatedList)

--- a/ShopifySharp/Entities/ProductVariant.cs
+++ b/ShopifySharp/Entities/ProductVariant.cs
@@ -111,6 +111,12 @@ namespace ShopifySharp
         public bool? Taxable { get; set; }
 
         /// <summary>
+        /// Specifies a tax code which is used for Avalara tax integrations
+        /// </summary>
+        [JsonProperty("tax_code")]
+        public string TaxCode { get; set; }
+
+        /// <summary>
         /// Specifies whether or not a customer needs to provide a shipping address when placing an order for this product variant.
         /// </summary>
         [JsonProperty("requires_shipping")]


### PR DESCRIPTION
This is the tax_code field used in Shopify for Product Variants for Shopify Plus stores that have the AvaTax app installed for calculating tax rates.