### PR TITLE
Update GraphService.cs

### DIFF
--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// <returns>A JToken containing the data from the request.</returns>
         public virtual async Task<JToken> PostAsync(string body)
         {
-            var req = PrepareRequest("api/graphql.json");
+            var req = PrepareRequest("graphql.json");
 
             var content = new StringContent(body, Encoding.UTF8, "application/graphql");
 
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// <returns>A JToken containing the data from the request.</returns>
         public virtual async Task<JToken> PostAsync(JToken body)
         {
-            var req = PrepareRequest("api/graphql.json");
+            var req = PrepareRequest("graphql.json");
 
             var content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
 


### PR DESCRIPTION
Hi,
I have seen that the current URI for GraphQL API is incorrect and returns a 406 Not Acceptable Error. Thus, i am proposing an update on the URI.
Current URI Example: https://{shop-name}.myshopify.com/admin/api/2019-04/api/graphql.json
Updated URI Example: https://{shop-name}.myshopify.com/admin/api/2019-04/graphql.json