### PR TITLE
Fixing Fields property encoding

### DIFF
--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -38,11 +38,12 @@ namespace ShopifySharp.Lists
                 throw new ShopifyException($"Cannot parse page link url: '{matchedUrl}'");
             }
 
-            string GetQueryParam(string name)
-            {
-                return uri.Query.Split('?', '&')
-                                .FirstOrDefault(p => p.StartsWith($"{name}="))
-                                ?.Substring($"{name}=".Length);
+            var uriQuery = Uri.UnescapeDataString(uri.Query);
+
+            string GetQueryParam (string name) {
+                return uriQuery.Split ('?', '&')
+                    .FirstOrDefault (p => p.StartsWith ($"{name}=")) ?
+                    .Substring ($"{name}=".Length);
             }
 
             string pageInfo = GetQueryParam("page_info");
@@ -55,10 +56,6 @@ namespace ShopifySharp.Lists
 
             int.TryParse(GetQueryParam("limit"), out int limit);
             
-            if (fields != null)
-            {
-                fields = fields.Replace("%2C", ",");
-            }
 
             return new LinkHeaderParseResult<T>.PagingLink<T>(matchedUrl, pageInfo, limit != 0 ? (int?)limit : null, fields ?? null);
         }

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -54,6 +54,11 @@ namespace ShopifySharp.Lists
             }
 
             int.TryParse(GetQueryParam("limit"), out int limit);
+            
+            if (fields != null)
+            {
+                fields = fields.Replace("%2C", ",");
+            }
 
             return new LinkHeaderParseResult<T>.PagingLink<T>(matchedUrl, pageInfo, limit != 0 ? (int?)limit : null, fields ?? null);
         }

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -38,12 +38,12 @@ namespace ShopifySharp.Lists
                 throw new ShopifyException($"Cannot parse page link url: '{matchedUrl}'");
             }
 
-            var uriQuery = Uri.UnescapeDataString(uri.Query);
+            var decodedUriQuery = Uri.UnescapeDataString(uri.Query);
 
-            string GetQueryParam (string name) {
-                return uriQuery.Split ('?', '&')
-                    .FirstOrDefault (p => p.StartsWith ($"{name}=")) ?
-                    .Substring ($"{name}=".Length);
+            string GetQueryParam(string name) {
+                return decodedUriQuery.Split('?', '&')
+                    .FirstOrDefault(p => p.StartsWith($"{name}="))
+                    ?.Substring ($"{name}=".Length);
             }
 
             string pageInfo = GetQueryParam("page_info");


### PR DESCRIPTION
Fix to fields encoding issue mentioned in:
[https://github.com/nozzlegear/ShopifySharp/issues/380#issuecomment-594217876](https://github.com/nozzlegear/ShopifySharp/issues/380#issuecomment-594217876)

Fields query parameter returned from Shopify has "," character changed to "%2C". As a result of this all object properties are null when using next or previous links.