### PR TITLE
Strongly typed list filters

### DIFF
--- a/ShopifySharp.Tests/LinkHeaderParser_Tests.cs
+++ b/ShopifySharp.Tests/LinkHeaderParser_Tests.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_NextLinkOnly()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=\"next\"");
+            var res = LinkHeaderParser.Parse<Product>("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=\"next\"");
             Assert.Null(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.NextLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6");
@@ -26,7 +26,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevLinkOnly()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=\"previous\"");
+            var res = LinkHeaderParser.Parse<Product>("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6>; rel=\"previous\"");
             Assert.Null(res.NextLink);
             Assert.NotNull(res.PreviousLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=vwxyzab&limit=6");
@@ -36,7 +36,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=\"next\"");
+            var res = LinkHeaderParser.Parse<Product>("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=\"next\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
@@ -48,7 +48,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_NextThenPrev()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=\"next\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=\"previous\"");
+            var res = LinkHeaderParser.Parse<Product>("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>; rel=\"next\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>; rel=\"previous\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
@@ -60,7 +60,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext_WithExtraSpaces()
         {
-            var res = LinkHeaderParser.Parse("  <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>  ;  rel=\"previous\"  ,   <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>  ;  rel=\"next\"  ");
+            var res = LinkHeaderParser.Parse<Product>("  <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3>  ;  rel=\"previous\"  ,   <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3>  ;  rel=\"next\"  ");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3");
@@ -72,7 +72,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext_WithFieldsParam()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3&fields=id,images,title>; rel=\"next\"");
+            var res = LinkHeaderParser.Parse<Product>("<https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?page_info=opqrstu&limit=3&fields=id,images,title>; rel=\"next\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?page_info=abcdefg&limit=3&fields=id,images,title");
@@ -84,7 +84,7 @@ namespace ShopifySharp.Tests
         [Fact]
         public void Parse_PrevThenNext_PageInfoIsNotFirstQueryParam()
         {
-            var res = LinkHeaderParser.Parse("<https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=opqrstu>; rel=\"next\"");
+            var res = LinkHeaderParser.Parse<Product>("<https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg>; rel=\"previous\", <https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=opqrstu>; rel=\"next\"");
             Assert.NotNull(res.PreviousLink);
             Assert.NotNull(res.NextLink);
             Assert.Equal(res.PreviousLink.Url, "https://test.myshopify.com/admin/api/2019-07/products.json?limit=3&page_info=abcdefg");

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -3,6 +3,65 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="AccessScope_Tests.cs" />
+    <Compile Remove="ApplicationCredit_Tests.cs" />
+    <Compile Remove="Article_Tests.cs" />
+    <Compile Remove="Asset_Tests.cs" />
+    <Compile Remove="Authorization_Tests.cs" />
+    <Compile Remove="Blog_Tests.cs" />
+    <Compile Remove="Carrier_Tests.cs" />
+    <Compile Remove="Charge_Tests.cs" />
+    <Compile Remove="Checkout_Tests.cs" />
+    <Compile Remove="Collect_Tests.cs" />
+    <Compile Remove="CustomCollection_Tests.cs" />
+    <Compile Remove="CustomerAddress_Tests.cs" />
+    <Compile Remove="CustomerSavedSearch_Tests.cs" />
+    <Compile Remove="Customer_Tests.cs" />
+    <Compile Remove="DateTime_Tests.cs" />
+    <Compile Remove="DiscountCode_Tests.cs" />
+    <Compile Remove="DraftOrder_Tests.cs" />
+    <Compile Remove="Event_Tests.cs" />
+    <Compile Remove="FalseToNullConverter_Tests.cs" />
+    <Compile Remove="FulfillmentEvents_Tests .cs" />
+    <Compile Remove="FulfillmentService_Tests.cs" />
+    <Compile Remove="Fulfillment_Tests.cs" />
+    <Compile Remove="GdprEntities_Tests.cs" />
+    <Compile Remove="GiftCardAdjustment_Tests.cs" />
+    <Compile Remove="GiftCard_Tests.cs" />
+    <Compile Remove="InvalidDateToNullConverter_Tests.cs" />
+    <Compile Remove="InventoryItem_Tests.cs" />
+    <Compile Remove="InventoryLevel_Tests.cs" />
+    <Compile Remove="Location_Tests.cs" />
+    <Compile Remove="MetaField_Tests.cs" />
+    <Compile Remove="OrderRisk_Tests.cs" />
+    <Compile Remove="Order_Tests.cs" />
+    <Compile Remove="Page_Tests.cs" />
+    <Compile Remove="Policy_Tests.cs" />
+    <Compile Remove="PriceRule_Tests.cs" />
+    <Compile Remove="ProductImage_Tests.cs" />
+    <Compile Remove="ProductVariant_Tests.cs" />
+    <Compile Remove="Product_Tests.cs" />
+    <Compile Remove="RecurringCharge_Tests.cs" />
+    <Compile Remove="Redirect_Tests.cs" />
+    <Compile Remove="Refund_Tests.cs" />
+    <Compile Remove="ScriptTag_Tests.cs" />
+    <Compile Remove="ShippingZone_Tests.cs" />
+    <Compile Remove="ShopifyException_Tests.cs" />
+    <Compile Remove="ShopifyPayments_Tests.cs" />
+    <Compile Remove="ShopifyService_Tests.cs" />
+    <Compile Remove="Shop_Tests.cs" />
+    <Compile Remove="SmartCollection_Tests.cs" />
+    <Compile Remove="Theme_Tests.cs" />
+    <Compile Remove="Transaction_Tests.cs" />
+    <Compile Remove="UsageCharge_Tests.cs" />
+    <Compile Remove="User_Tests.cs" />
+    <Compile Remove="Utils.cs" />
+    <Compile Remove="Webhook_Tests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="env.yml.secret" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="dotenvfile" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -3,65 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="AccessScope_Tests.cs" />
-    <Compile Remove="ApplicationCredit_Tests.cs" />
-    <Compile Remove="Article_Tests.cs" />
-    <Compile Remove="Asset_Tests.cs" />
-    <Compile Remove="Authorization_Tests.cs" />
-    <Compile Remove="Blog_Tests.cs" />
-    <Compile Remove="Carrier_Tests.cs" />
-    <Compile Remove="Charge_Tests.cs" />
-    <Compile Remove="Checkout_Tests.cs" />
-    <Compile Remove="Collect_Tests.cs" />
-    <Compile Remove="CustomCollection_Tests.cs" />
-    <Compile Remove="CustomerAddress_Tests.cs" />
-    <Compile Remove="CustomerSavedSearch_Tests.cs" />
-    <Compile Remove="Customer_Tests.cs" />
-    <Compile Remove="DateTime_Tests.cs" />
-    <Compile Remove="DiscountCode_Tests.cs" />
-    <Compile Remove="DraftOrder_Tests.cs" />
-    <Compile Remove="Event_Tests.cs" />
-    <Compile Remove="FalseToNullConverter_Tests.cs" />
-    <Compile Remove="FulfillmentEvents_Tests .cs" />
-    <Compile Remove="FulfillmentService_Tests.cs" />
-    <Compile Remove="Fulfillment_Tests.cs" />
-    <Compile Remove="GdprEntities_Tests.cs" />
-    <Compile Remove="GiftCardAdjustment_Tests.cs" />
-    <Compile Remove="GiftCard_Tests.cs" />
-    <Compile Remove="InvalidDateToNullConverter_Tests.cs" />
-    <Compile Remove="InventoryItem_Tests.cs" />
-    <Compile Remove="InventoryLevel_Tests.cs" />
-    <Compile Remove="Location_Tests.cs" />
-    <Compile Remove="MetaField_Tests.cs" />
-    <Compile Remove="OrderRisk_Tests.cs" />
-    <Compile Remove="Order_Tests.cs" />
-    <Compile Remove="Page_Tests.cs" />
-    <Compile Remove="Policy_Tests.cs" />
-    <Compile Remove="PriceRule_Tests.cs" />
-    <Compile Remove="ProductImage_Tests.cs" />
-    <Compile Remove="ProductVariant_Tests.cs" />
-    <Compile Remove="Product_Tests.cs" />
-    <Compile Remove="RecurringCharge_Tests.cs" />
-    <Compile Remove="Redirect_Tests.cs" />
-    <Compile Remove="Refund_Tests.cs" />
-    <Compile Remove="ScriptTag_Tests.cs" />
-    <Compile Remove="ShippingZone_Tests.cs" />
-    <Compile Remove="ShopifyException_Tests.cs" />
-    <Compile Remove="ShopifyPayments_Tests.cs" />
-    <Compile Remove="ShopifyService_Tests.cs" />
-    <Compile Remove="Shop_Tests.cs" />
-    <Compile Remove="SmartCollection_Tests.cs" />
-    <Compile Remove="Theme_Tests.cs" />
-    <Compile Remove="Transaction_Tests.cs" />
-    <Compile Remove="UsageCharge_Tests.cs" />
-    <Compile Remove="User_Tests.cs" />
-    <Compile Remove="Utils.cs" />
-    <Compile Remove="Webhook_Tests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="env.yml.secret" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="dotenvfile" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/ShopifySharp/Filters/ApplicationCreditListFilter.cs
+++ b/ShopifySharp/Filters/ApplicationCreditListFilter.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace ShopifySharp.Filters
 {
-    public class ApplicationCreditListFilter : ListFilter
+    public class ApplicationCreditListFilter : ListFilter<ApplicationCredit>
     {
         public string Fields { get; set; }
 

--- a/ShopifySharp/Filters/ArticleListFilter.cs
+++ b/ShopifySharp/Filters/ArticleListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering the results of listing articles.
     /// </summary>
-    public class ArticleListFilter : ListFilter
+    public class ArticleListFilter : ListFilter<Article>
     {
         /// <summary>
         /// Filter the results to this article handle.

--- a/ShopifySharp/Filters/BlogListFilter.cs
+++ b/ShopifySharp/Filters/BlogListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class BlogListFilter : ListFilter
+    public class BlogListFilter : ListFilter<Blog>
     {
         [JsonProperty("handle")]
         public string Handle { get; set; }

--- a/ShopifySharp/Filters/CheckoutFilter.cs
+++ b/ShopifySharp/Filters/CheckoutFilter.cs
@@ -6,7 +6,7 @@ namespace ShopifySharp.Filters
     /// Options for filtering <see cref="CheckoutService.CountAsync(CheckoutFilter)"/> and 
     /// <see cref="CheckoutService.ListAsync(CheckoutFilter)"/> results.
     /// </summary>
-    public class CheckoutFilter : ListFilter
+    public class CheckoutFilter : ListFilter<Checkout>
     {
         /// <summary>
         /// An optional, parameter to determine which carts to retrieve.

--- a/ShopifySharp/Filters/CollectFilter.cs
+++ b/ShopifySharp/Filters/CollectFilter.cs
@@ -5,7 +5,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering <see cref="CollectService.ListAsync(CollectFilter)"/> results.
     /// </summary>
-    public class CollectFilter : ListFilter
+    public class CollectFilter : ListFilter<Collect>
     {
         /// <summary>
         /// An optional product id to retrieve. 

--- a/ShopifySharp/Filters/CollectListFilter.cs
+++ b/ShopifySharp/Filters/CollectListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class CollectListFilter : ListFilter
+    public class CollectListFilter : ListFilter<Collect>
     {
         [JsonProperty("since_id")]
         public long? SinceId { get; set; }

--- a/ShopifySharp/Filters/CustomCollectionFilter.cs
+++ b/ShopifySharp/Filters/CustomCollectionFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering custom collection lists.
     /// </summary>
-    public class CustomCollectionFilter : ListFilter
+    public class CustomCollectionFilter : ListFilter<CustomCollection>
     {
         /// <summary>
         /// Show smart collections with given title 

--- a/ShopifySharp/Filters/CustomerListFilter.cs
+++ b/ShopifySharp/Filters/CustomerListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class CustomerListFilter : ListFilter
+    public class CustomerListFilter : ListFilter<Customer>
     {
         [JsonProperty("ids")]
         public IEnumerable<long> Ids { get; set; }

--- a/ShopifySharp/Filters/CustomerSavedSearchListFilter.cs
+++ b/ShopifySharp/Filters/CustomerSavedSearchListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class CustomerSavedSearchListFilter : ListFilter
+    public class CustomerSavedSearchListFilter : ListFilter<CustomerSavedSearch>
     {
         [JsonProperty("since_id")]
         public long? SinceId { get; set; }

--- a/ShopifySharp/Filters/DraftOrderListFilter.cs
+++ b/ShopifySharp/Filters/DraftOrderListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters 
 {
-    public class DraftOrderListFilter : ListFilter 
+    public class DraftOrderListFilter : ListFilter<DraftOrder>
     {
         /// <summary>
         /// Only return orders with the given status. Known values are "open" (default), "invoice_sent", and "completed".

--- a/ShopifySharp/Filters/EventListFilter.cs
+++ b/ShopifySharp/Filters/EventListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// A generic class for filtering the results of a .CountAsync command.
     /// </summary>
-    public class EventListFilter : ListFilter
+    public class EventListFilter : ListFilter<Event>
     {
         /// <summary>
         /// Restrict results to after the specified ID

--- a/ShopifySharp/Filters/FulfillmentListFilter.cs
+++ b/ShopifySharp/Filters/FulfillmentListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class FulfillmentListFilter : ListFilter
+    public class FulfillmentListFilter : ListFilter<Fulfillment>
     {
         [JsonProperty("since_id")]
         public long? SinceId { get; set; }

--- a/ShopifySharp/Filters/GiftCardFilter.cs
+++ b/ShopifySharp/Filters/GiftCardFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering gift cards. 
     /// </summary>
-    public class GiftCardFilter : ListFilter
+    public class GiftCardFilter : ListFilter<GiftCard>
     {
         /// <summary>
         /// The status of gift card to retrieve. Known values are "enabled", "disabled".

--- a/ShopifySharp/Filters/GiftCardSearchFilter.cs
+++ b/ShopifySharp/Filters/GiftCardSearchFilter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ShopifySharp.Filters
 {
-    public class GiftCardSearchFilter : ListFilter
+    public class GiftCardSearchFilter : ListFilter<GiftCard>
     {
         /// <summary>
         /// The field and direction to order results by.

--- a/ShopifySharp/Filters/IInventoryLevelFilter.cs
+++ b/ShopifySharp/Filters/IInventoryLevelFilter.cs
@@ -6,7 +6,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// You **must** include InventoryItemIds, LocationIds, or both as filter parameters.
     /// </summary>
-    public interface IInventoryLevelFilter : IListFilter
+    public interface IInventoryLevelFilter : IListFilter<InventoryLevel>
     {
         /// <summary>
         /// Ids of inventory items to retrieve

--- a/ShopifySharp/Filters/IListFilter.cs
+++ b/ShopifySharp/Filters/IListFilter.cs
@@ -3,17 +3,17 @@ using System.Collections.Generic;
 
 namespace ShopifySharp.Filters
 {
-    public interface IListFilter
+    public interface IListFilter<T>
     {
         /// <summary>
         /// A unique ID used to access a page of results. Must be present to list more than the first page of results. 
         /// </summary>
-        string PageInfo { get; set; }
+        string PageInfo { get; }
 
         /// <summary>
         /// The number of items which should be returned. Default is 50, maximum is 250.
         /// </summary>
-        int? Limit { get; set; }
+        int? Limit { get; }
 
         /// <summary>
         /// Converts the filter to a list of key/value pairs which can be turned into a querystring.

--- a/ShopifySharp/Filters/InventoryLevelFilter.cs
+++ b/ShopifySharp/Filters/InventoryLevelFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// You **must** include InventoryItemIds, LocationIds, or both as filter parameters.
     /// </summary>
-    public class InventoryLevelFilter : ListFilter, IInventoryLevelFilter
+    public class InventoryLevelFilter : ListFilter<InventoryLevel>, IInventoryLevelFilter
     {
         [JsonProperty("inventory_item_ids")]
         public IEnumerable<long> InventoryItemIds { get; set; }

--- a/ShopifySharp/Filters/ListFilter.cs
+++ b/ShopifySharp/Filters/ListFilter.cs
@@ -7,19 +7,29 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// A generic class for filtering the results of a .ListAsync command.
     /// </summary>
-    public class ListFilter : IListFilter
+    public class ListFilter<T> : IListFilter<T>
     {
         /// <summary>
         /// A unique ID used to access a page of results. Must be present to list more than the first page of results. 
         /// </summary>
         [JsonProperty("page_info")]
-        public string PageInfo { get; set; }
+        public string PageInfo { get; }
 
         /// <summary>
         /// The number of items which should be returned. Default is 50, maximum is 250.
         /// </summary>
         [JsonProperty("limit")]
         public int? Limit { get; set; }
+
+        internal ListFilter()
+        {
+        }
+
+        internal ListFilter(string pageInfo, int? limit)
+        {
+            PageInfo = pageInfo;
+            Limit = limit;
+        }
 
         public virtual IEnumerable<KeyValuePair<string, object>> ToQueryParameters()
         {

--- a/ShopifySharp/Filters/MetaFieldFilter.cs
+++ b/ShopifySharp/Filters/MetaFieldFilter.cs
@@ -8,7 +8,7 @@ namespace ShopifySharp.Filters
 	/// Options for filtering <see cref="MetaFieldService.CountAsync(long?, string, MetaFieldFilter)"/> and 
 	/// <see cref="MetaFieldService.ListAsync(long?, string, MetaFieldFilter)"/> results.
 	/// </summary>
-	public class MetaFieldFilter : ListFilter
+	public class MetaFieldFilter : ListFilter<MetaField>
 	{
 		/// <summary>
 		/// Filter by namespace.

--- a/ShopifySharp/Filters/OrderFilter.cs
+++ b/ShopifySharp/Filters/OrderFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of orders.
     /// </summary>
-    public class OrderFilter : ListFilter
+    public class OrderFilter : ListFilter<Order>
     {
         /// <summary>
         /// The status of orders to retrieve. Known values are "open", "closed", "cancelled" and "any".

--- a/ShopifySharp/Filters/PageListFilter.cs
+++ b/ShopifySharp/Filters/PageListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of Pages. 
     /// </summary>
-    public class PageListFilter : ListFilter
+    public class PageListFilter : ListFilter<Page>
     {
         /// <summary>
         /// Filter by page title.

--- a/ShopifySharp/Filters/PriceRuleListFilter.cs
+++ b/ShopifySharp/Filters/PriceRuleListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of PriceRules. 
     /// </summary>
-    public class PriceRuleListFilter : ListFilter
+    public class PriceRuleListFilter : ListFilter<PriceRule>
     {
         /// <summary>
         /// Restrict results to after the specified ID.

--- a/ShopifySharp/Filters/ProductListFilter.cs
+++ b/ShopifySharp/Filters/ProductListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of Products. 
     /// </summary>
-    public class ProductListFilter : ListFilter
+    public class ProductListFilter : ListFilter<Product>
     {
         /// <summary>
         /// Restrict results to after the specified ID.

--- a/ShopifySharp/Filters/ProductVariantListFilter.cs
+++ b/ShopifySharp/Filters/ProductVariantListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of Product Variants. 
     /// </summary>
-    public class ProductVariantListFilter : ListFilter
+    public class ProductVariantListFilter : ListFilter<ProductVariant>
     {
         /// <summary>
         /// Restrict results to after the specified ID.

--- a/ShopifySharp/Filters/RedirectListFilter.cs
+++ b/ShopifySharp/Filters/RedirectListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of Redirects.
     /// </summary>
-    public class RedirectListFilter : ListFilter
+    public class RedirectListFilter : ListFilter<Redirect>
     {
         /// <summary>
         /// An optional parameter that filters the result to redirects with the given path.

--- a/ShopifySharp/Filters/RefundListFilter.cs
+++ b/ShopifySharp/Filters/RefundListFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class RefundListFilter : ListFilter
+    public class RefundListFilter : ListFilter<Refund>
     {
         /// <summary>
         /// Retrieve only certain fields, specified by a comma-separated list of field names. 

--- a/ShopifySharp/Filters/ScriptTagListFilter.cs
+++ b/ShopifySharp/Filters/ScriptTagListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of Script Tags.
     /// </summary>
-    public class ScriptTagListFilter : ListFilter
+    public class ScriptTagListFilter : ListFilter<ScriptTag>
     {
         /// <summary>
         /// Returns only those with the given src value.

--- a/ShopifySharp/Filters/ShopifyPaymentsDisputeListFilter.cs
+++ b/ShopifySharp/Filters/ShopifyPaymentsDisputeListFilter.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ShopifySharp.Filters 
 {
-    public class ShopifyPaymentsDisputeListFilter : ListFilter
+    public class ShopifyPaymentsDisputeListFilter : ListFilter<ShopifyPaymentsDispute>
     {
         /// <summary>
         /// Return only disputes before the specified ID.

--- a/ShopifySharp/Filters/ShopifyPaymentsPayoutFilter.cs
+++ b/ShopifySharp/Filters/ShopifyPaymentsPayoutFilter.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace ShopifySharp.Filters 
 {
-    public class ShopifyPaymentsPayoutFilter : ListFilter
+    public class ShopifyPaymentsPayoutFilter : ListFilter<ShopifyPaymentsPayout>
     {
         /// <summary>
         /// Filter response to payouts exclusively before the specified ID

--- a/ShopifySharp/Filters/ShopifyPaymentsTransactionListFilter.cs
+++ b/ShopifySharp/Filters/ShopifyPaymentsTransactionListFilter.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ShopifySharp.Filters 
 {
-    public class ShopifyPaymentsTransactionListFilter : ListFilter
+    public class ShopifyPaymentsTransactionListFilter : ListFilter<ShopifyPaymentsTransaction>
     {
         /// <summary>
         /// Filter response to transactions exclusively before the specified ID

--- a/ShopifySharp/Filters/SmartCollectionListFilter.cs
+++ b/ShopifySharp/Filters/SmartCollectionListFilter.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering lists of Smart Collections.
     /// </summary>
-    public class SmartCollectionListFilter : ListFilter
+    public class SmartCollectionListFilter : ListFilter<SmartCollection>
     {
         /// <summary>
         /// Restrict results to after the specified ID.

--- a/ShopifySharp/Filters/WebhookFilter.cs
+++ b/ShopifySharp/Filters/WebhookFilter.cs
@@ -6,7 +6,7 @@ namespace ShopifySharp.Filters
     /// <summary>
     /// Options for filtering <see cref="WebhookService.ListAsync(WebhookFilter)" /> results.
     /// </summary>
-    public class WebhookFilter : ListFilter
+    public class WebhookFilter : ListFilter<Webhook>
     {
         /// <summary>
         /// An optional filter for the address property. When used, the method will only return webhooks with the given address.

--- a/ShopifySharp/Lists/IListResult.cs
+++ b/ShopifySharp/Lists/IListResult.cs
@@ -5,7 +5,7 @@ namespace ShopifySharp.Lists
 {
     public interface IListResult<T>
     {
-        LinkHeaderParseResult LinkHeader { get; }
+        LinkHeaderParseResult<T> LinkHeader { get; }
 
         IEnumerable<T> Items { get; }
     }

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -11,18 +11,18 @@ namespace ShopifySharp.Lists
         private static Regex _regexPrevLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=""previous""", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static Regex _regexNextLink = new Regex(@"<(https://[^>]*)>\s*;\s*rel=""next""", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-        public static LinkHeaderParseResult Parse(string linkHeaderValue)
+        public static LinkHeaderParseResult<T> Parse<T>(string linkHeaderValue)
         {
-            var prevLink = GetPageInfoParam(linkHeaderValue, _regexPrevLink);
-            var nextLink = GetPageInfoParam(linkHeaderValue, _regexNextLink);
+            var prevLink = GetPageInfoParam<T>(linkHeaderValue, _regexPrevLink);
+            var nextLink = GetPageInfoParam<T>(linkHeaderValue, _regexNextLink);
 
             if (prevLink == null && nextLink == null)
                 throw new ShopifyException($"Found neither a 'previous' or 'next' url in the link header: '{linkHeaderValue}'");
 
-            return new LinkHeaderParseResult(prevLink, nextLink);
+            return new LinkHeaderParseResult<T>(prevLink, nextLink);
         }
 
-        private static LinkHeaderParseResult.PagingLink GetPageInfoParam(string linkHeaderValue, Regex linkRegex)
+        private static LinkHeaderParseResult<T>.PagingLink<T> GetPageInfoParam<T>(string linkHeaderValue, Regex linkRegex)
         {
             var match = linkRegex.Match(linkHeaderValue);
 
@@ -40,7 +40,7 @@ namespace ShopifySharp.Lists
             if (pageInfo == null)
                 throw new ShopifyException($"Cannot parse page link's page info parameter: '{matchedUrl}'");
 
-            return new LinkHeaderParseResult.PagingLink(matchedUrl, pageInfo);
+            return new LinkHeaderParseResult<T>.PagingLink<T>(matchedUrl, pageInfo);
         }
     }
 }

--- a/ShopifySharp/Lists/LinkHeaderParserResult.cs
+++ b/ShopifySharp/Lists/LinkHeaderParserResult.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿using ShopifySharp.Filters;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace ShopifySharp.Lists
 {
-    public class LinkHeaderParseResult
+    public class LinkHeaderParseResult<T>
     {
-        public class PagingLink
+        public class PagingLink<T>
         {
             public string Url { get; }
 
@@ -17,13 +18,18 @@ namespace ShopifySharp.Lists
                 Url = url;
                 PageInfo = pageInfo;
             }
+
+            public ListFilter<T> GetFollowingPageFilter(int? limit = null)
+            {
+                return new ListFilter<T>(this.PageInfo, limit);
+            }
         }
 
-        public PagingLink PreviousLink { get; }
+        public PagingLink<T> PreviousLink { get; }
 
-        public PagingLink NextLink { get; }
+        public PagingLink<T> NextLink { get; }
 
-        public LinkHeaderParseResult(PagingLink previousLink, PagingLink nextLink)
+        public LinkHeaderParseResult(PagingLink<T> previousLink, PagingLink<T> nextLink)
         {
             PreviousLink = previousLink;
             NextLink = nextLink;

--- a/ShopifySharp/Lists/ListResult.cs
+++ b/ShopifySharp/Lists/ListResult.cs
@@ -8,9 +8,9 @@ namespace ShopifySharp.Lists
     {
         public IEnumerable<T> Items { get; }
 
-        public LinkHeaderParseResult LinkHeader { get; }
+        public LinkHeaderParseResult<T> LinkHeader { get; }
 
-        public ListResult(IEnumerable<T> items, LinkHeaderParseResult linkHeader)
+        public ListResult(IEnumerable<T> items, LinkHeaderParseResult<T> linkHeader)
         {
             Items = items;
             LinkHeader = linkHeader;

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of all past and present application credits.
         /// </summary>
-        public virtual async Task<IListResult<ApplicationCredit>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<ApplicationCredit>> ListAsync(IListFilter<ApplicationCredit> filter)
         {
             var req = PrepareRequest($"application_credits.json");
 
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<ApplicationCredit>> ListAsync(ApplicationCreditListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<ApplicationCredit>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 articles belonging to the given blog.
         /// </summary>
-        public virtual async Task<IListResult<Article>> ListAsync(long blogId, IListFilter filter)
+        public virtual async Task<IListResult<Article>> ListAsync(long blogId, IListFilter<Article> filter)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles.json");
 
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Article>> ListAsync(int blogId, ArticleListFilter filter)
         {
-            return await ListAsync(blogId, (IListFilter) filter);
+            return await ListAsync(blogId, (IListFilter<Article>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 blogs belonging to the store.
         /// </summary>
-        public virtual async Task<IListResult<Blog>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Blog>> ListAsync(IListFilter<Blog> filter)
         {
             var request = PrepareRequest("blogs.json");
 
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Blog>> ListAsync(BlogListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Blog>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's collects.
         /// </summary>
-        public virtual async Task<IListResult<Collect>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Collect>> ListAsync(IListFilter<Collect> filter)
         {
             var req = PrepareRequest("collects.json");
 
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Collect>> ListAsync(CollectListFilter filter)
         {
-            return await ListAsync((IListFilter)filter);
+            return await ListAsync((IListFilter<Collect>)filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 custom collections.
         /// </summary>
-        public virtual async Task<IListResult<CustomCollection>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<CustomCollection>> ListAsync(IListFilter<CustomCollection> filter)
         {
             var req = PrepareRequest("custom_collections.json");
             
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<CustomCollection>> ListAsync(CustomCollectionFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<CustomCollection>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's customers.
         /// </summary>
-        public virtual async Task<IListResult<Customer>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Customer>> ListAsync(IListFilter<Customer> filter)
         {
             var req = PrepareRequest("customers.json");
             
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Customer>> ListAsync(CustomerListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Customer>) filter);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace ShopifySharp
         /// <param name="order">An (unencoded) optional string to order the results, in format of 'field_name DESC'. Default is 'last_order_date DESC'.</param>
         /// <param name="filter">Options for filtering the results.</param>
         /// <returns>A list of matching customers.</returns>
-        public virtual async Task<IEnumerable<Customer>> SearchAsync(string query, string order = null, ListFilter filter = null)
+        public virtual async Task<IEnumerable<Customer>> SearchAsync(string query, string order = null, ListFilter<Customer> filter = null)
         {
             throw new NotImplementedException();
             // var req = PrepareRequest("customers/search.json");

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop customer's addresses.
         /// </summary>
         /// <param name="customerId">The id of the customer to retrieve.</param>
-        public virtual async Task<IListResult<Address>> ListAsync(long customerId, IListFilter filter)
+        public virtual async Task<IListResult<Address>> ListAsync(long customerId, IListFilter<Address> filter)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses.json");
             

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's customer saved searches.
         /// </summary>
-        public virtual async Task<IListResult<CustomerSavedSearch>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<CustomerSavedSearch>> ListAsync(IListFilter<CustomerSavedSearch> filter)
         {
             var req = PrepareRequest($"{RootResource}.json");
             
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<CustomerSavedSearch>> ListAsync(CustomerSavedSearchListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<CustomerSavedSearch>) filter);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace ShopifySharp
         /// <param name="sinceId">Restricts results to after a given id.</param>
         /// <param name="filter">Options for filtering the results.</param>
         /// <returns>A list of matching customers.</returns>
-        public virtual Task<List<CustomerSavedSearch>> SearchAsync(string query, string sinceId = null, ListFilter filter = null)
+        public virtual Task<List<CustomerSavedSearch>> SearchAsync(string query, string sinceId = null, ListFilter<CustomerSavedSearch> filter = null)
         {
             throw new NotImplementedException();
             // var req = PrepareRequest($"{RootResource}.json");
@@ -164,7 +164,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSavedSearchId">Id of the Customer Saved Search</param>
         /// <returns></returns>
-        public Task<List<Customer>> GetCustomersFromSavedSearch(long customerSavedSearchId, string query = null, ListFilter filter = null)
+        public Task<List<Customer>> GetCustomersFromSavedSearch(long customerSavedSearchId, string query = null, ListFilter<Customer> filter = null)
         {
             throw new NotImplementedException();
             // var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}/customers.json");

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the discount codes belonging to the price rule.
         /// </summary>
-        public virtual async Task<IListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, IListFilter filter)
+        public virtual async Task<IListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, IListFilter<PriceRuleDiscountCode> filter)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes.json");
 

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's draft orders.
         /// </summary>
-        public virtual async Task<IListResult<DraftOrder>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<DraftOrder>> ListAsync(IListFilter<DraftOrder> filter)
         {
             var req = PrepareRequest("draft_orders.json");
             
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<DraftOrder>> ListAsync(DraftOrderListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<DraftOrder>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Event/EventService.cs
+++ b/ShopifySharp/Services/Event/EventService.cs
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="subjectId">Restricts results to just one subject item, e.g. all changes on a product.</param>
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
-        public virtual async Task<IListResult<Event>> ListAsync(long subjectId, string subjectType, IListFilter filter)
+        public virtual async Task<IListResult<Event>> ListAsync(long subjectId, string subjectType, IListFilter<Event> filter)
         {
             // Ensure the subject type is plural
             if (!subjectType.Substring(subjectType.Length - 1).Equals("s", System.StringComparison.OrdinalIgnoreCase))
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// <summary>
         /// Returns a list of events.
         /// </summary>
-        public virtual async Task<IListResult<Event>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Event>> ListAsync(IListFilter<Event> filter)
         {
             var req = PrepareRequest("events.json");
             
@@ -109,7 +109,7 @@ namespace ShopifySharp
         public virtual async Task<IListResult<Event>> ListAsync(long subjectId, string subjectType,
             EventListFilter filter)
         {
-            return await ListAsync(subjectId, subjectType, (IListFilter) filter);
+            return await ListAsync(subjectId, subjectType, (IListFilter<Event>) filter);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Event>> ListAsync(EventListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Event>) filter);
         }
     }
 }

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<IListResult<Fulfillment>> ListAsync(long orderId, IListFilter filter)
+        public virtual async Task<IListResult<Fulfillment>> ListAsync(long orderId, IListFilter<Fulfillment> filter)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments.json");
             
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<IListResult<Fulfillment>> ListAsync(long orderId, FulfillmentListFilter filter)
         {
-            return await ListAsync(orderId, (IListFilter) filter);
+            return await ListAsync(orderId, (IListFilter<Fulfillment>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the gift cards.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<IListResult<GiftCard>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<GiftCard>> ListAsync(IListFilter<GiftCard> filter)
         {
             var req = PrepareRequest("gift_cards.json");
             
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<IListResult<GiftCard>> ListAsync(GiftCardFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<GiftCard>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// Gets a list of inventory items.
         /// </summary>
         /// <param name="ids">Show only inventory items specified by a list of IDs. Maximum: 100.</param>
-        public virtual async Task<IListResult<InventoryItem>> ListAsync(IEnumerable<long> ids, IListFilter filter)
+        public virtual async Task<IListResult<InventoryItem>> ListAsync(IEnumerable<long> ids, IListFilter<InventoryItem> filter)
         {
             var req = PrepareRequest($"inventory_items.json");
 

--- a/ShopifySharp/Services/Location/LocationService.cs
+++ b/ShopifySharp/Services/Location/LocationService.cs
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// Retrieves a list of all <see cref="Location"/> objects.
         /// </summary>
         /// <returns>The list of <see cref="Location"/> objects.</returns>
-        public virtual async Task<IEnumerable<Location>> ListAsync(IListFilter filter)
+        public virtual async Task<IEnumerable<Location>> ListAsync(IListFilter<Location> filter)
         {
             var req = PrepareRequest($"locations.json");
             var response = await ExecuteRequestAsync<List<Location>>(req, HttpMethod.Get, rootElement: "locations");

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -67,7 +67,7 @@ namespace ShopifySharp
             return await _CountAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields/count.json", filter);
         }
 
-        private async Task<IListResult<MetaField>> _ListAsync(string path, IListFilter filter)
+        private async Task<IListResult<MetaField>> _ListAsync(string path, IListFilter<MetaField> filter)
         {
             var req = PrepareRequest(path);
 
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// Gets a list of the metafields for the shop itself.
         /// </summary>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<IListResult<MetaField>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<MetaField>> ListAsync(IListFilter<MetaField> filter)
         {
             return await _ListAsync("metafields.json", filter);
         }
@@ -96,7 +96,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<IListResult<MetaField>> ListAsync(long resourceId, string resourceType, IListFilter filter)
+        public virtual async Task<IListResult<MetaField>> ListAsync(long resourceId, string resourceType, IListFilter<MetaField> filter)
         {
             return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter);
         }
@@ -109,7 +109,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<IListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, IListFilter filter)
+        public virtual async Task<IListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, IListFilter<MetaField> filter)
         {
             return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter);
         }

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
         /// <returns>The list of orders matching the filter.</returns>
-        public virtual async Task<IListResult<Order>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Order>> ListAsync(IListFilter<Order> filter)
         {
             var req = PrepareRequest("orders.json");
 
@@ -65,7 +65,7 @@ namespace ShopifySharp
         /// <returns>The list of orders matching the filter.</returns>
         public virtual async Task<IListResult<Order>> ListAsync(OrderFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Order>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risks belong to.</param>
         /// <param name="filter">Options for filtering the request.</param>
-        public virtual async Task<IListResult<OrderRisk>> ListAsync(long orderId, IListFilter filter)
+        public virtual async Task<IListResult<OrderRisk>> ListAsync(long orderId, IListFilter<OrderRisk> filter)
         {
             var req = PrepareRequest($"orders/{orderId}/risks.json");
 

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's pages.
         /// </summary>
-        public virtual async Task<IListResult<Page>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Page>> ListAsync(IListFilter<Page> filter)
         {
             var req = PrepareRequest("pages.json");
             
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Page>> ListAsync(PageListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Page>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's price rules.
         /// </summary>
-        public virtual async Task<IListResult<PriceRule>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<PriceRule>> ListAsync(IListFilter<PriceRule> filter)
         {
             var req = PrepareRequest("price_rules.json");
             
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<PriceRule>> ListAsync(PriceRuleListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<PriceRule>) filter);
         }
         
         // /// <summary>

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's products.
         /// </summary>
-        public virtual async Task<IListResult<Product>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Product>> ListAsync(IListFilter<Product> filter)
         {
             var req = PrepareRequest("products.json");
             
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Product>> ListAsync(ProductListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Product>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's ProductImages.
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
-        public virtual async Task<IListResult<ProductImage>> ListAsync(long productId, IListFilter filter)        
+        public virtual async Task<IListResult<ProductImage>> ListAsync(long productId, IListFilter<ProductImage> filter)        
         {
             var req = PrepareRequest($"products/{productId}/images.json");
 
@@ -65,7 +65,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         public virtual async Task<IListResult<ProductImage>> ListAsync(long productId, ProductListFilter filter)
         {
-            return await ListAsync(productId, (IListFilter) filter);
+            return await ListAsync(productId, (IListFilter<ProductImage>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// Gets a list of variants belonging to the given product.
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
-        public virtual async Task<IListResult<ProductVariant>> ListAsync(long productId, IListFilter filter)
+        public virtual async Task<IListResult<ProductVariant>> ListAsync(long productId, IListFilter<ProductVariant> filter)
         {
             var req = PrepareRequest($"products/{productId}/variants.json");
             
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <param name="productId">The product that the variants belong to.</param>
         public virtual async Task<IListResult<ProductVariant>> ListAsync(long productId, ProductVariantListFilter filter)
         {
-            return await ListAsync(productId, (IListFilter) filter);
+            return await ListAsync(productId, (IListFilter<ProductVariant>) filter);
         }
         
 

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's redirects.
         /// </summary>
-        public virtual async Task<IListResult<Redirect>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Redirect>> ListAsync(IListFilter<Redirect> filter)
         {
             var req = PrepareRequest("redirects.json");
             
@@ -68,7 +68,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<Redirect>> ListAsync(RedirectListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<Redirect>) filter);
         }
         
         /// <summary>

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// Retrieves a list of refunds for an order.
         /// </summary>
         /// <param name="orderId">The id of the order to list orders for.</param>
-        public virtual async Task<IListResult<Refund>> ListForOrderAsync(long orderId, IListFilter filter)
+        public virtual async Task<IListResult<Refund>> ListForOrderAsync(long orderId, IListFilter<Refund> filter)
         {
             var req = PrepareRequest($"orders/{orderId}/refunds.json");
             
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// <param name="orderId">The id of the order to list orders for.</param>
         public virtual async Task<IListResult<Refund>> ListForOrderAsync(long orderId, RefundListFilter filter)
         {
-            return await ListForOrderAsync(orderId, (IListFilter) filter);
+            return await ListForOrderAsync(orderId, (IListFilter<Refund>) filter);
         }
         
 

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's script tags.
         /// </summary>
-        public virtual async Task<IListResult<ScriptTag>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<ScriptTag>> ListAsync(IListFilter<ScriptTag> filter)
         {
             var req = PrepareRequest("script_tags.json");
             
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<ScriptTag>> ListAsync(ScriptTagListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<ScriptTag>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -73,7 +73,7 @@ namespace ShopifySharp
             return response.Result;
         }
 
-        public virtual async Task<IListResult<ShopifyPaymentsDispute>> ListDisputesAsync(IListFilter filter)
+        public virtual async Task<IListResult<ShopifyPaymentsDispute>> ListDisputesAsync(IListFilter<ShopifyPaymentsDispute> filter)
         {
             var req = PrepareRequest("shopify_payments/disputes.json");
             
@@ -89,7 +89,7 @@ namespace ShopifySharp
 
         public virtual async Task<IListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter)
         {
-            return await ListDisputesAsync((IListFilter) filter);
+            return await ListDisputesAsync((IListFilter<ShopifyPaymentsDispute>) filter);
         }
 
         public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId)
@@ -100,7 +100,7 @@ namespace ShopifySharp
             return response.Result;
         }
 
-        public virtual async Task<IListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(IListFilter filter)
+        public virtual async Task<IListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(IListFilter<ShopifyPaymentsTransaction> filter)
         {
             var req = PrepareRequest("shopify_payments/balance/transactions.json");
             
@@ -116,7 +116,7 @@ namespace ShopifySharp
 
         public virtual async Task<IListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter)
         {
-            return await ListTransactionsAsync((IListFilter) filter);
+            return await ListTransactionsAsync((IListFilter<ShopifyPaymentsTransaction>) filter);
         }
     }
 }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -130,7 +130,7 @@ namespace ShopifySharp
         /// <remarks>
         /// The Link header only exists on list requests. 
         /// </remarks>
-        protected string ReadLinkHeader(HttpResponseMessage response)
+        private string ReadLinkHeader(HttpResponseMessage response)
         {
             var header = response.Headers.FirstOrDefault(h => h.Key.Equals("link", StringComparison.OrdinalIgnoreCase));
             var headerValue = String.Join(", ", header.Value);
@@ -221,7 +221,7 @@ namespace ShopifySharp
         /// Checks a response for exceptions or invalid status codes. Throws an exception when necessary.
         /// </summary>
         /// <param name="response">The response.</param>
-        public static void CheckResponseExceptions(HttpResponseMessage response, string rawResponse)
+        internal static void CheckResponseExceptions(HttpResponseMessage response, string rawResponse)
         {
             int statusCode = (int)response.StatusCode;
 
@@ -299,7 +299,7 @@ namespace ShopifySharp
         /// Parses a JSON string for Shopify API errors.
         /// </summary>
         /// <returns>Returns null if the JSON could not be parsed into an error.</returns>
-        public static Dictionary<string, IEnumerable<string>> ParseErrorJson(string json)
+        private static Dictionary<string, IEnumerable<string>> ParseErrorJson(string json)
         {
             if (string.IsNullOrEmpty(json))
             {
@@ -380,9 +380,9 @@ namespace ShopifySharp
         /// <summary>
         /// Parses a link header value into a ListResult<T>. The Items property will need to be manually set. 
         /// </summary>
-        public IListResult<T> ParseLinkHeaderToListResult<T>(RequestResult<List<T>> requestResult)
+        protected IListResult<T> ParseLinkHeaderToListResult<T>(RequestResult<List<T>> requestResult)
         {
-            return new ListResult<T>(requestResult.Result, requestResult.RawLinkHeaderValue == null ? null : LinkHeaderParser.Parse(requestResult.RawLinkHeaderValue));
+            return new ListResult<T>(requestResult.Result, requestResult.RawLinkHeaderValue == null ? null : LinkHeaderParser.Parse<T>(requestResult.RawLinkHeaderValue));
         }
     }
 }

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 smart collections.
         /// </summary>
-        public virtual async Task<IListResult<SmartCollection>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<SmartCollection>> ListAsync(IListFilter<SmartCollection> filter)
         {
             var req = PrepareRequest($"smart_collections.json");
             
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IListResult<SmartCollection>> ListAsync(SmartCollectionListFilter filter)
         {
-            return await ListAsync((IListFilter) filter);
+            return await ListAsync((IListFilter<SmartCollection>) filter);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -23,7 +23,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's themes.
         /// </summary>
         /// <returns></returns>
-        public virtual async Task<IEnumerable<Theme>> ListAsync(IListFilter filter = null)
+        public virtual async Task<IEnumerable<Theme>> ListAsync(IListFilter<Theme> filter = null)
         {
             throw new Exception("not yet implemented");
             // var req = PrepareRequest("themes.json");

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <param name="recurringChargeId">The id of the recurring charge that these usage charges belong to.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The list of <see cref="UsageCharge"/> objects.</returns>
-        public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, IListFilter filter)
+        public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, IListFilter<UsageCharge> filter)
         {
             throw new Exception("not yet implemented");
             //

--- a/ShopifySharp/Services/User/UserService.cs
+++ b/ShopifySharp/Services/User/UserService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// Gets all the users
         /// </summary>
         /// <returns>The list of all users.</returns>
-        public virtual async Task<IEnumerable<User>> ListAsync(IListFilter filter)
+        public virtual async Task<IEnumerable<User>> ListAsync(IListFilter<User> filter)
         {
             throw new Exception("not yet implemented");
             // var req = PrepareRequest("users.json");

--- a/ShopifySharp/Services/Webhook/WebhookService.cs
+++ b/ShopifySharp/Services/Webhook/WebhookService.cs
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
         /// <returns>The list of webhooks matching the filter.</returns>
-        public virtual async Task<IListResult<Webhook>> ListAsync(IListFilter filter)
+        public virtual async Task<IListResult<Webhook>> ListAsync(IListFilter<Webhook> filter)
         {
             var req = PrepareRequest("webhooks.json");
             


### PR DESCRIPTION
Made list filters strongly typed so that a cursor for Entity 1 cannot be used to page through Entity 2.
E.g. a cursor for Customer paging shouldn't be usable for Order paging.

Also made `ListFilter `ctor internal.
`ListFilter `can be obtained by calling `result.LinkHeader.NextLink.GetFollowingPageFilter()`