### PR TITLE
Update restock in Refund.cs

### DIFF
--- a/ShopifySharp/Entities/Refund.cs
+++ b/ShopifySharp/Entities/Refund.cs
@@ -59,12 +59,12 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("refund_line_items")]
         public IEnumerable<RefundLineItem> RefundLineItems { get; set; }
-
+        
         /// <summary>
-        /// Whether or not the line items were added back to the store inventory.
+        /// How this refund affects inventory levels.
         /// </summary>
         [JsonProperty("restock_type")]
-        public bool? Restock { get; set; }
+        public string RestockType { get; set; }
 
         /// <summary>
         /// The list of <see cref="Transaction"/> objects

--- a/ShopifySharp/Entities/Refund.cs
+++ b/ShopifySharp/Entities/Refund.cs
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// <summary>
         /// Whether or not the line items were added back to the store inventory.
         /// </summary>
-        [JsonProperty("restock")]
+        [JsonProperty("restock_type")]
         public bool? Restock { get; set; }
 
         /// <summary>


### PR DESCRIPTION
SDK V4.25.0  Refund.cs File
Issue:  while creating refund exceptin:  {"error":"restock is no longer supported.
Please use restock_type on refund_line_items."}

FIX: Update restock_type in Refund.cs 
Reference: https://help.shopify.com/en/api/reference/orders/refund

Please review the changes :) 