### PR TITLE
Hmac bug

### DIFF
--- a/ShopifySharp.Tests/Authorization_Tests.cs
+++ b/ShopifySharp.Tests/Authorization_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
 using ShopifySharp.Enums;
 using Xunit;
@@ -48,7 +49,7 @@ namespace ShopifySharp.Tests
         public void Validates_Proxy_Requests_With_Raw_QueryString()
         {
             //Configure querystring
-            var qs = "shop=stages-test-shop-2.myshopify.com&path_prefix=/apps/stages-order-tracker&timestamp=1459781841&signature=239813a42e1164a9f52e85b2119b752774fafb26d0f730359c86572e1791854a";         
+            var qs = "shop=stages-test-shop-2.myshopify.com&path_prefix=/apps/stages-order-tracker&timestamp=1459781841&signature=239813a42e1164a9f52e85b2119b752774fafb26d0f730359c86572e1791854a";
 
             bool isValid = AuthorizationService.IsAuthenticProxyRequest(qs, Utils.SecretKey);
 
@@ -68,6 +69,15 @@ namespace ShopifySharp.Tests
 
             bool isValid = AuthorizationService.IsAuthenticRequest(qs, Utils.SecretKey);
 
+            Assert.True(isValid);
+        }
+
+        [Fact(Skip = "TODO: Generate a real query string with the shop and secret key used by the build server, which contains an ids[] parameter")]
+        public void Validates_Web_Requests_WithArrayParameter()
+        {
+            string query = "hmac=123....";
+            var qs = QueryHelpers.ParseQuery(query);
+            bool isValid = AuthorizationService.IsAuthenticRequest(qs, Utils.SecretKey);
             Assert.True(isValid);
         }
 
@@ -110,7 +120,7 @@ namespace ShopifySharp.Tests
         public async Task Validates_Shop_Malfunctioned_Urls()
         {
             string invalidUrl = "foo";
-            
+
             Assert.False(await AuthorizationService.IsValidShopDomainAsync(invalidUrl));
         }
 

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotenvfile" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/ShopifySharp/Services/Authorization/AuthorizationService.cs
+++ b/ShopifySharp/Services/Authorization/AuthorizationService.cs
@@ -43,7 +43,10 @@ namespace ShopifySharp
 
         private static string EncodeQuery(StringValues values, bool isKey)
         {
-            string s = values.FirstOrDefault();
+            //array parameters are handled differently: see https://community.shopify.com/c/Shopify-APIs-SDKs/HMAC-calculation-vs-ids-arrays/td-p/261154
+            string s = values.Count <= 1 ?
+                            values.FirstOrDefault() :
+                            '[' + string.Join(", ", values.Select(v => '"' + v + '"')) + ']';
 
             if (string.IsNullOrEmpty(s))
             {
@@ -55,7 +58,7 @@ namespace ShopifySharp
 
             if (isKey)
             {
-                output = output.Replace("=", "%3D");
+                output = output.Replace("=", "%3D").Replace("[]", "");
             }
 
             return output;


### PR DESCRIPTION
Fixed HMAC calculation when query string includes array parameters, such as ids[] given when using a bulk action app link.

I included a test that I verified locally but that I marked as `Skip` because the HMAC depends on whatever secret key is configured on the build server.

@nozzlegear  if you can generate a real query string with the matching key then you can replace the hard coded query string and unskip the test. You'll need to create a bulk action link (https://help.shopify.com/en/api/embedded-apps/app-extensions/shopify-admin/bulk-action-links) with the app matching the secret key.

I hope this make sense?