### PR TITLE
v5 contrib

### DIFF
--- a/ShopifySharp.Tests/LinkHeaderParser_Tests.cs
+++ b/ShopifySharp.Tests/LinkHeaderParser_Tests.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_NextLinkOnly()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=next");
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=\"next\"");
             Assert.Null(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6");
@@ -26,7 +26,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevLinkOnly()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=previous");
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=\"previous\"");
             Assert.Null(res.NextLink);
             Assert.NotNull(res.PreviousLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6");
@@ -36,7 +36,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=previous, <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=next");
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=\"next\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
@@ -48,7 +48,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_NextThenPrev()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=next, <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=previous");
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=\"next\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=\"previous\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
@@ -60,7 +60,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext_WithExtraSpaces()
         {
-            var res = LinkHeaderParser.Parse("  <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>  ;  rel=previous  ,   <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>  ;  rel=next  ");
+            var res = LinkHeaderParser.Parse("  <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>  ;  rel=\"previous\"  ,   <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>  ;  rel=\"next\"  ");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
@@ -72,7 +72,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext_WithFieldsParam()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title>; rel=previous, <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3&fields=id,images,title>; rel=next");
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3&fields=id,images,title>; rel=\"next\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title");
@@ -84,7 +84,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext_PageInfoIsNotFirstQueryParam()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg>; rel=previous, <https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=opqrstu>; rel=next");
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=opqrstu>; rel=\"next\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg");

--- a/ShopifySharp.Tests/LinkHeaderParser_Tests.cs
+++ b/ShopifySharp.Tests/LinkHeaderParser_Tests.cs
@@ -1,0 +1,96 @@
+using ShopifySharp.Infrastructure;
+using ShopifySharp.Lists;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+using EmptyAssert = ShopifySharp.Tests.Extensions.EmptyExtensions;
+
+namespace ShopifySharp.Tests
+{
+    [Trait("Category", "Link header parsing")]
+    public class LinkHeaderParser_Tests
+    {
+        [Fact]
+        public void Parse_NextLinkOnly()
+        {
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=next");
+            Assert.Null(res.PreviousLink);
+            Assert.NotNull(res.NextLink);
+            Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6");
+            Assert.Equal(res.NextLink.PageInfo, "vwxyzab");
+        }
+
+        [Fact]
+        public void Parse_PrevLinkOnly()
+        {
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=previous");
+            Assert.Null(res.NextLink);
+            Assert.NotNull(res.PreviousLink);
+            Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6");
+            Assert.Equal(res.PreviousLink.PageInfo, "vwxyzab");
+        }
+
+        [Fact]
+        public void Parse_PrevThenNext()
+        {
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=previous, <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=next");
+            Assert.NotNull(res.PreviousLink);
+            Assert.NotNull(res.NextLink);
+            Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
+            Assert.Equal(res.PreviousLink.PageInfo, "abcdefg");
+            Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3");
+            Assert.Equal(res.NextLink.PageInfo, "opqrstu");
+        }
+
+        [Fact]
+        public void Parse_NextThenPrev()
+        {
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=next, <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=previous");
+            Assert.NotNull(res.PreviousLink);
+            Assert.NotNull(res.NextLink);
+            Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
+            Assert.Equal(res.PreviousLink.PageInfo, "abcdefg");
+            Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3");
+            Assert.Equal(res.NextLink.PageInfo, "opqrstu");
+        }
+
+        [Fact]
+        public void Parse_PrevThenNext_WithExtraSpaces()
+        {
+            var res = LinkHeaderParser.Parse("  <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>  ;  rel=previous  ,   <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>  ;  rel=next  ");
+            Assert.NotNull(res.PreviousLink);
+            Assert.NotNull(res.NextLink);
+            Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
+            Assert.Equal(res.PreviousLink.PageInfo, "abcdefg");
+            Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3");
+            Assert.Equal(res.NextLink.PageInfo, "opqrstu");
+        }
+
+        [Fact]
+        public void Parse_PrevThenNext_WithFieldsParam()
+        {
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title>; rel=previous, <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3&fields=id,images,title>; rel=next");
+            Assert.NotNull(res.PreviousLink);
+            Assert.NotNull(res.NextLink);
+            Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title");
+            Assert.Equal(res.PreviousLink.PageInfo, "abcdefg");
+            Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3&fields=id,images,title");
+            Assert.Equal(res.NextLink.PageInfo, "opqrstu");
+        }
+
+        [Fact]
+        public void Parse_PrevThenNext_PageInfoIsNotFirstQueryParam()
+        {
+            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg>; rel=previous, <https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=opqrstu>; rel=next");
+            Assert.NotNull(res.PreviousLink);
+            Assert.NotNull(res.NextLink);
+            Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg");
+            Assert.Equal(res.PreviousLink.PageInfo, "abcdefg");
+            Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=opqrstu");
+            Assert.Equal(res.NextLink.PageInfo, "opqrstu");
+        }
+    }
+}

--- a/ShopifySharp/Filters/IListFilter.cs
+++ b/ShopifySharp/Filters/IListFilter.cs
@@ -16,11 +16,6 @@ namespace ShopifySharp.Filters
         int? Limit { get; set; }
 
         /// <summary>
-        /// A comma-separated list of which fields to show in the results. This parameter only works for some endpoints.
-        /// </summary>
-        string Fields { get; set; }
-
-        /// <summary>
         /// Converts the filter to a list of key/value pairs which can be turned into a querystring.
         /// </summary>
         IEnumerable<KeyValuePair<string, object>> ToQueryParameters();

--- a/ShopifySharp/Filters/IListFilter.cs
+++ b/ShopifySharp/Filters/IListFilter.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace ShopifySharp.Filters
@@ -13,6 +14,11 @@ namespace ShopifySharp.Filters
         /// The number of items which should be returned. Default is 50, maximum is 250.
         /// </summary>
         int? Limit { get; set; }
+
+        /// <summary>
+        /// A comma-separated list of which fields to show in the results. This parameter only works for some endpoints.
+        /// </summary>
+        string Fields { get; set; }
 
         /// <summary>
         /// Converts the filter to a list of key/value pairs which can be turned into a querystring.

--- a/ShopifySharp/Filters/ListFilter.cs
+++ b/ShopifySharp/Filters/ListFilter.cs
@@ -9,9 +9,23 @@ namespace ShopifySharp.Filters
     /// </summary>
     public class ListFilter : IListFilter
     {
+        /// <summary>
+        /// A unique ID used to access a page of results. Must be present to list more than the first page of results. 
+        /// </summary>
+        [JsonProperty("page_info")]
         public string PageInfo { get; set; }
 
+        /// <summary>
+        /// The number of items which should be returned. Default is 50, maximum is 250.
+        /// </summary>
+        [JsonProperty("limit")]
         public int? Limit { get; set; }
+
+        /// <summary>
+        /// A comma-separated list of which fields to show in the results. This parameter only works for some endpoints.
+        /// </summary>
+        [JsonProperty("fields")]
+        public string Fields { get; set; }
 
         public virtual IEnumerable<KeyValuePair<string, object>> ToQueryParameters()
         {

--- a/ShopifySharp/Filters/ListFilter.cs
+++ b/ShopifySharp/Filters/ListFilter.cs
@@ -21,12 +21,6 @@ namespace ShopifySharp.Filters
         [JsonProperty("limit")]
         public int? Limit { get; set; }
 
-        /// <summary>
-        /// A comma-separated list of which fields to show in the results. This parameter only works for some endpoints.
-        /// </summary>
-        [JsonProperty("fields")]
-        public string Fields { get; set; }
-
         public virtual IEnumerable<KeyValuePair<string, object>> ToQueryParameters()
         {
             throw new System.NotImplementedException();

--- a/ShopifySharp/Lists/IListResult.cs
+++ b/ShopifySharp/Lists/IListResult.cs
@@ -1,11 +1,12 @@
+using ShopifySharp.Infrastructure;
 using System.Collections.Generic;
 
 namespace ShopifySharp.Lists
 {
     public interface IListResult<T>
     {
-        string NextPageLink { get; set; }
-        string PreviousPageLink { get; set; }
-        IEnumerable<T> Items { get; set; }
+        LinkHeaderParseResult LinkHeader { get; }
+
+        IEnumerable<T> Items { get; }
     }
 }

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -15,6 +15,10 @@ namespace ShopifySharp.Lists
         {
             var prevLink = GetPageInfoParam(linkHeaderValue, _regexPrevLink);
             var nextLink = GetPageInfoParam(linkHeaderValue, _regexNextLink);
+
+            if (prevLink == null && nextLink == null)
+                throw new ShopifyException($"Found neither a 'previous' or 'next' url in the link header: '{linkHeaderValue}'");
+
             return new LinkHeaderParseResult(prevLink, nextLink);
         }
 

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -8,8 +8,8 @@ namespace ShopifySharp.Lists
 {
     public static class LinkHeaderParser
     {
-        private static Regex _regexPrevLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=previous", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-        private static Regex _regexNextLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=next", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static Regex _regexPrevLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=""previous""", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static Regex _regexNextLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=""next""", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         public static LinkHeaderParseResult Parse(string linkHeaderValue)
         {

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ShopifySharp.Lists
+{
+    public static class LinkHeaderParser
+    {
+        private static Regex _regexPrevLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=previous", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static Regex _regexNextLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=next", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public static LinkHeaderParseResult Parse(string linkHeaderValue)
+        {
+            var prevLink = GetPageInfoParam(linkHeaderValue, _regexPrevLink);
+            var nextLink = GetPageInfoParam(linkHeaderValue, _regexNextLink);
+
+            if (prevLink == null && nextLink == null)
+                throw new ShopifyException($"Found neither a 'previous' or 'next' url in the link header: '{linkHeaderValue}'");
+
+            return new LinkHeaderParseResult(prevLink, nextLink);
+        }
+
+        private static LinkHeaderParseResult.PagingLink GetPageInfoParam(string linkHeaderValue, Regex linkRegex)
+        {
+            var match = linkRegex.Match(linkHeaderValue);
+
+            if (!match.Success || match.Groups.Count < 2 || !match.Groups[1].Success)
+                return null;
+
+            string matchedUrl = match.Groups[1].Value;
+
+            if (!Uri.TryCreate(matchedUrl, UriKind.Absolute, out var uri))
+                throw new ShopifyException($"Cannot parse page link url: '{matchedUrl}'");
+
+            string pageInfo = uri.Query.Split('?', '&')
+                                        .FirstOrDefault(p => p.StartsWith("page_info="))
+                                        ?.Substring("page_info=".Length);
+            if (pageInfo == null)
+                throw new ShopifyException($"Cannot parse page link's page info parameter: '{matchedUrl}'");
+
+            return new LinkHeaderParseResult.PagingLink(matchedUrl, pageInfo);
+        }
+    }
+}

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -15,10 +15,6 @@ namespace ShopifySharp.Lists
         {
             var prevLink = GetPageInfoParam(linkHeaderValue, _regexPrevLink);
             var nextLink = GetPageInfoParam(linkHeaderValue, _regexNextLink);
-
-            if (prevLink == null && nextLink == null)
-                throw new ShopifyException($"Found neither a 'previous' or 'next' url in the link header: '{linkHeaderValue}'");
-
             return new LinkHeaderParseResult(prevLink, nextLink);
         }
 

--- a/ShopifySharp/Lists/LinkHeaderParserResult.cs
+++ b/ShopifySharp/Lists/LinkHeaderParserResult.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp.Lists
+{
+    public class LinkHeaderParseResult
+    {
+        public class PagingLink
+        {
+            public string Url { get; }
+
+            public string PageInfo { get; }
+
+            public PagingLink(string url, string pageInfo)
+            {
+                Url = url;
+                PageInfo = pageInfo;
+            }
+        }
+
+        public PagingLink PreviousLink { get; }
+
+        public PagingLink NextLink { get; }
+
+        public LinkHeaderParseResult(PagingLink previousLink, PagingLink nextLink)
+        {
+            PreviousLink = previousLink;
+            NextLink = nextLink;
+        }
+    }
+}

--- a/ShopifySharp/Lists/ListResult.cs
+++ b/ShopifySharp/Lists/ListResult.cs
@@ -1,3 +1,4 @@
+using ShopifySharp.Infrastructure;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -5,10 +6,14 @@ namespace ShopifySharp.Lists
 {
     public class ListResult<T> : IListResult<T>
     {
-        public string NextPageLink { get; set; }
-        
-        public string PreviousPageLink { get; set; }
-        
-        public IEnumerable<T> Items { get; set; } = Enumerable.Empty<T>();
+        public IEnumerable<T> Items { get; }
+
+        public LinkHeaderParseResult LinkHeader { get; }
+
+        public ListResult(IEnumerable<T> items, LinkHeaderParseResult linkHeader)
+        {
+            Items = items;
+            LinkHeader = linkHeader;
+        }
     }
 }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -137,7 +137,7 @@ namespace ShopifySharp
 
             return headerValue ?? string.Empty;
         }
-        
+
         /// <summary>
         /// Executes a request and returns a JToken for querying. Throws an exception when the response is invalid.
         /// Use this method when the expected response is a single line or simple object that doesn't warrant its own class.
@@ -159,7 +159,7 @@ namespace ShopifySharp
 
                         //Check for and throw exception when necessary.
                         CheckResponseExceptions(response, rawResult);
-                        
+
                         JToken jtoken = null;
 
                         // Don't parse the result when the request was Delete.
@@ -175,7 +175,7 @@ namespace ShopifySharp
                         return new RequestResult<JToken>(response, jtoken, rawResult, ReadLinkHeader(response));
                     }
                 });
-                
+
                 return policyResult;
             }
         }
@@ -377,104 +377,12 @@ namespace ShopifySharp
             return errors;
         }
 
-        bool TryParsePageInfoFromLink(string linkValue, out string url)
-        {
-            var regex = new Regex("<(.*)>;");
-            var match = regex.Match(linkValue);
-
-            if (match.Success == false)
-            {
-                url = null;
-                return false;
-            }
-
-            if (match.Groups.Count < 2)
-            {
-                url = null;
-                return false;
-            }
-            
-            var parsedLinkUrl = match.Groups[1].Value;
-
-            if (string.IsNullOrWhiteSpace(parsedLinkUrl))
-            {
-                url = null;
-                return false;
-            }
-
-            var querySubstringStartIndex = parsedLinkUrl.IndexOf("?", StringComparison.Ordinal);
-            var querystring = parsedLinkUrl.Substring(querySubstringStartIndex + 1);
-            var splitQuery =
-                querystring.Split(new[] {'?', '&'})
-                    .Select(querySegment =>
-                    {
-                        var splitKvp = querySegment.Split('=');
-                        var key = splitKvp.First();
-
-                        if (splitKvp.Length == 2)
-                        {
-                            return new
-                            {
-                                key = key,
-                                value = splitKvp[1]
-                            };
-                        }
-
-                        return new
-                        {
-                            key = key,
-                            value = ""
-                        };
-                    });
-            var pageInfoKvp = splitQuery.FirstOrDefault(kvp => kvp.key == "page_info");
-
-            if (pageInfoKvp == null || !string.IsNullOrEmpty(pageInfoKvp.value))
-            {
-                url = null;
-                return false;
-            }
-
-            url = pageInfoKvp.value;
-            return true;
-        }
-
         /// <summary>
         /// Parses a link header value into a ListResult<T>. The Items property will need to be manually set. 
         /// </summary>
         public IListResult<T> ParseLinkHeaderToListResult<T>(RequestResult<List<T>> requestResult)
         {
-            var links = requestResult.RawLinkHeaderValue
-                .Split(',')
-                .Select(link => link.Trim())
-                .ToArray();
-            var nextPageLink =
-                links.FirstOrDefault(link => link.Contains("rel=\"next\""));
-            var previousPageLink = 
-                links.FirstOrDefault(link => link.Contains("rel=\"previous\""));
-            var listResult = new ListResult<T>
-            {
-                Items = requestResult.Result
-            };
-
-            if (TryParsePageInfoFromLink(nextPageLink, out var parsedNextPageLink))
-            {
-                listResult.NextPageLink = parsedNextPageLink;
-            }
-            else
-            {
-                listResult.NextPageLink = null;
-            }
-            
-            if (TryParsePageInfoFromLink(previousPageLink, out var parsedPreviousPageLink))
-            {
-                listResult.PreviousPageLink = parsedPreviousPageLink;
-            }
-            else
-            {
-                listResult.PreviousPageLink = null;
-            }
-
-            return listResult;
+            return new ListResult<T>(requestResult.Result, requestResult.RawLinkHeaderValue == null ? null : LinkHeaderParser.Parse(requestResult.RawLinkHeaderValue));
         }
     }
 }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp
 {
     public abstract class ShopifyService
     {
-        public virtual string APIVersion => "2019-04";
+        public virtual string APIVersion => "2019-10";
 
         private static IRequestExecutionPolicy _GlobalExecutionPolicy = new DefaultRequestExecutionPolicy();
 


### PR DESCRIPTION
Link header parsing logic:
-Extracted link header parsing logic into its own class
-Added tests for link header parsing
-Handling extra cases such as the presence of commas in the link url when the 'fields' parameter is present