### PR TITLE
Shopify Refund API

### DIFF
--- a/ShopifySharp.Tests/Refund_Tests.cs
+++ b/ShopifySharp.Tests/Refund_Tests.cs
@@ -131,7 +131,7 @@ namespace ShopifySharp.Tests
         /// An id tied to an order.
         /// Requires that the order be manually created and set before testing.
         /// </summary>
-        public long? OrderId = 1941696315452; 
+        public long? OrderId = null; 
 
         public Refund_Tests_Fixture()
         {

--- a/ShopifySharp.Tests/Refund_Tests.cs
+++ b/ShopifySharp.Tests/Refund_Tests.cs
@@ -32,12 +32,12 @@ namespace ShopifySharp.Tests
         {
             //CalculateAsync
             var order = await Fixture.OrderService.GetAsync(Fixture.Created.First().Id.Value);
-            var requestedRefund = PrepareCalculate(order);
+            var requestedRefund = Prepare_Calculate(order);
             var calculateResponse = await Fixture.Service.CalculateAsync(order.Id.Value, requestedRefund);
             Assert.True(calculateResponse.Transactions.Count<Transaction>() > 0, "No transactions for order!"); //Perhaps something is unexpected with the order, or call/response was malformed."
 
             //RefundAsync
-            var fullRefundForAnOrder = PrepareRefund(calculateResponse);
+            var fullRefundForAnOrder = Prepare_Refund(calculateResponse);
             var refundResponse = await Fixture.Service.RefundAsync(order.Id.Value, fullRefundForAnOrder);
             Assert.True(refundResponse.ProcessedAt.HasValue && refundResponse.ProcessedAt > DateTime.UtcNow.AddDays(-1), "Refund was not processed"); //Order was not processed, thus was not successfully refunded"
 
@@ -138,7 +138,7 @@ namespace ShopifySharp.Tests
             Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
         }
 
-        public OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken); //original
+        public OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
         public RefundService Service { get; } = new RefundService(Utils.MyShopifyUrl, Utils.AccessToken);
 
         public string Note => "This order was created while testing ShopifySharp!";
@@ -149,7 +149,7 @@ namespace ShopifySharp.Tests
         {
             if (!OrderId.HasValue)
                 return;
-            // Create an order for count, list, get, etc. orders.
+            // Retrieve an order for count, list, get, etc. orders.
             await Retrieve(OrderId.Value);
         }
 

--- a/ShopifySharp.Tests/Refund_Tests.cs
+++ b/ShopifySharp.Tests/Refund_Tests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using ShopifySharp.Filters;
+using Xunit;
+
+namespace ShopifySharp.Tests
+{
+    [Trait("Category", "Refund")]
+    public class Refund_Tests : IClassFixture<Refund_Tests_Fixture>
+    {
+        private Refund_Tests_Fixture Fixture { get; }
+
+        public Refund_Tests(Refund_Tests_Fixture fixture)
+        {
+            this.Fixture = fixture;
+        }
+
+        ///<summary>
+        ///A test designed to validate the ShopifySharp Refund Methods.
+        ///Please note: An <see cref="OrderId"/> tied to a manually created, active order is required to be able to use this test.
+        ///This is because it seems API refunds cannot be applied against orders created via the API.
+        ///These four method tests are consolidated into one because they are reliant upon each other:
+        ///*GetAsync & ListForOrderAsync: To be able to list a refund, a refund must be created (via PrepareRefund).
+        ///*PrepareRefund: In order to create a Refund, a transaction Id must have been retrieved (via CalculateAsync).
+        ///</summary>
+        [Fact]
+        public async Task Get_Refund_And_List()
+        {
+            //CalculateAsync
+            var order = await Fixture.OrderService.GetAsync(Fixture.Created.First().Id.Value);
+            var requestedRefund = PrepareCalculate(order);
+            var calculateResponse = await Fixture.Service.CalculateAsync(order.Id.Value, requestedRefund);
+            Assert.True(calculateResponse.Transactions.Count<Transaction>() > 0, "No transactions for order!"); //Perhaps something is unexpected with the order, or call/response was malformed."
+
+            //RefundAsync
+            var fullRefundForAnOrder = PrepareRefund(calculateResponse);
+            var refundResponse = await Fixture.Service.RefundAsync(order.Id.Value, fullRefundForAnOrder);
+            Assert.True(refundResponse.ProcessedAt.HasValue && refundResponse.ProcessedAt > DateTime.UtcNow.AddDays(-1), "Refund was not processed"); //Order was not processed, thus was not successfully refunded"
+
+            //ListForOrderAsync
+            var getRefundsForOrder = await Fixture.Service.ListForOrderAsync(order.Id.Value);
+            Assert.True(getRefundsForOrder.First().Id.HasValue, "No refunds received!"); //Likely the creation of a refund or the retrieval of refunds weren't successful"
+
+            //GetAsync
+            var getSpecificRefund = await Fixture.Service.GetAsync(order.Id.Value, getRefundsForOrder.First().Id.Value);
+            Assert.True(getSpecificRefund.Id.HasValue, "No refund received!"); //Either refund wasn't successful or Refund Id may be incorrect."
+        }
+
+        /// <summary>
+        /// A helper function designed to construct a refund object that will be accepted by Shopify Refund "/orders/#{order_id}/refunds/calculate.json" endpoint
+        /// </summary>
+        public Refund Prepare_Calculate(Order order)
+        {
+            var RequestedRefund = new Refund()
+            {
+                Currency = "USD",
+                Shipping = new Shipping()
+                {
+                    FullRefund = true,
+                },
+                RefundLineItems = new List<ShopifySharp.RefundLineItem>(),
+            };
+            var liList = new List<RefundLineItem>();
+            foreach (var li in order.LineItems)
+            {
+                var newLi = new ShopifySharp.RefundLineItem()
+                {
+                    LineItemId = li.Id,
+                    Quantity = li.Quantity,
+                    RestockType = "no_restock",
+                };
+                liList.Add(newLi);
+            }
+            RequestedRefund.RefundLineItems = liList;
+            return RequestedRefund;
+        }
+
+        /// <summary>
+        /// A helper function designed to construct a refund object that will be accepted by Shopify Refund "/orders/#{order_id}/refunds.json" endpoint
+        /// </summary>
+        public Refund Prepare_Refund(Refund calculateRefundResponse)
+        {
+            var fullRefundForAnOrder = new Refund()
+            {
+                Currency = "USD",
+                Notify = true,
+                Note = "Shopify Sharp Test",
+                Shipping = new Shipping()
+                {
+                    FullRefund = true,
+                },
+                RefundLineItems = new List<ShopifySharp.RefundLineItem>(),
+                Transactions = new List<ShopifySharp.Transaction>(),
+            };
+            var liList = new List<RefundLineItem>();
+            foreach (var orderLi in calculateRefundResponse.RefundLineItems)
+            {
+                var lineItem = new ShopifySharp.RefundLineItem()
+                {
+                    LineItemId = orderLi.LineItemId,
+                    Quantity = orderLi.Quantity,
+                    RestockType = orderLi.RestockType,
+                };
+                liList.Add(lineItem);
+            };
+            fullRefundForAnOrder.RefundLineItems = liList;
+            var transactionList = new List<Transaction>();
+            foreach (var shopifyTransaction in calculateRefundResponse.Transactions)
+            {
+                var transactionLi = new ShopifySharp.Transaction()
+                {
+                    ParentId = shopifyTransaction.ParentId,
+                    Amount = shopifyTransaction.Amount,
+                    Kind = "refund",
+                    Gateway = "ShopifySharp Test",
+                };
+                transactionList.Add(transactionLi);
+            }
+            fullRefundForAnOrder.Transactions = transactionList;
+            return fullRefundForAnOrder;
+        }
+    }
+
+    public class Refund_Tests_Fixture : IAsyncLifetime
+    {
+        /// <summary>
+        /// An id tied to an order.
+        /// Requires that the order be manually created and set before testing.
+        /// </summary>
+        public long? OrderId = 1941696315452; 
+
+        public Refund_Tests_Fixture()
+        {
+            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+        }
+
+        public OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken); //original
+        public RefundService Service { get; } = new RefundService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+        public string Note => "This order was created while testing ShopifySharp!";
+
+        public List<Order> Created { get; } = new List<Order>();
+
+        public async Task InitializeAsync()
+        {
+            if (!OrderId.HasValue)
+                return;
+            // Create an order for count, list, get, etc. orders.
+            await Retrieve(OrderId.Value);
+        }
+
+        public async Task DisposeAsync()
+        {
+            foreach (var obj in Created)
+            {
+                try
+                {
+                    await OrderService.DeleteAsync(obj.Id.Value);
+                }
+                catch (ShopifyException ex)
+                {
+                    if (ex.HttpStatusCode != HttpStatusCode.NotFound)
+                    {
+                        Console.WriteLine($"Failed to delete created Order with id {obj.Id.Value}. {ex.Message}");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Convenience function for running tests. Retrieves an object and automatically adds it to the queue for deleting after tests finish.
+        /// </summary>
+        public async Task<Order> Retrieve(long orderId, bool skipAddToCreateList = false)
+        {
+            var obj = await OrderService.GetAsync(orderId);
+
+            if (!skipAddToCreateList)
+            {
+                Created.Add(obj);
+            }
+
+            return obj;
+        }
+    }
+}

--- a/ShopifySharp/Entities/Refund.cs
+++ b/ShopifySharp/Entities/Refund.cs
@@ -15,6 +15,23 @@ namespace ShopifySharp
         [JsonProperty("created_at")]
         public DateTimeOffset? CreatedAt { get; set; }
 
+        ///<summary>
+        /// Whether to send a refund notification to the customer
+        /// </summary>
+        [JsonProperty("notify")]
+        public bool? Notify { get; set; }
+
+        /// <summary>
+        /// Specify how much shipping to refund.
+        /// </summary>
+        [JsonProperty("shipping")]
+        public Shipping Shipping { get; set; }
+
+        /// <summary>
+        /// The three-letter code (ISO 4217 format) for the currency used for the refund. Note: Required whenever the shipping amount property is provided.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
 
         /// <summary>
         /// The list of <see cref="RefundOrderAdjustment"/> objects
@@ -60,5 +77,20 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("user_id")]
         public long? UserId { get; set; }
+    }
+
+    public class Shipping
+    {
+        /// <summary>
+        /// Whether to refund all remaining shipping.
+        /// </summary>
+        [JsonProperty("full_refund")]
+        public bool? FullRefund { get; set; }
+
+        /// <summary>
+        /// Set a specific amount to refund for shipping. Takes precedence over full_refund.
+        /// </summary>
+        [JsonProperty("amount")]
+        public decimal? Amount { get; set; }
     }
 }

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -1,0 +1,82 @@
+using Newtonsoft.Json.Linq;
+using System.Net.Http;
+using ShopifySharp.Filters;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// A service for creating Shopify Refunds.
+    /// </summary>
+    public class RefundService : ShopifyService
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="RefundService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public RefundService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
+
+        /// <summary>
+        /// Retrieves a list of refunds for an order.
+        /// </summary>
+        /// <param name="orderId">The id of the order to list orders for.</param>
+        /// <returns></returns>
+        public virtual async Task<IEnumerable<Refund>> ListForOrderAsync(long orderId, OrderFilter options = null)
+        {
+            var req = PrepareRequest($"orders/{orderId}/refunds.json");
+            req.QueryParams.Add("customer_id", orderId);
+            if (options != null)
+            {
+                req.QueryParams.AddRange(options.ToParameters());
+            }
+            return await ExecuteRequestAsync<List<Refund>>(req, HttpMethod.Get, rootElement: "refunds");
+        }
+
+        /// <summary>
+        /// Retrieves a specific refund.
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <param name="refundId"></param>
+        /// <returns></returns>
+        public virtual async Task<Refund> GetAsync(long orderId, long refundId, string fields = null)
+        {
+            var req = PrepareRequest($"orders/{orderId}/refunds/{refundId}.json");
+
+            if (string.IsNullOrEmpty(fields) == false)
+            {
+                req.QueryParams.Add("fields", fields);
+            }
+            return await ExecuteRequestAsync<Refund>(req, HttpMethod.Get, rootElement: "refund");
+        }
+
+        /// <summary>
+        /// Calculates <see cref="Refund"/> transactions based on line items and shipping.
+        /// When you want to create a refund, you should first use the calculate endpoint to generate accurate refund transactions.
+        /// Specify the line items that are being refunded, their quantity and restock instructions, and whether you intend to refund shipping costs.
+        /// If the restock instructions can't be met—for example, because you try to return more items than have been fulfilled—then the endpoint returns modified restock instructions.
+        /// You can then use the response in the body of the request to create the actual refund.
+        /// The response includes a transactions object with "kind": "suggested_refund", which must to be changed to "kind" : "refund" for the refund to be accepted.
+        /// </summary>
+        public virtual async Task<Refund> CalculateAsync(long orderId, Refund options = null)
+        {
+            var req = PrepareRequest($"orders/{orderId}/refunds/calculate.json");
+            var content = new JsonContent(new { refund = options ?? new Refund() });
+            var result = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund");
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Refund"/>. Use the calculate endpoint to produce the transactions to submit.
+        /// </summary>
+        public virtual async Task<Refund> RefundAsync(long orderId, Refund options = null)
+        {
+            var req = PrepareRequest($"orders/{orderId}/refunds.json");
+            var content = new JsonContent(new { refund = options ?? new Refund() });
+            var result = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund");
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
A service for creating Shopify Refunds.

**Please note**: For the associated test, OrderId is tied to a manually created, active order is required to be able to use this test. This is because it seems API refunds cannot be applied against orders created via the API.