### PR TITLE
Change JSON Parsing to not lose time zone information 

### DIFF
--- a/ShopifySharp.Tests/DateTime_Tests.cs
+++ b/ShopifySharp.Tests/DateTime_Tests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp.Tests
+{
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Threading.Tasks;
+
+    using Newtonsoft.Json;
+
+    using Xunit;
+
+    public class DateTime_Tests : IClassFixture<Order_Tests_Fixture>
+    {
+        public DateTime_Tests(Order_Tests_Fixture orderTestsFixture)
+        {
+            this.OrderTestsFixture = orderTestsFixture;
+        }
+
+        public Order_Tests_Fixture OrderTestsFixture { get; }
+
+        [Fact]
+        public async Task GraphQL_CompareOrderDates()
+        {
+            var orderId = this.OrderTestsFixture.Created.First().Id.Value;
+
+            var order = await this.OrderTestsFixture.Service.GetAsync(orderId);
+            Assert.NotNull(order.UpdatedAt);
+
+            // Shopify seems to take approx. 10 seconds to propagate new orders into the GraphQL API
+            await Task.Delay(TimeSpan.FromSeconds(11));
+
+            var graphService = new GraphService(Utils.MyShopifyUrl, Utils.AccessToken);
+            var graphQlOrder = await graphService.PostAsync(
+                                   @"
+{
+  orders(first:1,query:""id:" + orderId + @""") {  
+            edges{
+                node{
+                    updatedAt
+                }
+            }
+        }
+    }
+");
+
+            var jtokenOrder = graphQlOrder["orders"]["edges"].First["node"];
+
+            var testOrder = jtokenOrder.ToObject<TestGraphQLOrderWithString>();
+            var testOrderDateTime = DateTimeOffset.Parse(testOrder.UpdatedAt, CultureInfo.InvariantCulture);
+            Assert.Equal(order.UpdatedAt.Value, testOrderDateTime);
+
+            var testOrderWithDateTimeOffset = jtokenOrder.ToObject<TestGraphQLOrderWithDateTimeOffset>();
+            Assert.Equal(order.UpdatedAt.Value, testOrderWithDateTimeOffset.UpdatedAt);
+
+            var testOrderWithDateTime = jtokenOrder.ToObject<TestGraphQLOrderWithDateTime>();
+            Assert.Equal(order.UpdatedAt.Value, testOrderWithDateTime.UpdatedAt);
+        }
+
+        public class TestGraphQLOrderWithString
+        {
+            public string UpdatedAt { get; set; }
+        }
+
+        public class TestGraphQLOrderWithDateTime
+        {
+            public DateTime UpdatedAt { get; set; }
+        }
+
+        public class TestGraphQLOrderWithDateTimeOffset
+        {
+            public DateTimeOffset UpdatedAt { get; set; }
+        }
+    }
+}

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -145,7 +145,9 @@ namespace ShopifySharp
                         // Don't parse the result when the request was Delete.
                         if (baseRequestMessage.Method != HttpMethod.Delete)
                         {
-                            jtoken = JToken.Parse(rawResult);
+                            // Make sure that dates are not stripped of any timezone information if tokens are de-serialised into strings/DateTime/DateTimeZoneOffset
+                            using (var reader = new JsonTextReader(new StringReader(rawResult)) { DateParseHandling = DateParseHandling.None })
+                                jtoken = JObject.Load(reader);
                         }
 
                         return new RequestResult<JToken>(response, jtoken, rawResult);


### PR DESCRIPTION
When querying the GraphQL endpoint with Shopify, the dates come base with time zone information. However the default JToken.Parse() strips the timezone information for dates and returns them as DateTime instances. This makes any conversion to DateTimeOffset incorrect as it picks up the local time.

Changing to explicitly not handling datetimes in the _tokenising_ part of the parsing means that date times are correctly converted to DateTimeOffset when de-serializing.