### PR TITLE
Introduce Cancellation Token support across all public service APIs.  (Resolves #238)

### DIFF
--- a/ShopifySharp.Experimental/ApplicationCredit.fs
+++ b/ShopifySharp.Experimental/ApplicationCredit.fs
@@ -1,6 +1,7 @@
 ﻿namespace ShopifySharp.Experimental
 
 open System.Net.Http
+open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -62,7 +63,7 @@ module ApplicationCredits =
             let req = base.PrepareRequest "application_credits.json"
             let data = dict [ "application_credit" => data ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, content, "usage_charge")
+            base.ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, CancellationToken.None, content, "usage_charge")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Experimental/Charges.fs
+++ b/ShopifySharp.Experimental/Charges.fs
@@ -1,6 +1,7 @@
 ﻿namespace ShopifySharp.Experimental
 
 open System.Net.Http
+open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -63,7 +64,7 @@ module Charges =
             let req = base.PrepareRequest "application_charges.json"
             let data = dict [ "application_charge" => data ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<Charge>(req, HttpMethod.Post, content, "application_charge")
+            base.ExecuteRequestAsync<Charge>(req, HttpMethod.Post, CancellationToken.None, content, "application_charge")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Experimental/Orders.fs
+++ b/ShopifySharp.Experimental/Orders.fs
@@ -2,6 +2,9 @@
 
 open System.Collections.Generic
 open System.Net.Http
+open System.Threading
+open System.Threading
+open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -274,21 +277,21 @@ module Orders =
             let req = base.PrepareRequest "orders.json"
             let data = dict [ "order" => order ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, content, "order")
+            base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, CancellationToken.None, content, "order")
             |> mapTask (fun response -> response.Result)
             
         member x.CreateAsync(order: OrderProperties, options: CreationOptions.CreationOptionProperties) =
             let req = base.PrepareRequest "orders.json"
             let data = dict [ "order", mergeOrderAndCreationOptions order options |> JsonValue.MapPropertyValuesToObjects ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, content, "order")
+            base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, CancellationToken.None, content, "order")
             |> mapTask (fun response -> response.Result)
             
         member x.UpdateAsync (id: int64, order: OrderProperties) =
             let req = base.PrepareRequest (sprintf "orders/%i.json" id)
             let data = dict [ "order" => order ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<Order>(req, HttpMethod.Put, content, "order")
+            base.ExecuteRequestAsync<Order>(req, HttpMethod.Put, CancellationToken.None, content, "order")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Experimental/RecurringCharges.fs
+++ b/ShopifySharp.Experimental/RecurringCharges.fs
@@ -1,6 +1,7 @@
 ﻿namespace ShopifySharp.Experimental
 
 open System.Net.Http
+open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -75,7 +76,7 @@ module RecurringCharges =
             let req = base.PrepareRequest "recurring_application_charges.json"
             let data = dict [ "recurring_application_charge" => data ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<RecurringCharge>(req, HttpMethod.Post, content, "recurring_application_charge")
+            base.ExecuteRequestAsync<RecurringCharge>(req, HttpMethod.Post, CancellationToken.None, content, "recurring_application_charge")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Experimental/ScriptTags.fs
+++ b/ShopifySharp.Experimental/ScriptTags.fs
@@ -1,6 +1,8 @@
 ﻿namespace ShopifySharp.Experimental
 
 open System.Net.Http
+open System.Threading
+open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -80,14 +82,14 @@ module ScriptTags =
             let req = base.PrepareRequest "script_tags.json"
             let data = dict [ "script_tag" => tag ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, content, "script_tag")
+            base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, CancellationToken.None, content, "script_tag")
             |> mapTask (fun response -> response.Result)
             
         member x.UpdateAsync (id : int64, tag : ScriptTagProperties) =
             let req = base.PrepareRequest (sprintf "script_tags/%i.json" id)
             let data = dict [ "script_tag" => tag ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, content, "script_tag")
+            base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, CancellationToken.None, content, "script_tag")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Experimental/UsageCharges.fs
+++ b/ShopifySharp.Experimental/UsageCharges.fs
@@ -1,6 +1,7 @@
 ﻿namespace ShopifySharp.Experimental
 
 open System.Net.Http
+open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -55,7 +56,7 @@ module UsageCharges =
             let req = base.PrepareRequest (sprintf "recurring_application_charges/%i/usage_charges.json" recurringChargeId)
             let data = dict [ "usage_charge" => data ]
             let content = new JsonContent(data)
-            base.ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, content, "usage_charge")
+            base.ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, CancellationToken.None, content, "usage_charge")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Experimental/Webhooks.fs
+++ b/ShopifySharp.Experimental/Webhooks.fs
@@ -1,6 +1,8 @@
 namespace ShopifySharp.Experimental
 
 open System.Net.Http
+open System.Threading
+open System.Threading
 open System.Threading.Tasks
 open ShopifySharp
 open ShopifySharp.Infrastructure
@@ -82,7 +84,7 @@ module Webhooks =
             let data = dict [ "webhook" => webhook ]
             let content = new JsonContent(data)
             
-            base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Post, content, "webhook")
+            base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Post, CancellationToken.None, content, "webhook")
             |> mapTask (fun response -> response.Result)
             
         member x.UpdateAsync (id: int64, webhook: WebhookProperties) =
@@ -90,7 +92,7 @@ module Webhooks =
             let data = dict [ "webhook" => webhook ]
             let content = new JsonContent(data)
             
-            base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Put, content, "webhook")
+            base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Put, CancellationToken.None, content, "webhook")
             |> mapTask (fun response -> response.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)

--- a/ShopifySharp.Tests/ExecuteRequestCancellation_Tests.cs
+++ b/ShopifySharp.Tests/ExecuteRequestCancellation_Tests.cs
@@ -38,12 +38,12 @@ namespace ShopifySharp.Tests
             
             public new Task<T> ExecutePostAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
             {
-                return base.ExecutePostAsync<T>(path, resultRootElt, jsonContent, cancellationToken);
+                return base.ExecutePostAsync<T>(path, resultRootElt, cancellationToken, jsonContent);
             }
 
             public new Task<T> ExecutePutAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
             {
-                return base.ExecutePutAsync<T>(path, resultRootElt, jsonContent, cancellationToken);
+                return base.ExecutePutAsync<T>(path, resultRootElt, cancellationToken, jsonContent);
             }
 
             public new Task ExecuteDeleteAsync(string path, CancellationToken cancellationToken)
@@ -53,7 +53,7 @@ namespace ShopifySharp.Tests
 
             public new Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method, HttpContent content = null, CancellationToken cancellationToken = default)
             {
-                return base.ExecuteRequestAsync(uri, method, content, cancellationToken);
+                return base.ExecuteRequestAsync(uri, method, cancellationToken, content);
             }
         }
 

--- a/ShopifySharp.Tests/ExecuteRequestCancellation_Tests.cs
+++ b/ShopifySharp.Tests/ExecuteRequestCancellation_Tests.cs
@@ -13,8 +13,7 @@ namespace ShopifySharp.Tests
     [Trait("Category", "ExecuteRequestCancellation")]
     public class ExecuteRequestCancellation_Tests
     {
-
-        public class TestService : ShopifyService
+        private class TestService : ShopifyService
         {
             public TestService() : base("someurl", "sometoken")
             {
@@ -169,7 +168,7 @@ namespace ShopifySharp.Tests
             });
         }
         
-        private OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+        private static OrderService OrderService => new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
 
         [Fact]
         public async Task Cancelling_An_OrderService_List_Terminates_HttpRequest()

--- a/ShopifySharp.Tests/ExecuteRequestCancellation_Tests.cs
+++ b/ShopifySharp.Tests/ExecuteRequestCancellation_Tests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using ShopifySharp.Filters;
+using ShopifySharp.Infrastructure;
+using ShopifySharp.Lists;
+using Xunit;
+
+namespace ShopifySharp.Tests
+{
+    [Trait("Category", "ExecuteRequestCancellation")]
+    public class ExecuteRequestCancellation_Tests
+    {
+
+        public class TestService : ShopifyService
+        {
+            public TestService() : base("someurl", "sometoken")
+            {
+            }
+            
+            // these are what services call to execute their public API requests
+            public new Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, string fields, CancellationToken cancellationToken = default)
+            {
+                return base.ExecuteGetAsync<T>(path, resultRootElt, fields, cancellationToken);
+            }
+
+            public new Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, Parameterizable queryParams = null, CancellationToken cancellationToken = default)
+            {
+                return base.ExecuteGetAsync<T>(path, resultRootElt, queryParams, cancellationToken);
+            }
+
+            public new Task<ListResult<T>> ExecuteGetListAsync<T>(string path, string resultRootElt, ListFilter<T> filter, CancellationToken cancellationToken = default)
+            {
+                return base.ExecuteGetListAsync(path, resultRootElt, filter, cancellationToken);
+            }
+            
+            public new Task<T> ExecutePostAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
+            {
+                return base.ExecutePostAsync<T>(path, resultRootElt, jsonContent, cancellationToken);
+            }
+
+            public new Task<T> ExecutePutAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
+            {
+                return base.ExecutePutAsync<T>(path, resultRootElt, jsonContent, cancellationToken);
+            }
+
+            public new Task ExecuteDeleteAsync(string path, CancellationToken cancellationToken)
+            {
+                return base.ExecuteDeleteAsync(path, cancellationToken);
+            }
+
+            public new Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method, HttpContent content = null, CancellationToken cancellationToken = default)
+            {
+                return base.ExecuteRequestAsync(uri, method, content, cancellationToken);
+            }
+        }
+
+        [Fact]
+        public async Task Cancelling_An_ExecuteGetListAsync_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecuteGetListAsync<object>(string.Empty, string.Empty, null, cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+
+        [Fact]
+        public async Task Cancelling_An_ExecuteGetAsync_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecuteGetAsync<object>(string.Empty, string.Empty, string.Empty, cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+                
+        [Fact]
+        public async Task Cancelling_An_ExecuteGetAsyncFilter_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecuteGetAsync<object>(string.Empty, string.Empty, new PageCountFilter(), cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+                        
+        [Fact]
+        public async Task Cancelling_An_ExecutePutAsync_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecutePutAsync<object>(string.Empty, string.Empty, null, cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+                                
+        [Fact]
+        public async Task Cancelling_An_ExecutePostAsync_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecutePostAsync<object>(string.Empty, string.Empty, null, cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+                                
+        [Fact]
+        public async Task Cancelling_An_ExecuteDeleteAsync_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecuteDeleteAsync(string.Empty, cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+
+        [Fact]
+        public async Task Cancelling_An_ExecuteRequestAsync_Terminates_HttpRequest()
+        {
+            var service = new TestService();
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = service.ExecuteRequestAsync(new RequestUri(new Uri("http://unreachable")), HttpMethod.Get, null, cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+        
+        private OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+
+        [Fact]
+        public async Task Cancelling_An_OrderService_List_Terminates_HttpRequest()
+        {
+            var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                var task = OrderService.ListAsync(cancellationToken: cts.Token);
+
+                cts.Cancel();
+
+                await task;
+            });
+        }
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/DefaultRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/DefaultRequestExecutionPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 
@@ -6,7 +7,7 @@ namespace ShopifySharp
 {
     public class DefaultRequestExecutionPolicy : IRequestExecutionPolicy
     {
-        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage request, ExecuteRequestAsync<T> executeRequestAsync)
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage request, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken)
         {
             var fullResult = await executeRequestAsync(request);
 

--- a/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 
@@ -14,6 +15,7 @@ namespace ShopifySharp
     {
         /// <param name="baseRequest">The base request that was built by a service to execute.</param>
         /// <param name="executeRequestAsync">A delegate that executes the request you pass to it.</param>
-        Task<RequestResult<T>> Run<T>(CloneableRequestMessage requestMessage, ExecuteRequestAsync<T> executeRequestAsync);
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task<RequestResult<T>> Run<T>(CloneableRequestMessage requestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken);
     }
 }

--- a/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 
@@ -19,7 +20,7 @@ namespace ShopifySharp
             _retryOnlyIfLeakyBucketFull = retryOnlyIfLeakyBucketFull;
         }
 
-        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync)
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken)
         {
             while (true)
             {
@@ -36,7 +37,7 @@ namespace ShopifySharp
                     //Only retry if breach caused by full bucket
                     //Other limits will bubble the exception because it's not clear how long the program should wait
                     //Even if there is a Retry-After header, we probably don't want the thread to sleep for potentially many hours
-                    await Task.Delay(RETRY_DELAY);
+                    await Task.Delay(RETRY_DELAY, cancellationToken);
                 }
             }
         }

--- a/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 using ShopifySharp.Infrastructure;
 
 namespace ShopifySharp
@@ -37,7 +38,7 @@ namespace ShopifySharp
             _retryOnlyIfLeakyBucketFull = retryOnlyIfLeakyBucketFull;
         }
 
-        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync)
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken)
         {
             var accessToken = GetAccessToken(baseRequest);
             LeakyBucket bucket = null;
@@ -80,7 +81,7 @@ namespace ShopifySharp
                     //-There may be timing and latency delays
                     //-Multiple programs may use the same access token
                     //-Multiple instances of the same program may use the same access token
-                    await Task.Delay(THROTTLE_DELAY);
+                    await Task.Delay(THROTTLE_DELAY, cancellationToken);
                 }
             }
         }

--- a/ShopifySharp/Services/AccessScope/AccessScopeService.cs
+++ b/ShopifySharp/Services/AccessScope/AccessScopeService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<AccessScope>> ListAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<AccessScope>>("oauth/access_scopes.json", "access_scopes");
+            return await ExecuteGetAsync<IEnumerable<AccessScope>>("oauth/access_scopes.json", "access_scopes", cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/AccessScope/AccessScopeService.cs
+++ b/ShopifySharp/Services/AccessScope/AccessScopeService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ShopifySharp
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <summary>
         /// Retrieves a list of access scopes associated to the access token.
         /// </summary>
-        public virtual async Task<IEnumerable<AccessScope>> ListAsync()
+        public virtual async Task<IEnumerable<AccessScope>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<AccessScope>>("oauth/access_scopes.json", "access_scopes");
         }

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ListFilter<ApplicationCredit> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("application_credits.json", "application_credits", filter);
+            return await ExecuteGetListAsync("application_credits.json", "application_credits", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ApplicationCreditListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <param name="fields">A comma-separated list of fields to include in the response.</param>
         public virtual async Task<ApplicationCredit> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<ApplicationCredit>($"application_credits/{id}.json", "application_credit", fields);
+            return await ExecuteGetAsync<ApplicationCredit>($"application_credits/{id}.json", "application_credit", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ShopifySharp
                 application_credit = credit,
             });
 
-            var response = await ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, body, "application_credit");
+            var response = await ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, body, "application_credit", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -1,6 +1,7 @@
 ﻿using ShopifySharp.Infrastructure;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Lists;
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of all past and present application credits.
         /// </summary>
-        public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ListFilter<ApplicationCredit> filter)
+        public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ListFilter<ApplicationCredit> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("application_credits.json", "application_credits", filter);
         }
@@ -30,7 +31,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of all past and present application credits.
         /// </summary>
-        public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ApplicationCreditListFilter filter)
+        public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ApplicationCreditListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The application credit's id.</param>
         /// <param name="fields">A comma-separated list of fields to include in the response.</param>
-        public virtual async Task<ApplicationCredit> GetAsync(long id, string fields = null)
+        public virtual async Task<ApplicationCredit> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<ApplicationCredit>($"application_credits/{id}.json", "application_credit", fields);
         }
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="ApplicationCredit"/>.
         /// </summary>
         /// <param name="credit">A new <see cref="ApplicationCredit"/>. Id should be set to null.</param>
-        public virtual async Task<ApplicationCredit> CreateAsync(ApplicationCredit credit)
+        public virtual async Task<ApplicationCredit> CreateAsync(ApplicationCredit credit, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"application_credits.json");
             var body = new JsonContent(new

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ListFilter<ApplicationCredit> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("application_credits.json", "application_credits", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("application_credits.json", "application_credits", filter, cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ApplicationCredit> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<ApplicationCredit>($"application_credits/{id}.json", "application_credit", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<ApplicationCredit>($"application_credits/{id}.json", "application_credit", fields, cancellationToken);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace ShopifySharp
                 application_credit = credit,
             });
 
-            var response = await ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, body, "application_credit", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, cancellationToken, body, "application_credit");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -41,6 +41,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The application credit's id.</param>
         /// <param name="fields">A comma-separated list of fields to include in the response.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ApplicationCredit> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<ApplicationCredit>($"application_credits/{id}.json", "application_credit", fields, cancellationToken: cancellationToken);
@@ -50,6 +51,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="ApplicationCredit"/>.
         /// </summary>
         /// <param name="credit">A new <see cref="ApplicationCredit"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ApplicationCredit> CreateAsync(ApplicationCredit credit, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"application_credits.json");

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Article>> ListAsync(long blogId, ListFilter<Article> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"blogs/{blogId}/articles.json", "articles", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"blogs/{blogId}/articles.json", "articles", filter, cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(long blogId, ArticleCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"blogs/{blogId}/articles/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>($"blogs/{blogId}/articles/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Get, rootElement: "article", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Get, cancellationToken, rootElement: "article");
             return response.Result;
         }
 
@@ -89,7 +89,7 @@ namespace ShopifySharp
                 article = body
             });
 
-            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Post, content, "article", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Post, cancellationToken, content, "article");
             return response.Result;
         }
 
@@ -116,7 +116,7 @@ namespace ShopifySharp
                 article = body
             });
 
-            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Put, content, "article", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Put, cancellationToken, content, "article");
             return response.Result;
         }
 
@@ -130,7 +130,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"articles/authors.json");
 
-            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "authors", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, cancellationToken, rootElement: "authors");
             return response.Result;
         }
 
@@ -164,7 +164,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("limit", limit.Value);
             }
 
-            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "tags", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, cancellationToken, rootElement: "tags");
             return response.Result;
         }
 
@@ -189,7 +189,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("limit", limit.Value);
             }
 
-            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "tags", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, cancellationToken, rootElement: "tags");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -2,6 +2,7 @@
 using ShopifySharp.Infrastructure;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Lists;
 
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 articles belonging to the given blog.
         /// </summary>
-        public virtual async Task<ListResult<Article>> ListAsync(long blogId, ListFilter<Article> filter = null)
+        public virtual async Task<ListResult<Article>> ListAsync(long blogId, ListFilter<Article> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"blogs/{blogId}/articles.json", "articles", filter);
         }
@@ -30,7 +31,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 articles belonging to the given blog.
         /// </summary>
-        public virtual async Task<ListResult<Article>> ListAsync(int blogId, ArticleListFilter filter)
+        public virtual async Task<ListResult<Article>> ListAsync(int blogId, ArticleListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(blogId, (ListFilter<Article>) filter);
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the articles belong to.</param>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<int> CountAsync(long blogId, ArticleCountFilter filter = null)
+        public virtual async Task<int> CountAsync(long blogId, ArticleCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"blogs/{blogId}/articles/count.json", "count", filter);
         }
@@ -51,7 +52,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="articleId">The article's id.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
-        public virtual async Task<Article> GetAsync(long blogId, long articleId, string fields = null)
+        public virtual async Task<Article> GetAsync(long blogId, long articleId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
 
@@ -70,7 +71,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article will belong to.</param>
         /// <param name="article">The article being created. Id should be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
-        public virtual async Task<Article> CreateAsync(long blogId, Article article, IEnumerable<MetaField> metafields = null)
+        public virtual async Task<Article> CreateAsync(long blogId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles.json");
             var body = article.ToDictionary();
@@ -96,7 +97,7 @@ namespace ShopifySharp
         /// <param name="articleId">Id of the object being updated.</param>
         /// <param name="article">The article being updated.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
-        public virtual async Task<Article> UpdateAsync(long blogId, long articleId, Article article, IEnumerable<MetaField> metafields = null)
+        public virtual async Task<Article> UpdateAsync(long blogId, long articleId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
             var body = article.ToDictionary();
@@ -120,7 +121,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="articleId">The article benig deleted.</param>
-        public virtual async Task DeleteAsync(long blogId, long articleId)
+        public virtual async Task DeleteAsync(long blogId, long articleId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
 
@@ -130,7 +131,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of all article authors.
         /// </summary>
-        public virtual async Task<IEnumerable<string>> ListAuthorsAsync()
+        public virtual async Task<IEnumerable<string>> ListAuthorsAsync(CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"articles/authors.json");
 
@@ -143,7 +144,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="limit">The number of tags to return</param>
         /// <param name="popular">A flag to indicate only to a certain number of the most popular tags.</param>
-        public virtual async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null)
+        public virtual async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"articles/tags.json");
 
@@ -167,7 +168,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the tags belong to.</param>
         /// <param name="limit">The number of tags to return</param>
         /// <param name="popular">A flag to indicate only to a certain number of the most popular tags.</param>
-        public virtual async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null)
+        public virtual async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/tags.json");
 

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Article>> ListAsync(long blogId, ListFilter<Article> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"blogs/{blogId}/articles.json", "articles", filter);
+            return await ExecuteGetListAsync($"blogs/{blogId}/articles.json", "articles", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Article>> ListAsync(int blogId, ArticleListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(blogId, (ListFilter<Article>) filter);
+            return await ListAsync(blogId, (ListFilter<Article>) filter, cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<int> CountAsync(long blogId, ArticleCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"blogs/{blogId}/articles/count.json", "count", filter);
+            return await ExecuteGetAsync<int>($"blogs/{blogId}/articles/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Get, rootElement: "article");
+            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Get, rootElement: "article", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -86,7 +86,7 @@ namespace ShopifySharp
                 article = body
             });
 
-            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Post, content, "article");
+            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Post, content, "article", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -112,7 +112,7 @@ namespace ShopifySharp
                 article = body
             });
 
-            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Put, content, "article");
+            var response = await ExecuteRequestAsync<Article>(req, HttpMethod.Put, content, "article", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -125,7 +125,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"articles/authors.json");
 
-            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "authors");
+            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "authors", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -158,7 +158,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("limit", limit.Value);
             }
 
-            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "tags");
+            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "tags", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -182,7 +182,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("limit", limit.Value);
             }
 
-            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "tags");
+            var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, rootElement: "tags", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -41,6 +41,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the articles belong to.</param>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(long blogId, ArticleCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"blogs/{blogId}/articles/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -52,6 +53,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="articleId">The article's id.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Article> GetAsync(long blogId, long articleId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
@@ -71,6 +73,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the article will belong to.</param>
         /// <param name="article">The article being created. Id should be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Article> CreateAsync(long blogId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles.json");
@@ -97,6 +100,7 @@ namespace ShopifySharp
         /// <param name="articleId">Id of the object being updated.</param>
         /// <param name="article">The article being updated.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Article> UpdateAsync(long blogId, long articleId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
@@ -121,6 +125,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blogId">The blog that the article belongs to.</param>
         /// <param name="articleId">The article benig deleted.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long blogId, long articleId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
@@ -144,6 +149,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="limit">The number of tags to return</param>
         /// <param name="popular">A flag to indicate only to a certain number of the most popular tags.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"articles/tags.json");
@@ -168,6 +174,7 @@ namespace ShopifySharp
         /// <param name="blogId">The blog that the tags belong to.</param>
         /// <param name="limit">The number of tags to return</param>
         /// <param name="popular">A flag to indicate only to a certain number of the most popular tags.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"blogs/{blogId}/articles/tags.json");

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Get, rootElement: "asset");
+            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Get, rootElement: "asset", cancellationToken: cancellationToken);
             
             return response.Result;
         }
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<IEnumerable<Asset>> ListAsync(long themeId, AssetListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Asset>>($"themes/{themeId}/assets.json", "assets", filter);
+            return await ExecuteGetAsync<IEnumerable<Asset>>($"themes/{themeId}/assets.json", "assets", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace ShopifySharp
                 asset = asset
             });
 
-            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Put, content, "asset");
+            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Put, content, "asset", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -89,7 +89,7 @@ namespace ShopifySharp
 
             req = SetAssetQuerystring(req, key, themeId);
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// <param name="themeId">The id of the theme that the asset belongs to. Assets themselves do not have ids.</param>
         /// <param name="key">The key value of the asset, e.g. 'templates/index.liquid' or 'assets/bg-body.gif'.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Asset"/>.</returns>
         public virtual async Task<Asset> GetAsync(long themeId, string key, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -50,6 +51,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Asset>> ListAsync(long themeId, AssetListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<Asset>>($"themes/{themeId}/assets.json", "assets", filter, cancellationToken: cancellationToken);
@@ -65,6 +67,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="asset">The asset.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The created or updated asset.</returns>
         public virtual async Task<Asset> CreateOrUpdateAsync(long themeId, Asset asset, CancellationToken cancellationToken = default)
         {
@@ -83,6 +86,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="key">The key value of the asset, e.g. 'templates/index.liquid' or 'assets/bg-body.gif'.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long themeId, string key, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}/assets.json");

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Net.Http;
+using System.Threading;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
 
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// <param name="key">The key value of the asset, e.g. 'templates/index.liquid' or 'assets/bg-body.gif'.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Asset"/>.</returns>
-        public virtual async Task<Asset> GetAsync(long themeId, string key, string fields = null)
+        public virtual async Task<Asset> GetAsync(long themeId, string key, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}/assets.json");
 
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<IEnumerable<Asset>> ListAsync(long themeId, AssetListFilter filter = null)
+        public virtual async Task<IEnumerable<Asset>> ListAsync(long themeId, AssetListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<Asset>>($"themes/{themeId}/assets.json", "assets", filter);
         }
@@ -65,7 +66,7 @@ namespace ShopifySharp
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="asset">The asset.</param>
         /// <returns>The created or updated asset.</returns>
-        public virtual async Task<Asset> CreateOrUpdateAsync(long themeId, Asset asset)
+        public virtual async Task<Asset> CreateOrUpdateAsync(long themeId, Asset asset, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}/assets.json");
             var content = new JsonContent(new
@@ -82,7 +83,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme that the asset belongs to.</param>
         /// <param name="key">The key value of the asset, e.g. 'templates/index.liquid' or 'assets/bg-body.gif'.</param>
-        public virtual async Task DeleteAsync(long themeId, string key)
+        public virtual async Task DeleteAsync(long themeId, string key, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}/assets.json");
 

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Get, rootElement: "asset", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Get, cancellationToken, rootElement: "asset");
             
             return response.Result;
         }
@@ -54,7 +54,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Asset>> ListAsync(long themeId, AssetListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Asset>>($"themes/{themeId}/assets.json", "assets", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<IEnumerable<Asset>>($"themes/{themeId}/assets.json", "assets", filter, cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ShopifySharp
                 asset = asset
             });
 
-            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Put, content, "asset", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Asset>(req, HttpMethod.Put, cancellationToken, content, "asset");
             return response.Result;
         }
 
@@ -93,7 +93,7 @@ namespace ShopifySharp
 
             req = SetAssetQuerystring(req, key, themeId);
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Net.Http;
+using System.Threading;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 blogs belonging to the store.
         /// </summary>
-        public virtual async Task<ListResult<Blog>> ListAsync(ListFilter<Blog> filter = null)
+        public virtual async Task<ListResult<Blog>> ListAsync(ListFilter<Blog> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("blogs.json", "blogs", filter);
         }
@@ -32,7 +33,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 blogs belonging to the store.
         /// </summary>
-        public virtual async Task<ListResult<Blog>> ListAsync(BlogListFilter filter)
+        public virtual async Task<ListResult<Blog>> ListAsync(BlogListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a count of all blogs.
         /// </summary>
-        public virtual async Task<int> CountAsync()
+        public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("blogs/count.json", "count");
         }
@@ -50,7 +51,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blog">The blog being created. Id should be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
-        public virtual async Task<Blog> CreateAsync(Blog blog, IEnumerable<MetaField> metafields = null)
+        public virtual async Task<Blog> CreateAsync(Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest("blogs.json");
             var body = blog.ToDictionary();
@@ -75,7 +76,7 @@ namespace ShopifySharp
         /// <param name="blogId">Id of the object being updated.</param>
         /// <param name="blog">The updated blog.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
-        public virtual async Task<Blog> UpdateAsync(long blogId, Blog blog, IEnumerable<MetaField> metafields = null)
+        public virtual async Task<Blog> UpdateAsync(long blogId, Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest($"blogs/{blogId}.json");
             var body = blog.ToDictionary();
@@ -98,7 +99,7 @@ namespace ShopifySharp
         /// Gets a blog with the given id.
         /// </summary>
         /// <param name="id">The id of the blog you want to retrieve.</param>
-        public virtual async Task<Blog> GetAsync(long id)
+        public virtual async Task<Blog> GetAsync(long id, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest($"blogs/{id}.json");
 
@@ -110,7 +111,7 @@ namespace ShopifySharp
         /// Deletes a blog with the given id.
         /// </summary>
         /// <param name="id">The id of the blog you want to delete.</param>
-        public virtual async Task DeleteAsync(long id)
+        public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest($"blogs/{id}.json");
 

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -51,6 +51,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="blog">The blog being created. Id should be null.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Blog> CreateAsync(Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest("blogs.json");
@@ -76,6 +77,7 @@ namespace ShopifySharp
         /// <param name="blogId">Id of the object being updated.</param>
         /// <param name="blog">The updated blog.</param>
         /// <param name="metafields">Optional metafield data that can be returned by the <see cref="MetaFieldService"/>.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Blog> UpdateAsync(long blogId, Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest($"blogs/{blogId}.json");
@@ -99,6 +101,7 @@ namespace ShopifySharp
         /// Gets a blog with the given id.
         /// </summary>
         /// <param name="id">The id of the blog you want to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Blog> GetAsync(long id, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest($"blogs/{id}.json");
@@ -111,6 +114,7 @@ namespace ShopifySharp
         /// Deletes a blog with the given id.
         /// </summary>
         /// <param name="id">The id of the blog you want to delete.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest($"blogs/{id}.json");

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Blog>> ListAsync(ListFilter<Blog> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("blogs.json", "blogs", filter);
+            return await ExecuteGetListAsync("blogs.json", "blogs", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Blog>> ListAsync(BlogListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("blogs/count.json", "count");
+            return await ExecuteGetAsync<int>("blogs/count.json", "count", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace ShopifySharp
                 blog = body
             });
 
-            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Post, content, rootElement: "blog");
+            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Post, content, rootElement: "blog", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -91,7 +91,7 @@ namespace ShopifySharp
                 blog = body
             });
 
-            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Put, content, "blog");
+            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Put, content, "blog", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -103,7 +103,7 @@ namespace ShopifySharp
         {
             var request = PrepareRequest($"blogs/{id}.json");
 
-            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Get, rootElement: "blog");
+            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Get, rootElement: "blog", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -115,7 +115,7 @@ namespace ShopifySharp
         {
             var request = PrepareRequest($"blogs/{id}.json");
 
-            await ExecuteRequestAsync(request, HttpMethod.Delete);
+            await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Blog>> ListAsync(ListFilter<Blog> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("blogs.json", "blogs", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("blogs.json", "blogs", filter, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace ShopifySharp
                 blog = body
             });
 
-            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Post, content, rootElement: "blog", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Post, cancellationToken, content, "blog");
             return response.Result;
         }
 
@@ -93,7 +93,7 @@ namespace ShopifySharp
                 blog = body
             });
 
-            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Put, content, "blog", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Put, cancellationToken, content, "blog");
             return response.Result;
         }
 
@@ -106,7 +106,7 @@ namespace ShopifySharp
         {
             var request = PrepareRequest($"blogs/{id}.json");
 
-            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Get, rootElement: "blog", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Get, cancellationToken, rootElement: "blog");
             return response.Result;
         }
 
@@ -119,7 +119,7 @@ namespace ShopifySharp
         {
             var request = PrepareRequest($"blogs/{id}.json");
 
-            await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -32,6 +32,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="Carrier"/> Carrier
         /// </summary>
         /// <param name="carrier">A new <see cref="Carrier"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Carrier"/>.</returns>
         public virtual async Task<Carrier> CreateAsync(Carrier carrier, CancellationToken cancellationToken = default)
         {
@@ -49,6 +50,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="Carrier"/> with the given id.
         /// </summary>
         /// <param name="carrierId">The id of the Carrier to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Carrier"/>.</returns>
         public virtual async Task<Carrier> GetAsync(long carrierId, CancellationToken cancellationToken = default)
         {            
@@ -62,6 +64,7 @@ namespace ShopifySharp
         /// Deletes a Carruer with the given Id.
         /// </summary>
         /// <param name="carrierId">The Carrier's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long carrierId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
@@ -74,6 +77,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="carrierId">Id of the Carrier being updated.</param>
         /// <param name="carrier">The <see cref="Carrier"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Carrier"/>.</returns>
         public virtual async Task<Carrier> UpdateAsync(long carrierId, Carrier carrier, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<Carrier>> ListAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync< IEnumerable < Carrier >>("carrier_services.json", "carrier_services");
+            return await ExecuteGetAsync< IEnumerable < Carrier >>("carrier_services.json", "carrier_services", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
                 carrier_service = carrier
             });
 
-            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Post, content, "carrier_service");
+            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Post, content, "carrier_service", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -54,7 +54,7 @@ namespace ShopifySharp
         {            
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
 
-            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Get, rootElement: "carrier_service");
+            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Get, rootElement: "carrier_service", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -66,7 +66,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace ShopifySharp
                 carrier_service = carrier
             });
 
-            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Put, content, "carrier_service");
+            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Put, content, "carrier_service", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using System;
+using System.Threading;
 
 namespace ShopifySharp
 {
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <summary>
         /// Retrieve a list of all carrier services that are associated with the store.
         /// </summary>
-        public virtual async Task<IEnumerable<Carrier>> ListAsync()
+        public virtual async Task<IEnumerable<Carrier>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync< IEnumerable < Carrier >>("carrier_services.json", "carrier_services");
         }
@@ -32,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="carrier">A new <see cref="Carrier"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="Carrier"/>.</returns>
-        public virtual async Task<Carrier> CreateAsync(Carrier carrier)
+        public virtual async Task<Carrier> CreateAsync(Carrier carrier, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("carrier_services.json");
             var content = new JsonContent(new
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="carrierId">The id of the Carrier to retrieve.</param>
         /// <returns>The <see cref="Carrier"/>.</returns>
-        public virtual async Task<Carrier> GetAsync(long carrierId)
+        public virtual async Task<Carrier> GetAsync(long carrierId, CancellationToken cancellationToken = default)
         {            
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
 
@@ -61,7 +62,7 @@ namespace ShopifySharp
         /// Deletes a Carruer with the given Id.
         /// </summary>
         /// <param name="carrierId">The Carrier's Id.</param>
-        public virtual async Task DeleteAsync(long carrierId)
+        public virtual async Task DeleteAsync(long carrierId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
 
@@ -74,7 +75,7 @@ namespace ShopifySharp
         /// <param name="carrierId">Id of the Carrier being updated.</param>
         /// <param name="carrier">The <see cref="Carrier"/> to update.</param>
         /// <returns>The updated <see cref="Carrier"/>.</returns>
-        public virtual async Task<Carrier> UpdateAsync(long carrierId, Carrier carrier)
+        public virtual async Task<Carrier> UpdateAsync(long carrierId, Carrier carrier, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
             var content = new JsonContent(new

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -42,7 +42,7 @@ namespace ShopifySharp
                 carrier_service = carrier
             });
 
-            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Post, content, "carrier_service", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Post, cancellationToken, content, "carrier_service");
             return response.Result;
         }
 
@@ -56,7 +56,7 @@ namespace ShopifySharp
         {            
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
 
-            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Get, rootElement: "carrier_service", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Get, cancellationToken, rootElement: "carrier_service");
             return response.Result;
         }
 
@@ -69,7 +69,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"carrier_services/{carrierId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace ShopifySharp
                 carrier_service = carrier
             });
 
-            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Put, content, "carrier_service", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Put, cancellationToken, content, "carrier_service");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -24,6 +24,7 @@ namespace ShopifySharp
         /// Creates a <see cref="Charge"/>.
         /// </summary>
         /// <param name="charge">The <see cref="Charge"/> to create.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Charge"/>.</returns>
         public virtual async Task<Charge> CreateAsync(Charge charge, CancellationToken cancellationToken = default)
         {
@@ -39,6 +40,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Charge"/>.</returns>
         public virtual async Task<Charge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -57,6 +59,7 @@ namespace ShopifySharp
         /// Retrieves a list of all past and present <see cref="Charge"/> objects.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Charge>> ListAsync(ChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync< IEnumerable < Charge >>("application_charges.json", "application_charges", filter, cancellationToken: cancellationToken);
@@ -66,6 +69,7 @@ namespace ShopifySharp
         /// Activates a <see cref="Charge"/> that the shop owner has accepted.
         /// </summary>
         /// <param name="id">The id of the charge to activate.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task ActivateAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"application_charges/{id}/activate.json");

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
             var req = PrepareRequest("application_charges.json");
             var content = new JsonContent(new { application_charge = charge });
 
-            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Post, content, "application_charge");
+            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Post, content, "application_charge", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -49,7 +49,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Get, rootElement: "application_charge");
+            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Get, rootElement: "application_charge", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<IEnumerable<Charge>> ListAsync(ChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync< IEnumerable < Charge >>("application_charges.json", "application_charges", filter);
+            return await ExecuteGetAsync< IEnumerable < Charge >>("application_charges.json", "application_charges", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"application_charges/{id}/activate.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Post);
+            await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="charge">The <see cref="Charge"/> to create.</param>
         /// <returns>The new <see cref="Charge"/>.</returns>
-        public virtual async Task<Charge> CreateAsync(Charge charge)
+        public virtual async Task<Charge> CreateAsync(Charge charge, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("application_charges.json");
             var content = new JsonContent(new { application_charge = charge });
@@ -39,7 +40,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Charge"/>.</returns>
-        public virtual async Task<Charge> GetAsync(long id, string fields = null)
+        public virtual async Task<Charge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"application_charges/{id}.json");
 
@@ -56,7 +57,7 @@ namespace ShopifySharp
         /// Retrieves a list of all past and present <see cref="Charge"/> objects.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<IEnumerable<Charge>> ListAsync(ChargeListFilter filter = null)
+        public virtual async Task<IEnumerable<Charge>> ListAsync(ChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync< IEnumerable < Charge >>("application_charges.json", "application_charges", filter);
         }
@@ -65,7 +66,7 @@ namespace ShopifySharp
         /// Activates a <see cref="Charge"/> that the shop owner has accepted.
         /// </summary>
         /// <param name="id">The id of the charge to activate.</param>
-        public virtual async Task ActivateAsync(long id)
+        public virtual async Task ActivateAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"application_charges/{id}/activate.json");
 

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
             var req = PrepareRequest("application_charges.json");
             var content = new JsonContent(new { application_charge = charge });
 
-            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Post, content, "application_charge", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Post, cancellationToken, content, "application_charge");
             return response.Result;
         }
 
@@ -51,7 +51,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Get, rootElement: "application_charge", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Get, cancellationToken, rootElement: "application_charge");
             return response.Result;
         }
 
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Charge>> ListAsync(ChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync< IEnumerable < Charge >>("application_charges.json", "application_charges", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync< IEnumerable < Charge >>("application_charges.json", "application_charges", filter, cancellationToken);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"application_charges/{id}/activate.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -22,6 +22,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's orders.
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The count of all orders for the shop.</returns>
         public virtual async Task<int> CountAsync(CheckoutCountFilter filter = null, CancellationToken cancellationToken = default)
         {
@@ -32,6 +33,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's abandoned checkouts.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Checkout>> ListAsync(ListFilter<Checkout> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("checkouts.json", "checkouts", filter, cancellationToken: cancellationToken);
@@ -41,6 +43,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's abandoned checkouts.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Checkout>> ListAsync(CheckoutListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter(), cancellationToken);

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// <returns>The count of all orders for the shop.</returns>
         public virtual async Task<int> CountAsync(CheckoutCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("checkouts/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("checkouts/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Checkout>> ListAsync(ListFilter<Checkout> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("checkouts.json", "checkouts", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("checkouts.json", "checkouts", filter, cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ShopifySharp
             var req = PrepareRequest("checkout.json");
             var body = checkout.ToDictionary();
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, new JsonContent(checkout), rootElement: "checkout", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, cancellationToken, new JsonContent(checkout), "checkout");
             return response.Result;
         }
 
@@ -70,7 +70,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}/complete.json");
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, rootElement: "checkout", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, cancellationToken, rootElement: "checkout");
             return response.Result;
         }
 
@@ -82,7 +82,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}.json");
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Get, rootElement: "checkout", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Get, cancellationToken, rootElement: "checkout");
             return response.Result;
         }
 
@@ -94,7 +94,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}.json");
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Put, new JsonContent(updatedCheckout), rootElement: "checkout", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Put, cancellationToken, new JsonContent(updatedCheckout), "checkout");
             return response.Result;
         }
 
@@ -108,7 +108,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
 
-            var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, rootElement: "shipping_rates", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, cancellationToken, rootElement: "shipping_rates");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <returns>The count of all orders for the shop.</returns>
         public virtual async Task<int> CountAsync(CheckoutCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("checkouts/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("checkouts/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<ListResult<Checkout>> ListAsync(ListFilter<Checkout> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("checkouts.json", "checkouts", filter);
+            return await ExecuteGetListAsync("checkouts.json", "checkouts", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<ListResult<Checkout>> ListAsync(CheckoutListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
         
         /// <summary>
@@ -55,7 +55,7 @@ namespace ShopifySharp
             var req = PrepareRequest("checkout.json");
             var body = checkout.ToDictionary();
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, new JsonContent(checkout), rootElement: "checkout");
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, new JsonContent(checkout), rootElement: "checkout", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -67,7 +67,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}/complete.json");
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, rootElement: "checkout");
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, rootElement: "checkout", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -79,7 +79,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}.json");
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Get, rootElement: "checkout");
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Get, rootElement: "checkout", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -91,7 +91,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}.json");
 
-            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Put, new JsonContent(updatedCheckout), rootElement: "checkout");
+            var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Put, new JsonContent(updatedCheckout), rootElement: "checkout", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -105,7 +105,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
 
-            var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, rootElement: "shipping_rates");
+            var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, rootElement: "shipping_rates", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using System;
+using System.Threading;
 using ShopifySharp.Filters;
 using ShopifySharp.Lists;
 
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
         /// <returns>The count of all orders for the shop.</returns>
-        public virtual async Task<int> CountAsync(CheckoutCountFilter filter = null)
+        public virtual async Task<int> CountAsync(CheckoutCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("checkouts/count.json", "count", filter);
         }
@@ -31,7 +32,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's abandoned checkouts.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<ListResult<Checkout>> ListAsync(ListFilter<Checkout> filter)
+        public virtual async Task<ListResult<Checkout>> ListAsync(ListFilter<Checkout> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("checkouts.json", "checkouts", filter);
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's abandoned checkouts.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<ListResult<Checkout>> ListAsync(CheckoutListFilter filter = null)
+        public virtual async Task<ListResult<Checkout>> ListAsync(CheckoutListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// Creates a new Checkout.
         /// </summary>
         [Obsolete("This endpoint does not appear to be documented by Shopify. It may no longer work, use with caution. This method may be removed in a future version of ShopifySharp.")]
-        public virtual async Task<Checkout> CreateAsync(Checkout checkout)
+        public virtual async Task<Checkout> CreateAsync(Checkout checkout, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("checkout.json");
             var body = checkout.ToDictionary();
@@ -62,7 +63,7 @@ namespace ShopifySharp
         /// Completes a checkout without requiring payment.
         /// </summary>
         [Obsolete("This endpoint does not appear to be documented by Shopify. It may no longer work, use with caution. This method may be removed in a future version of ShopifySharp.")]
-        public virtual async Task<Checkout> CompleteAsync(string token)
+        public virtual async Task<Checkout> CompleteAsync(string token, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"checkouts/{token}/complete.json");
 
@@ -74,7 +75,7 @@ namespace ShopifySharp
         /// Gets an existing, processing or completed checkout.
         /// </summary>
         [Obsolete("This endpoint does not appear to be documented by Shopify. It may no longer work, use with caution. This method may be removed in a future version of ShopifySharp.")]
-        public virtual async Task<Checkout> GetAsync(string token)
+        public virtual async Task<Checkout> GetAsync(string token, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"checkouts/{token}.json");
 
@@ -86,7 +87,7 @@ namespace ShopifySharp
         /// Updates an existing checkout based on the token id.
         /// </summary>
         [Obsolete("This endpoint does not appear to be documented by Shopify. It may no longer work, use with caution. This method may be removed in a future version of ShopifySharp.")]
-        public virtual async Task<Checkout> UpdateAsync(string token, Checkout updatedCheckout)
+        public virtual async Task<Checkout> UpdateAsync(string token, Checkout updatedCheckout, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"checkouts/{token}.json");
 
@@ -100,7 +101,7 @@ namespace ShopifySharp
         /// shipping rate, update the checkout's shipping line with the handle of the selected rate. 
         /// </summary>
         [Obsolete("This endpoint does not appear to be documented by Shopify. It may no longer work, use with caution. This method may be removed in a future version of ShopifySharp.")]
-        public virtual async Task<IEnumerable<CheckoutShippingRate>> ListShippingRatesAsync(string token)
+        public virtual async Task<IEnumerable<CheckoutShippingRate>> ListShippingRatesAsync(string token, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
 

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -23,7 +24,7 @@ namespace ShopifySharp
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CollectService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
-        public virtual async Task<int> CountAsync(CollectCountFilter filter = null)
+        public virtual async Task<int> CountAsync(CollectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("collects/count.json", "count", filter);
         }
@@ -31,7 +32,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's collects.
         /// </summary>
-        public virtual async Task<ListResult<Collect>> ListAsync(ListFilter<Collect> filter)
+        public virtual async Task<ListResult<Collect>> ListAsync(ListFilter<Collect> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("collects.json", "collects", filter);
         }
@@ -39,7 +40,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's collects.
         /// </summary>
-        public virtual async Task<ListResult<Collect>> ListAsync(CollectListFilter filter = null)
+        public virtual async Task<ListResult<Collect>> ListAsync(CollectListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -50,7 +51,7 @@ namespace ShopifySharp
         /// <param name="collectId">The id of the collect to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Collect"/>.</returns>
-        public virtual async Task<Collect> GetAsync(long collectId, string fields = null)
+        public virtual async Task<Collect> GetAsync(long collectId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Collect>($"collects/{collectId}.json", "collect", fields);
         }
@@ -61,7 +62,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="collect">A new <see cref="Collect"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="Collect"/>.</returns>
-        public virtual async Task<Collect> CreateAsync(Collect collect)
+        public virtual async Task<Collect> CreateAsync(Collect collect, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("collects.json");
             var content = new JsonContent(new
@@ -77,7 +78,7 @@ namespace ShopifySharp
         /// Deletes a collect with the given Id.
         /// </summary>
         /// <param name="collectId">The product object's Id.</param>
-        public virtual async Task DeleteAsync(long collectId)
+        public virtual async Task DeleteAsync(long collectId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"collects/{collectId}.json");
 

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -50,6 +50,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="collectId">The id of the collect to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Collect"/>.</returns>
         public virtual async Task<Collect> GetAsync(long collectId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -61,6 +62,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="Collect"/> on the store. Map product to collection
         /// </summary>
         /// <param name="collect">A new <see cref="Collect"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Collect"/>.</returns>
         public virtual async Task<Collect> CreateAsync(Collect collect, CancellationToken cancellationToken = default)
         {
@@ -78,6 +80,7 @@ namespace ShopifySharp
         /// Deletes a collect with the given Id.
         /// </summary>
         /// <param name="collectId">The product object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long collectId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"collects/{collectId}.json");

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
 
         public virtual async Task<int> CountAsync(CollectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("collects/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("collects/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Collect>> ListAsync(ListFilter<Collect> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("collects.json", "collects", filter);
+            return await ExecuteGetListAsync("collects.json", "collects", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Collect>> ListAsync(CollectListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Collect"/>.</returns>
         public virtual async Task<Collect> GetAsync(long collectId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Collect>($"collects/{collectId}.json", "collect", fields);
+            return await ExecuteGetAsync<Collect>($"collects/{collectId}.json", "collect", fields, cancellationToken: cancellationToken);
         }
 
 
@@ -70,7 +70,7 @@ namespace ShopifySharp
                 collect = collect
             });
 
-            var response = await ExecuteRequestAsync<Collect>(req, HttpMethod.Post, content, "collect");
+            var response = await ExecuteRequestAsync<Collect>(req, HttpMethod.Post, content, "collect", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -82,7 +82,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"collects/{collectId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
 
         public virtual async Task<int> CountAsync(CollectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("collects/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("collects/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Collect>> ListAsync(ListFilter<Collect> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("collects.json", "collects", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("collects.json", "collects", filter, cancellationToken);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Collect"/>.</returns>
         public virtual async Task<Collect> GetAsync(long collectId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Collect>($"collects/{collectId}.json", "collect", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Collect>($"collects/{collectId}.json", "collect", fields, cancellationToken);
         }
 
 
@@ -72,7 +72,7 @@ namespace ShopifySharp
                 collect = collect
             });
 
-            var response = await ExecuteRequestAsync<Collect>(req, HttpMethod.Post, content, "collect", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Collect>(req, HttpMethod.Post, cancellationToken, content, "collect");
             return response.Result;
         }
 
@@ -85,7 +85,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"collects/{collectId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -39,6 +39,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="CustomCollection"/> Custom Collection
         /// </summary>
         /// <param name="customCollection">A new <see cref="CustomCollection"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="CustomCollection"/>.</returns>
         public virtual async Task<CustomCollection> CreateAsync(CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
@@ -63,6 +64,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customCollectionId">The id of the custom collection to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="CustomCollection"/>.</returns>
         public virtual async Task<CustomCollection> GetAsync(long customCollectionId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -73,6 +75,7 @@ namespace ShopifySharp
         /// Deletes a custom collection with the given Id.
         /// </summary>
         /// <param name="customCollectionId">The custom collection's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long customCollectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
@@ -85,6 +88,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customCollectionId">Id of the object being updated.</param>
         /// <param name="customCollection">The <see cref="CustomCollection"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="CustomCollection"/>.</returns>
         public virtual async Task<CustomCollection> UpdateAsync(long customCollectionId, CustomCollection customCollection, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<CustomCollection>> ListAsync(ListFilter<CustomCollection> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("custom_collections.json", "custom_collections", filter);
+            return await ExecuteGetListAsync("custom_collections.json", "custom_collections", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<CustomCollection>> ListAsync(CustomCollectionListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -48,14 +48,14 @@ namespace ShopifySharp
                 custom_collection = customCollection
             });
 
-            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Post, content, "custom_collection");
+            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Post, content, "custom_collection", cancellationToken: cancellationToken);
             
             return response.Result;
         }
 
         public virtual async Task<int> CountAsync(CustomCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("custom_collections/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("custom_collections/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="CustomCollection"/>.</returns>
         public virtual async Task<CustomCollection> GetAsync(long customCollectionId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<CustomCollection>($"custom_collections/{customCollectionId}.json", "custom_collection", fields);
+            return await ExecuteGetAsync<CustomCollection>($"custom_collections/{customCollectionId}.json", "custom_collection", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace ShopifySharp
                 custom_collection = customCollection
             });
 
-            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Put, content, "custom_collection");
+            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Put, content, "custom_collection", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<CustomCollection>> ListAsync(ListFilter<CustomCollection> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("custom_collections.json", "custom_collections", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("custom_collections.json", "custom_collections", filter, cancellationToken);
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace ShopifySharp
                 custom_collection = customCollection
             });
 
-            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Post, content, "custom_collection", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Post, cancellationToken, content, "custom_collection");
             
             return response.Result;
         }
 
         public virtual async Task<int> CountAsync(CustomCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("custom_collections/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("custom_collections/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -68,7 +68,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="CustomCollection"/>.</returns>
         public virtual async Task<CustomCollection> GetAsync(long customCollectionId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<CustomCollection>($"custom_collections/{customCollectionId}.json", "custom_collection", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<CustomCollection>($"custom_collections/{customCollectionId}.json", "custom_collection", fields, cancellationToken);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace ShopifySharp
                 custom_collection = customCollection
             });
 
-            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Put, content, "custom_collection", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CustomCollection>(req, HttpMethod.Put, cancellationToken, content, "custom_collection");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -21,7 +22,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 custom collections.
         /// </summary>
-        public virtual async Task<ListResult<CustomCollection>> ListAsync(ListFilter<CustomCollection> filter = null)
+        public virtual async Task<ListResult<CustomCollection>> ListAsync(ListFilter<CustomCollection> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("custom_collections.json", "custom_collections", filter);
         }
@@ -29,7 +30,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 custom collections.
         /// </summary>
-        public virtual async Task<ListResult<CustomCollection>> ListAsync(CustomCollectionListFilter filter)
+        public virtual async Task<ListResult<CustomCollection>> ListAsync(CustomCollectionListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -39,7 +40,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customCollection">A new <see cref="CustomCollection"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="CustomCollection"/>.</returns>
-        public virtual async Task<CustomCollection> CreateAsync(CustomCollection customCollection)
+        public virtual async Task<CustomCollection> CreateAsync(CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("custom_collections.json");
             var content = new JsonContent(new
@@ -52,7 +53,7 @@ namespace ShopifySharp
             return response.Result;
         }
 
-        public virtual async Task<int> CountAsync(CustomCollectionCountFilter filter = null)
+        public virtual async Task<int> CountAsync(CustomCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("custom_collections/count.json", "count", filter);
         }
@@ -63,7 +64,7 @@ namespace ShopifySharp
         /// <param name="customCollectionId">The id of the custom collection to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="CustomCollection"/>.</returns>
-        public virtual async Task<CustomCollection> GetAsync(long customCollectionId, string fields = null)
+        public virtual async Task<CustomCollection> GetAsync(long customCollectionId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<CustomCollection>($"custom_collections/{customCollectionId}.json", "custom_collection", fields);
         }
@@ -72,7 +73,7 @@ namespace ShopifySharp
         /// Deletes a custom collection with the given Id.
         /// </summary>
         /// <param name="customCollectionId">The custom collection's Id.</param>
-        public virtual async Task DeleteAsync(long customCollectionId)
+        public virtual async Task DeleteAsync(long customCollectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
 
@@ -85,7 +86,7 @@ namespace ShopifySharp
         /// <param name="customCollectionId">Id of the object being updated.</param>
         /// <param name="customCollection">The <see cref="CustomCollection"/> to update.</param>
         /// <returns>The updated <see cref="CustomCollection"/>.</returns>
-        public virtual async Task<CustomCollection> UpdateAsync(long customCollectionId, CustomCollection customCollection)
+        public virtual async Task<CustomCollection> UpdateAsync(long customCollectionId, CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
             var content = new JsonContent(new

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"customers/count.json", "count");
+            return await ExecuteGetAsync<int>($"customers/count.json", "count", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Customer>> ListAsync(ListFilter<Customer> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("customers.json", "customers", filter);
+            return await ExecuteGetListAsync("customers.json", "customers", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Customer>> ListAsync(CustomerListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Customer"/>.</returns>
         public virtual async Task<Customer> GetAsync(long customerId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Customer>($"customers/{customerId}.json", "customer", fields);
+            return await ExecuteGetAsync<Customer>($"customers/{customerId}.json", "customer", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<ListResult<Customer>> SearchAsync(ListFilter<Customer> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("customers/search.json", "customers", filter);
+            return await ExecuteGetListAsync("customers/search.json", "customers", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<ListResult<Customer>> SearchAsync(CustomerSearchListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await SearchAsync(filter?.AsListFilter());
+            return await SearchAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace ShopifySharp
                 customer = body
             });
 
-            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Post, content, "customer");
+            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Post, content, "customer", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -126,7 +126,7 @@ namespace ShopifySharp
                 customer = body
             });
 
-            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Put, content, "customer");
+            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Put, content, "customer", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -138,7 +138,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"customers/{customerId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
 
@@ -157,7 +157,7 @@ namespace ShopifySharp
                 customer_invite = invite
             });
 
-            var response = await ExecuteRequestAsync<CustomerInvite>(req, HttpMethod.Post, content, "customer_invite");
+            var response = await ExecuteRequestAsync<CustomerInvite>(req, HttpMethod.Post, content, "customer_invite", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -172,7 +172,7 @@ namespace ShopifySharp
         public virtual async Task<string> GetAccountActivationUrl(long customerid, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerid}/account_activation_url.json");
-            var response = await ExecuteRequestAsync(req, HttpMethod.Post);
+            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken: cancellationToken);
 
             return response.Result.SelectToken("account_activation_url").ToString();
         }
@@ -190,7 +190,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<IEnumerable<Order>> ListOrdersForCustomerAsync(long customerId, CustomerOrderListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<Order>>($"customers/{customerId}/orders.json", "orders", filter);
+            return await ExecuteGetAsync<List<Order>>($"customers/{customerId}/orders.json", "orders", filter, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -49,6 +49,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The id of the customer to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Customer"/>.</returns>
         public virtual async Task<Customer> GetAsync(long customerId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -59,6 +60,7 @@ namespace ShopifySharp
         /// Searches through a shop's customers for the given search query. NOTE: Assumes the <paramref name="query"/> and <paramref name="order"/> strings are not encoded.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Customer>> SearchAsync(ListFilter<Customer> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("customers/search.json", "customers", filter, cancellationToken: cancellationToken);
@@ -68,6 +70,7 @@ namespace ShopifySharp
         /// Searches through a shop's customers for the given search query. NOTE: Assumes the <paramref name="query"/> and <paramref name="order"/> strings are not encoded.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Customer>> SearchAsync(CustomerSearchListFilter filter, CancellationToken cancellationToken = default)
         {
             return await SearchAsync(filter?.AsListFilter(), cancellationToken);
@@ -78,6 +81,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customer">A new <see cref="Customer"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the customer.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Customer"/>.</returns>
         public virtual async Task<Customer> CreateAsync(Customer customer, CustomerCreateOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -107,6 +111,7 @@ namespace ShopifySharp
         /// <param name="customerId">Id of the object being updated.</param>
         /// <param name="customer">The <see cref="Customer"/> to update.</param>
         /// <param name="options">Options for updating the customer.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Customer"/>.</returns>
         public virtual async Task<Customer> UpdateAsync(long customerId, Customer customer, CustomerUpdateOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -134,6 +139,7 @@ namespace ShopifySharp
         /// Deletes a customer with the given Id.
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long customerId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}.json");
@@ -147,6 +153,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
         /// <param name="invite">Options for the invite email request</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns></returns>
         public virtual async Task<CustomerInvite> SendInviteAsync(long customerId, CustomerInvite invite = null, CancellationToken cancellationToken = default)
         {
@@ -168,6 +175,7 @@ namespace ShopifySharp
         /// If you make a new POST request to this endpoint, a new URL will be generated which will be again valid for 7 days, but the previous URL will no longer be valid.
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns></returns>
         public virtual async Task<string> GetAccountActivationUrl(long customerid, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Customer>> ListAsync(ListFilter<Customer> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("customers.json", "customers", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("customers.json", "customers", filter, cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Customer"/>.</returns>
         public virtual async Task<Customer> GetAsync(long customerId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Customer>($"customers/{customerId}.json", "customer", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Customer>($"customers/{customerId}.json", "customer", fields, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Customer>> SearchAsync(ListFilter<Customer> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("customers/search.json", "customers", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("customers/search.json", "customers", filter, cancellationToken);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace ShopifySharp
                 customer = body
             });
 
-            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Post, content, "customer", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Post, cancellationToken, content, "customer");
             return response.Result;
         }
 
@@ -131,7 +131,7 @@ namespace ShopifySharp
                 customer = body
             });
 
-            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Put, content, "customer", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Customer>(req, HttpMethod.Put, cancellationToken, content, "customer");
             return response.Result;
         }
 
@@ -164,7 +164,7 @@ namespace ShopifySharp
                 customer_invite = invite
             });
 
-            var response = await ExecuteRequestAsync<CustomerInvite>(req, HttpMethod.Post, content, "customer_invite", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CustomerInvite>(req, HttpMethod.Post, cancellationToken, content, "customer_invite");
             return response.Result;
         }
 
@@ -180,7 +180,7 @@ namespace ShopifySharp
         public virtual async Task<string> GetAccountActivationUrl(long customerid, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerid}/account_activation_url.json");
-            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken);
 
             return response.Result.SelectToken("account_activation_url").ToString();
         }
@@ -190,6 +190,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The id of the customer to list orders for.</param>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <remarks>
         /// Previously this was part of the OrderService, and was documented under the Orders API in Shopify.
         /// Shopify appears to have moved it to the Customers API.
@@ -198,7 +199,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<IEnumerable<Order>> ListOrdersForCustomerAsync(long customerId, CustomerOrderListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<Order>>($"customers/{customerId}/orders.json", "orders", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<List<Order>>($"customers/{customerId}/orders.json", "orders", filter, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <remarks>
         /// According to Shopify's documentation, the count endpoint does not support any parameters. 
         /// </remarks>
-        public virtual async Task<int> CountAsync()
+        public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"customers/count.json", "count");
         }
@@ -30,7 +31,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's customers.
         /// </summary>
-        public virtual async Task<ListResult<Customer>> ListAsync(ListFilter<Customer> filter = null)
+        public virtual async Task<ListResult<Customer>> ListAsync(ListFilter<Customer> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("customers.json", "customers", filter);
         }
@@ -38,7 +39,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's customers.
         /// </summary>
-        public virtual async Task<ListResult<Customer>> ListAsync(CustomerListFilter filter)
+        public virtual async Task<ListResult<Customer>> ListAsync(CustomerListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// <param name="customerId">The id of the customer to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Customer"/>.</returns>
-        public virtual async Task<Customer> GetAsync(long customerId, string fields = null)
+        public virtual async Task<Customer> GetAsync(long customerId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Customer>($"customers/{customerId}.json", "customer", fields);
         }
@@ -58,7 +59,7 @@ namespace ShopifySharp
         /// Searches through a shop's customers for the given search query. NOTE: Assumes the <paramref name="query"/> and <paramref name="order"/> strings are not encoded.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<ListResult<Customer>> SearchAsync(ListFilter<Customer> filter)
+        public virtual async Task<ListResult<Customer>> SearchAsync(ListFilter<Customer> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("customers/search.json", "customers", filter);
         }
@@ -67,7 +68,7 @@ namespace ShopifySharp
         /// Searches through a shop's customers for the given search query. NOTE: Assumes the <paramref name="query"/> and <paramref name="order"/> strings are not encoded.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<ListResult<Customer>> SearchAsync(CustomerSearchListFilter filter)
+        public virtual async Task<ListResult<Customer>> SearchAsync(CustomerSearchListFilter filter, CancellationToken cancellationToken = default)
         {
             return await SearchAsync(filter?.AsListFilter());
         }
@@ -78,7 +79,7 @@ namespace ShopifySharp
         /// <param name="customer">A new <see cref="Customer"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the customer.</param>
         /// <returns>The new <see cref="Customer"/>.</returns>
-        public virtual async Task<Customer> CreateAsync(Customer customer, CustomerCreateOptions options = null)
+        public virtual async Task<Customer> CreateAsync(Customer customer, CustomerCreateOptions options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("customers.json");
             var body = customer.ToDictionary();
@@ -107,7 +108,7 @@ namespace ShopifySharp
         /// <param name="customer">The <see cref="Customer"/> to update.</param>
         /// <param name="options">Options for updating the customer.</param>
         /// <returns>The updated <see cref="Customer"/>.</returns>
-        public virtual async Task<Customer> UpdateAsync(long customerId, Customer customer, CustomerUpdateOptions options = null)
+        public virtual async Task<Customer> UpdateAsync(long customerId, Customer customer, CustomerUpdateOptions options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}.json");
             var body = customer.ToDictionary();
@@ -133,7 +134,7 @@ namespace ShopifySharp
         /// Deletes a customer with the given Id.
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
-        public virtual async Task DeleteAsync(long customerId)
+        public virtual async Task DeleteAsync(long customerId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}.json");
 
@@ -147,7 +148,7 @@ namespace ShopifySharp
         /// <param name="customerId">The customer object's Id.</param>
         /// <param name="invite">Options for the invite email request</param>
         /// <returns></returns>
-        public virtual async Task<CustomerInvite> SendInviteAsync(long customerId, CustomerInvite invite = null)
+        public virtual async Task<CustomerInvite> SendInviteAsync(long customerId, CustomerInvite invite = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/send_invite.json");
 
@@ -168,7 +169,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
         /// <returns></returns>
-        public virtual async Task<string> GetAccountActivationUrl(long customerid)
+        public virtual async Task<string> GetAccountActivationUrl(long customerid, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerid}/account_activation_url.json");
             var response = await ExecuteRequestAsync(req, HttpMethod.Post);
@@ -187,7 +188,7 @@ namespace ShopifySharp
         /// https://shopify.dev/docs/admin-api/rest/reference/customers/customer#orders-2020-01
         /// This list does not appear to be paginated. 
         /// </remarks>
-        public virtual async Task<IEnumerable<Order>> ListOrdersForCustomerAsync(long customerId, CustomerOrderListFilter filter = null)
+        public virtual async Task<IEnumerable<Order>> ListOrdersForCustomerAsync(long customerId, CustomerOrderListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<List<Order>>($"customers/{customerId}/orders.json", "orders", filter);
         }

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -22,6 +22,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop customer's addresses.
         /// </summary>
         /// <param name="customerId">The id of the customer to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Address>> ListAsync(long customerId, ListFilter<Address> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter, cancellationToken: cancellationToken);
@@ -33,6 +34,7 @@ namespace ShopifySharp
         /// <param name="customerId">The id of the customer to retrieve.</param>
         /// <param name="addressId">The id of the customer address to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Address"/>.</returns>
         public virtual async Task<Address> GetAsync(long customerId, long addressId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -53,6 +55,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The id of the customer to create address for.</param>
         /// <param name="address">A new <see cref="Address"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Address"/>.</returns>
         public virtual async Task<Address> CreateAsync(long customerId, Address address, CancellationToken cancellationToken = default)
         {
@@ -73,6 +76,7 @@ namespace ShopifySharp
         /// <param name="customerId">Id of the customer object being updated.</param>
         /// <param name="addressId">Id of the address object being updated.</param>
         /// <param name="address">The <see cref="Address"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Customer"/>.</returns>
         public virtual async Task<Address> UpdateAsync(long customerId, long addressId, Address address, CancellationToken cancellationToken = default)
         {
@@ -93,6 +97,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
         /// <param name="addressId">The address object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
@@ -105,6 +110,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
         /// <param name="addressId">The address object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns></returns>
         public virtual async Task<Address> SetDefault(long customerId, long addressId, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -21,7 +22,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop customer's addresses.
         /// </summary>
         /// <param name="customerId">The id of the customer to retrieve.</param>
-        public virtual async Task<ListResult<Address>> ListAsync(long customerId, ListFilter<Address> filter = null)
+        public virtual async Task<ListResult<Address>> ListAsync(long customerId, ListFilter<Address> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter);
         }
@@ -33,7 +34,7 @@ namespace ShopifySharp
         /// <param name="addressId">The id of the customer address to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Address"/>.</returns>
-        public virtual async Task<Address> GetAsync(long customerId, long addressId, string fields = null)
+        public virtual async Task<Address> GetAsync(long customerId, long addressId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
 
@@ -53,7 +54,7 @@ namespace ShopifySharp
         /// <param name="customerId">The id of the customer to create address for.</param>
         /// <param name="address">A new <see cref="Address"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="Address"/>.</returns>
-        public virtual async Task<Address> CreateAsync(long customerId, Address address)
+        public virtual async Task<Address> CreateAsync(long customerId, Address address, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses.json");
             var addressBody = address.ToDictionary();
@@ -73,7 +74,7 @@ namespace ShopifySharp
         /// <param name="addressId">Id of the address object being updated.</param>
         /// <param name="address">The <see cref="Address"/> to update.</param>
         /// <returns>The updated <see cref="Customer"/>.</returns>
-        public virtual async Task<Address> UpdateAsync(long customerId, long addressId, Address address)
+        public virtual async Task<Address> UpdateAsync(long customerId, long addressId, Address address, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
             var addressBody = address.ToDictionary();
@@ -92,7 +93,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerId">The customer object's Id.</param>
         /// <param name="addressId">The address object's Id.</param>
-        public virtual async Task DeleteAsync(long customerId, long addressId)
+        public virtual async Task DeleteAsync(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
 
@@ -105,7 +106,7 @@ namespace ShopifySharp
         /// <param name="customerId">The customer object's Id.</param>
         /// <param name="addressId">The address object's Id.</param>
         /// <returns></returns>
-        public virtual async Task<Address> SetDefault(long customerId, long addressId)
+        public virtual async Task<Address> SetDefault(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}/default.json");
 

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Address>> ListAsync(long customerId, ListFilter<Address> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter, cancellationToken);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Get, rootElement: "customer_address", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Get, cancellationToken, rootElement: "customer_address");
             return response.Result;
         }
 
@@ -66,7 +66,7 @@ namespace ShopifySharp
                 address = addressBody
             });
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Post, content, "customer_address", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Post, cancellationToken, content, "customer_address");
             return response.Result;
         }
 
@@ -88,7 +88,7 @@ namespace ShopifySharp
                 address = addressBody
             });
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, content, "customer_address", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, cancellationToken, content, "customer_address");
             return response.Result;
         }
 
@@ -102,7 +102,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}/default.json");
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, rootElement: "customer_address", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, cancellationToken, rootElement: "customer_address");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// <param name="customerId">The id of the customer to retrieve.</param>
         public virtual async Task<ListResult<Address>> ListAsync(long customerId, ListFilter<Address> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter);
+            return await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Get, rootElement: "customer_address");
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Get, rootElement: "customer_address", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -63,7 +63,7 @@ namespace ShopifySharp
                 address = addressBody
             });
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Post, content, "customer_address");
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Post, content, "customer_address", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -84,7 +84,7 @@ namespace ShopifySharp
                 address = addressBody
             });
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, content, "customer_address");
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, content, "customer_address", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -97,7 +97,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}/default.json");
 
-            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, rootElement: "customer_address");
+            var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, rootElement: "customer_address", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -54,6 +54,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSearchId">The id of the customer to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Customer"/>.</returns>
         public virtual async Task<CustomerSavedSearch> GetAsync(long customerSearchId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -72,6 +73,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="Customer"/> on the store.
         /// </summary>
         /// <param name="customerSavedSearch">A new <see cref="CustomerSavedSearch"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Customer"/>.</returns>
         public virtual async Task<CustomerSavedSearch> CreateAsync(CustomerSavedSearch customerSavedSearch, CancellationToken cancellationToken = default)
         {
@@ -97,6 +99,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSavedSearchId">Id of the object being updated.</param>
         /// <param name="customerSavedSearch">The <see cref="CustomerSavedSearch"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<CustomerSavedSearch> UpdateAsync(long customerSavedSearchId, CustomerSavedSearch customerSavedSearch, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
@@ -127,6 +130,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSavedSearchId">Id of the Customer Saved Search.</param>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Customer>> GetCustomersFromSavedSearchAsync(long customerSavedSearchId, CustomerSavedSearchFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<List<Customer>>($"{RootResource}/{customerSavedSearchId}/customers.json", "customers", filter, cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// <returns>The count of all customers for the shop.</returns>
         public virtual async Task<int> CountAsync(CustomerSavedSearchCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"{RootResource}/count.json", "count", filter);
+            return await ExecuteGetAsync<int>($"{RootResource}/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(ListFilter<CustomerSavedSearch> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"{RootResource}.json", RootResource, filter);
+            return await ExecuteGetListAsync($"{RootResource}.json", RootResource, filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(CustomerSavedSearchListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync((ListFilter<CustomerSavedSearch>) filter);
+            return await ListAsync((ListFilter<CustomerSavedSearch>) filter, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Get, rootElement: RootElement);
+            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Get, rootElement: RootElement, cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -88,7 +88,7 @@ namespace ShopifySharp
                 customer_saved_search = body
             });
 
-            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Post, content, RootElement);
+            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Post, content, RootElement, cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -107,7 +107,7 @@ namespace ShopifySharp
                 customer_saved_search = body
             });
 
-            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Put, content, RootElement);
+            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Put, content, RootElement, cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -129,7 +129,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<IEnumerable<Customer>> GetCustomersFromSavedSearchAsync(long customerSavedSearchId, CustomerSavedSearchFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<Customer>>($"{RootResource}/{customerSavedSearchId}/customers.json", "customers", filter);
+            return await ExecuteGetAsync<List<Customer>>($"{RootResource}/{customerSavedSearchId}/customers.json", "customers", filter, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -27,7 +28,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's customers.
         /// </summary>
         /// <returns>The count of all customers for the shop.</returns>
-        public virtual async Task<int> CountAsync(CustomerSavedSearchCountFilter filter = null)
+        public virtual async Task<int> CountAsync(CustomerSavedSearchCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"{RootResource}/count.json", "count", filter);
         }
@@ -35,7 +36,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's customer saved searches.
         /// </summary>
-        public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(ListFilter<CustomerSavedSearch> filter = null)
+        public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(ListFilter<CustomerSavedSearch> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"{RootResource}.json", RootResource, filter);
         }
@@ -43,7 +44,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's customer saved searches.
         /// </summary>
-        public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(CustomerSavedSearchListFilter filter)
+        public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(CustomerSavedSearchListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync((ListFilter<CustomerSavedSearch>) filter);
         }
@@ -54,7 +55,7 @@ namespace ShopifySharp
         /// <param name="customerSearchId">The id of the customer to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Customer"/>.</returns>
-        public virtual async Task<CustomerSavedSearch> GetAsync(long customerSearchId, string fields = null)
+        public virtual async Task<CustomerSavedSearch> GetAsync(long customerSearchId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{RootResource}/{customerSearchId}.json");
 
@@ -72,7 +73,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSavedSearch">A new <see cref="CustomerSavedSearch"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="Customer"/>.</returns>
-        public virtual async Task<CustomerSavedSearch> CreateAsync(CustomerSavedSearch customerSavedSearch)
+        public virtual async Task<CustomerSavedSearch> CreateAsync(CustomerSavedSearch customerSavedSearch, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(customerSavedSearch.Name))
             {
@@ -96,7 +97,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSavedSearchId">Id of the object being updated.</param>
         /// <param name="customerSavedSearch">The <see cref="CustomerSavedSearch"/> to update.</param>
-        public virtual async Task<CustomerSavedSearch> UpdateAsync(long customerSavedSearchId, CustomerSavedSearch customerSavedSearch)
+        public virtual async Task<CustomerSavedSearch> UpdateAsync(long customerSavedSearchId, CustomerSavedSearch customerSavedSearch, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
             var body = customerSavedSearch.ToDictionary();
@@ -126,7 +127,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="customerSavedSearchId">Id of the Customer Saved Search.</param>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<IEnumerable<Customer>> GetCustomersFromSavedSearchAsync(long customerSavedSearchId, CustomerSavedSearchFilter filter = null)
+        public virtual async Task<IEnumerable<Customer>> GetCustomersFromSavedSearchAsync(long customerSavedSearchId, CustomerSavedSearchFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<List<Customer>>($"{RootResource}/{customerSavedSearchId}/customers.json", "customers", filter);
         }

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// <returns>The count of all customers for the shop.</returns>
         public virtual async Task<int> CountAsync(CustomerSavedSearchCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"{RootResource}/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>($"{RootResource}/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<CustomerSavedSearch>> ListAsync(ListFilter<CustomerSavedSearch> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"{RootResource}.json", RootResource, filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"{RootResource}.json", RootResource, filter, cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Get, rootElement: RootElement, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Get, cancellationToken, rootElement: RootElement);
             return response.Result;
         }
 
@@ -90,7 +90,7 @@ namespace ShopifySharp
                 customer_saved_search = body
             });
 
-            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Post, content, RootElement, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Post, cancellationToken, content, RootElement);
             return response.Result;
         }
 
@@ -110,7 +110,7 @@ namespace ShopifySharp
                 customer_saved_search = body
             });
 
-            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Put, content, RootElement, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CustomerSavedSearch>(req, HttpMethod.Put, cancellationToken, content, RootElement);
             return response.Result;
         }
 
@@ -118,11 +118,12 @@ namespace ShopifySharp
         /// Deletes a customer with the given Id.
         /// </summary>
         /// <param name="customerSavedSearchId">The customer object's Id.</param>
-        public virtual Task DeleteAsync(long customerSavedSearchId)
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual Task DeleteAsync(long customerSavedSearchId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
 
-            return ExecuteRequestAsync(req, HttpMethod.Delete);
+            return ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -133,7 +134,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Customer>> GetCustomersFromSavedSearchAsync(long customerSavedSearchId, CustomerSavedSearchFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<Customer>>($"{RootResource}/{customerSavedSearchId}/customers.json", "customers", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<List<Customer>>($"{RootResource}/{customerSavedSearchId}/customers.json", "customers", filter, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -40,6 +40,7 @@ namespace ShopifySharp
         /// <param name="priceRuleId">The id of the associated price rule.</param>
         /// <param name="discountId">The id of the discount to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="PriceRuleDiscountCode"/>.</returns>
         public virtual async Task<PriceRuleDiscountCode> GetAsync(long priceRuleId, long discountId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -50,6 +51,7 @@ namespace ShopifySharp
         /// Creates a new discount code.
         /// </summary>
         /// <param name="priceRuleId">Id of an existing price rule.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<PriceRuleDiscountCode> CreateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes.json");
@@ -69,6 +71,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="priceRuleId">The Id of the Price Rule being updated.</param>
         /// <param name="code">The code being updated.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<PriceRuleDiscountCode> UpdateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{code.Id.Value}.json");
@@ -86,6 +89,7 @@ namespace ShopifySharp
         /// </summary>
         /// /// <param name="priceRuleId">The price rule object's Id.</param>
         /// <param name="discountId">The discount object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long priceRuleId, long discountCodeId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -23,7 +23,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, ListFilter<PriceRuleDiscountCode> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"price_rules/{priceRuleId}/discount_codes.json", "discount_codes", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"price_rules/{priceRuleId}/discount_codes.json", "discount_codes", filter, cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="PriceRuleDiscountCode"/>.</returns>
         public virtual async Task<PriceRuleDiscountCode> GetAsync(long priceRuleId, long discountId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<PriceRuleDiscountCode>($"price_rules/{priceRuleId}/discount_codes/{discountId}.json", "discount_code", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<PriceRuleDiscountCode>($"price_rules/{priceRuleId}/discount_codes/{discountId}.json", "discount_code", fields, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ShopifySharp
                 discount_code = body
             });
 
-            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Post, content, "discount_code", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Post, cancellationToken, content, "discount_code");
             return response.Result;
         }
 
@@ -80,7 +80,7 @@ namespace ShopifySharp
                 discount_code = code
             });
 
-            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Put, content, "discount_code", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Put, cancellationToken, content, "discount_code");
             return response.Result;
         }
 
@@ -94,7 +94,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -23,7 +23,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, ListFilter<PriceRuleDiscountCode> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"price_rules/{priceRuleId}/discount_codes.json", "discount_codes", filter);
+            return await ExecuteGetListAsync($"price_rules/{priceRuleId}/discount_codes.json", "discount_codes", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, PriceRuleDiscountCodeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(priceRuleId, filter?.AsListFilter());
+            return await ListAsync(priceRuleId, filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="PriceRuleDiscountCode"/>.</returns>
         public virtual async Task<PriceRuleDiscountCode> GetAsync(long priceRuleId, long discountId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<PriceRuleDiscountCode>($"price_rules/{priceRuleId}/discount_codes/{discountId}.json", "discount_code", fields);
+            return await ExecuteGetAsync<PriceRuleDiscountCode>($"price_rules/{priceRuleId}/discount_codes/{discountId}.json", "discount_code", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace ShopifySharp
                 discount_code = body
             });
 
-            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Post, content, "discount_code");
+            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Post, content, "discount_code", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -77,7 +77,7 @@ namespace ShopifySharp
                 discount_code = code
             });
 
-            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Put, content, "discount_code");
+            var response = await ExecuteRequestAsync<PriceRuleDiscountCode>(req, HttpMethod.Put, content, "discount_code", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -90,7 +90,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -20,7 +21,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the discount codes belonging to the price rule.
         /// </summary>
-        public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, ListFilter<PriceRuleDiscountCode> filter)
+        public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, ListFilter<PriceRuleDiscountCode> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"price_rules/{priceRuleId}/discount_codes.json", "discount_codes", filter);
         }
@@ -28,7 +29,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the discount codes belonging to the price rule.
         /// </summary>
-        public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, PriceRuleDiscountCodeListFilter filter = null)
+        public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, PriceRuleDiscountCodeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(priceRuleId, filter?.AsListFilter());
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// <param name="discountId">The id of the discount to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="PriceRuleDiscountCode"/>.</returns>
-        public virtual async Task<PriceRuleDiscountCode> GetAsync(long priceRuleId, long discountId, string fields = null)
+        public virtual async Task<PriceRuleDiscountCode> GetAsync(long priceRuleId, long discountId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<PriceRuleDiscountCode>($"price_rules/{priceRuleId}/discount_codes/{discountId}.json", "discount_code", fields);
         }
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// Creates a new discount code.
         /// </summary>
         /// <param name="priceRuleId">Id of an existing price rule.</param>
-        public virtual async Task<PriceRuleDiscountCode> CreateAsync(long priceRuleId, PriceRuleDiscountCode code)
+        public virtual async Task<PriceRuleDiscountCode> CreateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes.json");
             var body = code.ToDictionary();
@@ -68,7 +69,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="priceRuleId">The Id of the Price Rule being updated.</param>
         /// <param name="code">The code being updated.</param>
-        public virtual async Task<PriceRuleDiscountCode> UpdateAsync(long priceRuleId, PriceRuleDiscountCode code)
+        public virtual async Task<PriceRuleDiscountCode> UpdateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{code.Id.Value}.json");
             var content = new JsonContent(new
@@ -85,7 +86,7 @@ namespace ShopifySharp
         /// </summary>
         /// /// <param name="priceRuleId">The price rule object's Id.</param>
         /// <param name="discountId">The discount object's Id.</param>
-        public virtual async Task DeleteAsync(long priceRuleId, long discountCodeId)
+        public virtual async Task DeleteAsync(long priceRuleId, long discountCodeId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
 

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the count.</param>
         public virtual async Task<int> CountAsync(DraftOrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<DraftOrder>> ListAsync(ListFilter<DraftOrder> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("draft_orders.json", "draft_orders", filter);
+            return await ExecuteGetListAsync("draft_orders.json", "draft_orders", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<DraftOrder>> ListAsync(DraftOrderListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync((ListFilter<DraftOrder>) filter);
+            return await ListAsync((ListFilter<DraftOrder>) filter, cancellationToken);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace ShopifySharp
         /// <param name="fields">A comma-separated list of fields to return.</param>
         public virtual async Task<DraftOrder> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<DraftOrder>($"draft_orders/{id}.json", "draft_order", fields);
+            return await ExecuteGetAsync<DraftOrder>($"draft_orders/{id}.json", "draft_order", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ShopifySharp
                 draft_order = body
             });
 
-            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Post, content, "draft_order");
+            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Post, content, "draft_order", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -87,7 +87,7 @@ namespace ShopifySharp
                 draft_order = order.ToDictionary()
             });
 
-            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, content, "draft_order");
+            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, content, "draft_order", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -99,7 +99,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"draft_orders/{id}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"draft_orders/{id}/complete.json");
             req.QueryParams.Add("payment_pending", paymentPending);
 
-            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, rootElement: "draft_order");
+            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, rootElement: "draft_order", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -130,7 +130,7 @@ namespace ShopifySharp
                 draft_order_invoice = body
             });
 
-            var response = await ExecuteRequestAsync<DraftOrderInvoice>(req, HttpMethod.Post, content, "draft_order_invoice");
+            var response = await ExecuteRequestAsync<DraftOrderInvoice>(req, HttpMethod.Post, content, "draft_order_invoice", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(DraftOrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<DraftOrder>> ListAsync(ListFilter<DraftOrder> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("draft_orders.json", "draft_orders", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("draft_orders.json", "draft_orders", filter, cancellationToken);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<DraftOrder> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<DraftOrder>($"draft_orders/{id}.json", "draft_order", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<DraftOrder>($"draft_orders/{id}.json", "draft_order", fields, cancellationToken);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace ShopifySharp
                 draft_order = body
             });
 
-            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Post, content, "draft_order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Post, cancellationToken, content, "draft_order");
             return response.Result;
         }
 
@@ -91,7 +91,7 @@ namespace ShopifySharp
                 draft_order = order.ToDictionary()
             });
 
-            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, content, "draft_order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, cancellationToken, content, "draft_order");
             return response.Result;
         }
 
@@ -104,7 +104,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"draft_orders/{id}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"draft_orders/{id}/complete.json");
             req.QueryParams.Add("payment_pending", paymentPending);
 
-            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, rootElement: "draft_order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, cancellationToken, rootElement: "draft_order");
             return response.Result;
         }
 
@@ -137,7 +137,7 @@ namespace ShopifySharp
                 draft_order_invoice = body
             });
 
-            var response = await ExecuteRequestAsync<DraftOrderInvoice>(req, HttpMethod.Post, content, "draft_order_invoice", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<DraftOrderInvoice>(req, HttpMethod.Post, cancellationToken, content, "draft_order_invoice");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -21,7 +22,7 @@ namespace ShopifySharp
         /// Retrieves a count of the shop's draft orders. 
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
-        public virtual async Task<int> CountAsync(DraftOrderCountFilter filter = null)
+        public virtual async Task<int> CountAsync(DraftOrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter);
         }
@@ -29,7 +30,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's draft orders.
         /// </summary>
-        public virtual async Task<ListResult<DraftOrder>> ListAsync(ListFilter<DraftOrder> filter = null)
+        public virtual async Task<ListResult<DraftOrder>> ListAsync(ListFilter<DraftOrder> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("draft_orders.json", "draft_orders", filter);
         }
@@ -37,7 +38,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's draft orders.
         /// </summary>
-        public virtual async Task<ListResult<DraftOrder>> ListAsync(DraftOrderListFilter filter)
+        public virtual async Task<ListResult<DraftOrder>> ListAsync(DraftOrderListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync((ListFilter<DraftOrder>) filter);
         }
@@ -47,7 +48,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the object to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
-        public virtual async Task<DraftOrder> GetAsync(long id, string fields = null)
+        public virtual async Task<DraftOrder> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<DraftOrder>($"draft_orders/{id}.json", "draft_order", fields);
         }
@@ -57,7 +58,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="order">A new DraftOrder. Id should be set to null.</param>
         /// <param name="useCustomerDefaultAddress">Optional boolean that you can send as part of a draft order object to load customer shipping information. Defaults to false.</param>
-        public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, bool useCustomerDefaultAddress = false)
+        public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, bool useCustomerDefaultAddress = false, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("draft_orders.json");
             var body = order.ToDictionary();
@@ -78,7 +79,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the item being updated.</param>
         /// <param name="order">The updated draft order.</param>
-        public virtual async Task<DraftOrder> UpdateAsync(long id, DraftOrder order)
+        public virtual async Task<DraftOrder> UpdateAsync(long id, DraftOrder order, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}.json");
             var content = new JsonContent(new 
@@ -94,7 +95,7 @@ namespace ShopifySharp
         /// Deletes the draft order with the given id.
         /// </summary>
         /// <param name="id">The id of the item being deleted.</param>
-        public virtual async Task DeleteAsync(long id)
+        public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}.json");
 
@@ -106,7 +107,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the item being completed.</param>
         /// <param name="paymentPending">A bool indicating whether payment is pending or not. True if payment is pending, false if payment is not pending and order has been paid. Defaults to false (payment not pending).</param>
-        public virtual async Task<DraftOrder> CompleteAsync(long id, bool paymentPending = false)
+        public virtual async Task<DraftOrder> CompleteAsync(long id, bool paymentPending = false, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}/complete.json");
             req.QueryParams.Add("payment_pending", paymentPending);
@@ -119,7 +120,7 @@ namespace ShopifySharp
         /// Send an invoice for the draft order.
         /// </summary>
         /// <param name="id">The id of the item with the invoice.</param>
-        public virtual async Task<DraftOrderInvoice> SendInvoiceAsync(long id, DraftOrderInvoice customInvoice = null)
+        public virtual async Task<DraftOrderInvoice> SendInvoiceAsync(long id, DraftOrderInvoice customInvoice = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}/send_invoice.json");
             // If the custom invoice is not null, use that as the body. Else use an empty dictionary object which will send the default invoice

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -22,6 +22,7 @@ namespace ShopifySharp
         /// Retrieves a count of the shop's draft orders. 
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(DraftOrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -48,6 +49,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the object to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<DraftOrder> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<DraftOrder>($"draft_orders/{id}.json", "draft_order", fields, cancellationToken: cancellationToken);
@@ -58,6 +60,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="order">A new DraftOrder. Id should be set to null.</param>
         /// <param name="useCustomerDefaultAddress">Optional boolean that you can send as part of a draft order object to load customer shipping information. Defaults to false.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, bool useCustomerDefaultAddress = false, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("draft_orders.json");
@@ -79,6 +82,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the item being updated.</param>
         /// <param name="order">The updated draft order.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<DraftOrder> UpdateAsync(long id, DraftOrder order, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}.json");
@@ -95,6 +99,7 @@ namespace ShopifySharp
         /// Deletes the draft order with the given id.
         /// </summary>
         /// <param name="id">The id of the item being deleted.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}.json");
@@ -107,6 +112,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the item being completed.</param>
         /// <param name="paymentPending">A bool indicating whether payment is pending or not. True if payment is pending, false if payment is not pending and order has been paid. Defaults to false (payment not pending).</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<DraftOrder> CompleteAsync(long id, bool paymentPending = false, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}/complete.json");
@@ -120,6 +126,7 @@ namespace ShopifySharp
         /// Send an invoice for the draft order.
         /// </summary>
         /// <param name="id">The id of the item with the invoice.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<DraftOrderInvoice> SendInvoiceAsync(long id, DraftOrderInvoice customInvoice = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"draft_orders/{id}/send_invoice.json");

--- a/ShopifySharp/Services/Event/EventService.cs
+++ b/ShopifySharp/Services/Event/EventService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<int> CountAsync(EventCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("events/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("events/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Event"/>.</returns>
         public virtual async Task<Event> GetAsync(long eventId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Event>($"events/{eventId}.json", "event", fields);
+            return await ExecuteGetAsync<Event>($"events/{eventId}.json", "event", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace ShopifySharp
                 subjectType = subjectType + "s";
             }
             
-            return await ExecuteGetListAsync($"{subjectType?.ToLower()}/{subjectId}/events.json", "events", filter);
+            return await ExecuteGetListAsync($"{subjectType?.ToLower()}/{subjectId}/events.json", "events", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Event>> ListAsync(ListFilter<Event> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"events.json", "events", filter);
+            return await ExecuteGetListAsync($"events.json", "events", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace ShopifySharp
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
         public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, EventListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(subjectId, subjectType, (ListFilter<Event>) filter);
+            return await ListAsync(subjectId, subjectType, (ListFilter<Event>) filter, cancellationToken);
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Event>> ListAsync(EventListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Event/EventService.cs
+++ b/ShopifySharp/Services/Event/EventService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all site events.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(EventCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("events/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -36,6 +37,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="eventId">The id of the event to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Event"/>.</returns>
         public virtual async Task<Event> GetAsync(long eventId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -47,6 +49,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="subjectId">Restricts results to just one subject item, e.g. all changes on a product.</param>
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, ListFilter<Event> filter = null, CancellationToken cancellationToken = default)
         {
             // Ensure the subject type is plural
@@ -71,6 +74,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="subjectId">Restricts results to just one subject item, e.g. all changes on a product.</param>
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, EventListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(subjectId, subjectType, (ListFilter<Event>) filter, cancellationToken);

--- a/ShopifySharp/Services/Event/EventService.cs
+++ b/ShopifySharp/Services/Event/EventService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Lists;
 
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all site events.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<int> CountAsync(EventCountFilter filter = null)
+        public virtual async Task<int> CountAsync(EventCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("events/count.json", "count", filter);
         }
@@ -36,7 +37,7 @@ namespace ShopifySharp
         /// <param name="eventId">The id of the event to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Event"/>.</returns>
-        public virtual async Task<Event> GetAsync(long eventId, string fields = null)
+        public virtual async Task<Event> GetAsync(long eventId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Event>($"events/{eventId}.json", "event", fields);
         }
@@ -46,7 +47,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="subjectId">Restricts results to just one subject item, e.g. all changes on a product.</param>
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
-        public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, ListFilter<Event> filter = null)
+        public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, ListFilter<Event> filter = null, CancellationToken cancellationToken = default)
         {
             // Ensure the subject type is plural
             if (!subjectType.Substring(subjectType.Length - 1).Equals("s", StringComparison.OrdinalIgnoreCase))
@@ -60,7 +61,7 @@ namespace ShopifySharp
         /// <summary>
         /// Returns a list of events.
         /// </summary>
-        public virtual async Task<ListResult<Event>> ListAsync(ListFilter<Event> filter)
+        public virtual async Task<ListResult<Event>> ListAsync(ListFilter<Event> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"events.json", "events", filter);
         }
@@ -70,7 +71,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="subjectId">Restricts results to just one subject item, e.g. all changes on a product.</param>
         /// <param name="subjectType">The subject's type, e.g. 'Order' or 'Product'. Known subject types are 'Articles', 'Blogs', 'Custom_Collections', 'Comments', 'Orders', 'Pages', 'Products' and 'Smart_Collections'.  A current list of subject types can be found at https://help.shopify.com/api/reference/event </param>
-        public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, EventListFilter filter)
+        public virtual async Task<ListResult<Event>> ListAsync(long subjectId, string subjectType, EventListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(subjectId, subjectType, (ListFilter<Event>) filter);
         }
@@ -78,7 +79,7 @@ namespace ShopifySharp
         /// <summary>
         /// Returns a list of events.
         /// </summary>
-        public virtual async Task<ListResult<Event>> ListAsync(EventListFilter filter = null)
+        public virtual async Task<ListResult<Event>> ListAsync(EventListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// <returns>The count of all fulfillments for the shop.</returns>
         public virtual async Task<int> CountAsync(long orderId, FulfillmentCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"orders/{orderId}/fulfillments/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>($"orders/{orderId}/fulfillments/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, ListFilter<Fulfillment> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"orders/{orderId}/fulfillments.json", "fulfillments", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"orders/{orderId}/fulfillments.json", "fulfillments", filter, cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Fulfillment"/>.</returns>
         public virtual async Task<Fulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Fulfillment>($"orders/{orderId}/fulfillments/{fulfillmentId}.json", "fulfillment", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Fulfillment>($"orders/{orderId}/fulfillments/{fulfillmentId}.json", "fulfillment", fields, cancellationToken);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace ShopifySharp
                 fulfillment = body
             });
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, content, "fulfillment", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, content, "fulfillment");
             return response.Result;
         }
 
@@ -106,7 +106,7 @@ namespace ShopifySharp
                 fulfillment = body
             });
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Put, content, "fulfillment", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Put, cancellationToken, content, "fulfillment");
             return response.Result;
         }
 
@@ -120,7 +120,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/complete.json");
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment");
             return response.Result;
         }
 
@@ -134,7 +134,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/cancel.json");
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment");
             return response.Result;
         }
 
@@ -148,7 +148,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/open.json");
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <returns>The count of all fulfillments for the shop.</returns>
         public virtual async Task<int> CountAsync(long orderId, FulfillmentCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"orders/{orderId}/fulfillments/count.json", "count", filter);
+            return await ExecuteGetAsync<int>($"orders/{orderId}/fulfillments/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, ListFilter<Fulfillment> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"orders/{orderId}/fulfillments.json", "fulfillments", filter);
+            return await ExecuteGetListAsync($"orders/{orderId}/fulfillments.json", "fulfillments", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, FulfillmentListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(orderId, filter?.AsListFilter());
+            return await ListAsync(orderId, filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Fulfillment"/>.</returns>
         public virtual async Task<Fulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Fulfillment>($"orders/{orderId}/fulfillments/{fulfillmentId}.json", "fulfillment", fields);
+            return await ExecuteGetAsync<Fulfillment>($"orders/{orderId}/fulfillments/{fulfillmentId}.json", "fulfillment", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace ShopifySharp
                 fulfillment = body
             });
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, content, "fulfillment");
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, content, "fulfillment", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -100,7 +100,7 @@ namespace ShopifySharp
                 fulfillment = body
             });
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Put, content, "fulfillment");
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Put, content, "fulfillment", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -113,7 +113,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/complete.json");
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment");
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -126,7 +126,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/cancel.json");
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment");
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -139,7 +139,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/open.json");
 
-            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment");
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, rootElement: "fulfillment", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the count.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The count of all fulfillments for the shop.</returns>
         public virtual async Task<int> CountAsync(long orderId, FulfillmentCountFilter filter = null, CancellationToken cancellationToken = default)
         {
@@ -37,6 +38,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, ListFilter<Fulfillment> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"orders/{orderId}/fulfillments.json", "fulfillments", filter, cancellationToken: cancellationToken);
@@ -47,6 +49,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, FulfillmentListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(orderId, filter?.AsListFilter(), cancellationToken);
@@ -58,6 +61,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The id of the Fulfillment to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Fulfillment"/>.</returns>
         public virtual async Task<Fulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -69,6 +73,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillment">A new <see cref="Fulfillment"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Fulfillment"/>.</returns>
         public virtual async Task<Fulfillment> CreateAsync(long orderId, Fulfillment fulfillment, CancellationToken cancellationToken = default)
         {
@@ -90,6 +95,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">Id of the object being updated.</param>
         /// <param name="fulfillment">The <see cref="Fulfillment"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Fulfillment"/>.</returns>
         public virtual async Task<Fulfillment> UpdateAsync(long orderId, long fulfillmentId, Fulfillment fulfillment, CancellationToken cancellationToken = default)
         {
@@ -109,6 +115,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Fulfillment> CompleteAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/complete.json");
@@ -122,6 +129,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Fulfillment> CancelAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/cancel.json");
@@ -135,6 +143,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Fulfillment> OpenAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/open.json");

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using System;
+using System.Threading;
 using ShopifySharp.Lists;
 
 namespace ShopifySharp
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the count.</param>
         /// <returns>The count of all fulfillments for the shop.</returns>
-        public virtual async Task<int> CountAsync(long orderId, FulfillmentCountFilter filter = null)
+        public virtual async Task<int> CountAsync(long orderId, FulfillmentCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"orders/{orderId}/fulfillments/count.json", "count", filter);
         }
@@ -36,7 +37,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, ListFilter<Fulfillment> filter = null)
+        public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, ListFilter<Fulfillment> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"orders/{orderId}/fulfillments.json", "fulfillments", filter);
         }
@@ -46,7 +47,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, FulfillmentListFilter filter)
+        public virtual async Task<ListResult<Fulfillment>> ListAsync(long orderId, FulfillmentListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(orderId, filter?.AsListFilter());
         }
@@ -58,7 +59,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentId">The id of the Fulfillment to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Fulfillment"/>.</returns>
-        public virtual async Task<Fulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null)
+        public virtual async Task<Fulfillment> GetAsync(long orderId, long fulfillmentId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Fulfillment>($"orders/{orderId}/fulfillments/{fulfillmentId}.json", "fulfillment", fields);
         }
@@ -69,7 +70,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillment">A new <see cref="Fulfillment"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="Fulfillment"/>.</returns>
-        public virtual async Task<Fulfillment> CreateAsync(long orderId, Fulfillment fulfillment)
+        public virtual async Task<Fulfillment> CreateAsync(long orderId, Fulfillment fulfillment, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments.json");
             var body = fulfillment.ToDictionary();
@@ -90,7 +91,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentId">Id of the object being updated.</param>
         /// <param name="fulfillment">The <see cref="Fulfillment"/> to update.</param>
         /// <returns>The updated <see cref="Fulfillment"/>.</returns>
-        public virtual async Task<Fulfillment> UpdateAsync(long orderId, long fulfillmentId, Fulfillment fulfillment)
+        public virtual async Task<Fulfillment> UpdateAsync(long orderId, long fulfillmentId, Fulfillment fulfillment, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}.json");
             var body = fulfillment.ToDictionary();
@@ -108,7 +109,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
-        public virtual async Task<Fulfillment> CompleteAsync(long orderId, long fulfillmentId)
+        public virtual async Task<Fulfillment> CompleteAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/complete.json");
 
@@ -121,7 +122,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
-        public virtual async Task<Fulfillment> CancelAsync(long orderId, long fulfillmentId)
+        public virtual async Task<Fulfillment> CancelAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/cancel.json");
 
@@ -134,7 +135,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="fulfillmentId">The fulfillment's id.</param>
-        public virtual async Task<Fulfillment> OpenAsync(long orderId, long fulfillmentId)
+        public virtual async Task<Fulfillment> OpenAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/open.json");
 

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillment belongs to.</param>
         /// <param name="fulfillmentId">The fulfillment id to which the fulfillment events belong to.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The list of fulfillment events for the given fulfillment.</returns>
         public virtual async Task<IEnumerable<FulfillmentEvent>> ListAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
@@ -38,6 +39,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillment belongs to.</param>
         /// <param name="fulfillmentId">The id of the fulfillment to which the event belongs to.</param>
         /// <param name="fulfillmentEventId">The id of the fulfillment event to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="FulfillmentEvent"/>.</returns>
         public virtual async Task<FulfillmentEvent> GetAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
@@ -48,6 +50,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="FulfillmentEvent"/> on the fulfillment.
         /// </summary>
         /// <param name="event">A new <see cref="Fulfillment"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="FulfillmentEvent"/>.</returns>
         public virtual async Task<FulfillmentEvent> CreateAsync(long orderId, long fulfillmentId, FulfillmentEvent @event, CancellationToken cancellationToken = default)
         {
@@ -68,6 +71,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillment belongs to.</param>
         /// <param name="fulfillmentId">The id of the fulfillment to which the event belongs to.</param>
         /// <param name="fulfillmentEventId">The id of the fulfillment event to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -61,7 +61,7 @@ namespace ShopifySharp
                 @event
             });
 
-            var response = await ExecuteRequestAsync<FulfillmentEvent>(req, HttpMethod.Post, content, "fulfillment_event", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<FulfillmentEvent>(req, HttpMethod.Post, cancellationToken, content, "fulfillment_event");
             return response.Result;
         }
 
@@ -76,7 +76,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillment belongs to.</param>
         /// <param name="fulfillmentId">The fulfillment id to which the fulfillment events belong to.</param>
         /// <returns>The list of fulfillment events for the given fulfillment.</returns>
-        public virtual async Task<IEnumerable<FulfillmentEvent>> ListAsync(long orderId, long fulfillmentId)
+        public virtual async Task<IEnumerable<FulfillmentEvent>> ListAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<FulfillmentEvent>>($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json", "fulfillment_events");
         }
@@ -38,7 +39,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentId">The id of the fulfillment to which the event belongs to.</param>
         /// <param name="fulfillmentEventId">The id of the fulfillment event to retrieve.</param>
         /// <returns>The <see cref="FulfillmentEvent"/>.</returns>
-        public virtual async Task<FulfillmentEvent> GetAsync(long orderId, long fulfillmentId, long fulfillmentEventId)
+        public virtual async Task<FulfillmentEvent> GetAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<FulfillmentEvent>($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json", "fulfillment_event");
         }
@@ -48,7 +49,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="event">A new <see cref="Fulfillment"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="FulfillmentEvent"/>.</returns>
-        public virtual async Task<FulfillmentEvent> CreateAsync(long orderId, long fulfillmentId, FulfillmentEvent @event)
+        public virtual async Task<FulfillmentEvent> CreateAsync(long orderId, long fulfillmentId, FulfillmentEvent @event, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json");
 
@@ -67,7 +68,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillment belongs to.</param>
         /// <param name="fulfillmentId">The id of the fulfillment to which the event belongs to.</param>
         /// <param name="fulfillmentEventId">The id of the fulfillment event to retrieve.</param>
-        public virtual async Task DeleteAsync(long orderId, long fulfillmentId, long fulfillmentEventId)
+        public virtual async Task DeleteAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
 

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <returns>The list of fulfillment events for the given fulfillment.</returns>
         public virtual async Task<IEnumerable<FulfillmentEvent>> ListAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<FulfillmentEvent>>($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json", "fulfillment_events");
+            return await ExecuteGetAsync<IEnumerable<FulfillmentEvent>>($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json", "fulfillment_events", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="FulfillmentEvent"/>.</returns>
         public virtual async Task<FulfillmentEvent> GetAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<FulfillmentEvent>($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json", "fulfillment_event");
+            return await ExecuteGetAsync<FulfillmentEvent>($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json", "fulfillment_event", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ShopifySharp
                 @event
             });
 
-            var response = await ExecuteRequestAsync<FulfillmentEvent>(req, HttpMethod.Post, content, "fulfillment_event");
+            var response = await ExecuteRequestAsync<FulfillmentEvent>(req, HttpMethod.Post, content, "fulfillment_event", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -72,7 +72,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// <returns>The list of fulfillment services matching the filter.</returns>
         public virtual async Task<IEnumerable<FulfillmentServiceEntity>> ListAsync(FulfillmentServiceListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<FulfillmentServiceEntity>>("fulfillment_services.json", "fulfillment_services", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<List<FulfillmentServiceEntity>>("fulfillment_services.json", "fulfillment_services", filter, cancellationToken);
         }
 
         /// <summary>
@@ -36,13 +36,14 @@ namespace ShopifySharp
         /// <returns>The <see cref="Fulfillment"/>.</returns>
         public virtual async Task<FulfillmentServiceEntity> GetAsync(long fulfillmentServiceId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<FulfillmentServiceEntity>($"fulfillment_services/{fulfillmentServiceId}.json", "fulfillment_service", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<FulfillmentServiceEntity>($"fulfillment_services/{fulfillmentServiceId}.json", "fulfillment_service", fields, cancellationToken);
         }
 
         /// <summary>
         /// Creates a new <see cref="FulfillmentServiceEntity"/>.
         /// </summary>
         /// <param name="fulfillmentServiceEntity">A new <see cref="FulfillmentServiceEntity"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// has been created.</param>
         /// <returns>The new <see cref="FulfillmentServiceEntity"/>.</returns>
         public virtual async Task<FulfillmentServiceEntity> CreateAsync(FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
@@ -55,7 +56,7 @@ namespace ShopifySharp
                 fulfillment_service = body
             });
 
-            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Post, content, "fulfillment_service", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Post, cancellationToken, content, "fulfillment_service");
             return response.Result;
         }
 
@@ -76,7 +77,7 @@ namespace ShopifySharp
                 fulfillment_service = body
             });
 
-            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Put, content, "fulfillment_service", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Put, cancellationToken, content, "fulfillment_service");
             return response.Result;
         }
 
@@ -89,7 +90,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 
@@ -20,7 +21,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="scope">Set scope to all to retrieve all of the store's fulfillment services</param>
         /// <returns>The list of fulfillment services matching the filter.</returns>
-        public virtual async Task<IEnumerable<FulfillmentServiceEntity>> ListAsync(FulfillmentServiceListFilter filter = null)
+        public virtual async Task<IEnumerable<FulfillmentServiceEntity>> ListAsync(FulfillmentServiceListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<List<FulfillmentServiceEntity>>("fulfillment_services.json", "fulfillment_services", filter);
         }
@@ -31,7 +32,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentServiceId">The if of the fulfillment service.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Fulfillment"/>.</returns>
-        public virtual async Task<FulfillmentServiceEntity> GetAsync(long fulfillmentServiceId, string fields = null)
+        public virtual async Task<FulfillmentServiceEntity> GetAsync(long fulfillmentServiceId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<FulfillmentServiceEntity>($"fulfillment_services/{fulfillmentServiceId}.json", "fulfillment_service", fields);
         }
@@ -42,7 +43,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentServiceEntity">A new <see cref="FulfillmentServiceEntity"/>. Id should be set to null.</param>
         /// has been created.</param>
         /// <returns>The new <see cref="FulfillmentServiceEntity"/>.</returns>
-        public virtual async Task<FulfillmentServiceEntity> CreateAsync(FulfillmentServiceEntity fulfillmentServiceEntity)
+        public virtual async Task<FulfillmentServiceEntity> CreateAsync(FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"fulfillment_services.json");
             var body = fulfillmentServiceEntity.ToDictionary();
@@ -62,7 +63,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentServiceId">Id of the fulfillment service being updated.</param>
         /// <param name="fulfillmentServiceEntity">The <see cref="FulfillmentServiceEntity"/> to update.</param>
         /// <returns>The updated <see cref="FulfillmentServiceEntity"/>.</returns>
-        public virtual async Task<FulfillmentServiceEntity> UpdateAsync(long fulfillmentServiceId, FulfillmentServiceEntity fulfillmentServiceEntity)
+        public virtual async Task<FulfillmentServiceEntity> UpdateAsync(long fulfillmentServiceId, FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
             var body = fulfillmentServiceEntity.ToDictionary();
@@ -80,7 +81,7 @@ namespace ShopifySharp
         /// Deletes a fulfillment service with the given Id.
         /// </summary>
         /// <param name="fulfillmentServiceId">The fulfillment service object's Id.</param>
-        public virtual async Task DeleteAsync(long fulfillmentServiceId)
+        public virtual async Task DeleteAsync(long fulfillmentServiceId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
 

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -23,7 +23,7 @@ namespace ShopifySharp
         /// <returns>The list of fulfillment services matching the filter.</returns>
         public virtual async Task<IEnumerable<FulfillmentServiceEntity>> ListAsync(FulfillmentServiceListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<FulfillmentServiceEntity>>("fulfillment_services.json", "fulfillment_services", filter);
+            return await ExecuteGetAsync<List<FulfillmentServiceEntity>>("fulfillment_services.json", "fulfillment_services", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Fulfillment"/>.</returns>
         public virtual async Task<FulfillmentServiceEntity> GetAsync(long fulfillmentServiceId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<FulfillmentServiceEntity>($"fulfillment_services/{fulfillmentServiceId}.json", "fulfillment_service", fields);
+            return await ExecuteGetAsync<FulfillmentServiceEntity>($"fulfillment_services/{fulfillmentServiceId}.json", "fulfillment_service", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
                 fulfillment_service = body
             });
 
-            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Post, content, "fulfillment_service");
+            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Post, content, "fulfillment_service", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -73,7 +73,7 @@ namespace ShopifySharp
                 fulfillment_service = body
             });
 
-            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Put, content, "fulfillment_service");
+            var response = await ExecuteRequestAsync<FulfillmentServiceEntity>(req, HttpMethod.Put, content, "fulfillment_service", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -85,7 +85,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -20,6 +20,7 @@ namespace ShopifySharp
         /// Gets a list of your app's FulfillmentServices.
         /// </summary>
         /// <param name="scope">Set scope to all to retrieve all of the store's fulfillment services</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The list of fulfillment services matching the filter.</returns>
         public virtual async Task<IEnumerable<FulfillmentServiceEntity>> ListAsync(FulfillmentServiceListFilter filter = null, CancellationToken cancellationToken = default)
         {
@@ -31,6 +32,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="fulfillmentServiceId">The if of the fulfillment service.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Fulfillment"/>.</returns>
         public virtual async Task<FulfillmentServiceEntity> GetAsync(long fulfillmentServiceId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -62,6 +64,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="fulfillmentServiceId">Id of the fulfillment service being updated.</param>
         /// <param name="fulfillmentServiceEntity">The <see cref="FulfillmentServiceEntity"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="FulfillmentServiceEntity"/>.</returns>
         public virtual async Task<FulfillmentServiceEntity> UpdateAsync(long fulfillmentServiceId, FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
@@ -81,6 +84,7 @@ namespace ShopifySharp
         /// Deletes a fulfillment service with the given Id.
         /// </summary>
         /// <param name="fulfillmentServiceId">The fulfillment service object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long fulfillmentServiceId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
 
         public virtual async Task<int> CountAsync(GiftCardCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"gift_cards/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>($"gift_cards/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<GiftCard>> ListAsync(ListFilter<GiftCard> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("gift_cards.json", "gift_cards", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("gift_cards.json", "gift_cards", filter, cancellationToken);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace ShopifySharp
                 gift_card = body
             });
 
-            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, content, "gift_card", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, cancellationToken, content, "gift_card");
             return response.Result;
         }
 
@@ -93,7 +93,7 @@ namespace ShopifySharp
             {
                 gift_card = giftCard
             });
-            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Put, content, "gift_card", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Put, cancellationToken, content, "gift_card");
             return response.Result;
         }
         
@@ -106,7 +106,7 @@ namespace ShopifySharp
         public virtual async Task<GiftCard> DisableAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"gift_cards/{giftCardId}/disable.json");
-            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, rootElement: "gift_card", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, cancellationToken, rootElement: "gift_card");
             return response.Result;
         }
 
@@ -126,7 +126,7 @@ namespace ShopifySharp
             
             req.QueryParams.AddRange(filter.ToQueryParameters());
             
-            var response = await ExecuteRequestAsync<List<GiftCard>>(req, HttpMethod.Get, rootElement: "gift_cards", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<GiftCard>>(req, HttpMethod.Get, cancellationToken, rootElement: "gift_cards");
 
             return ParseLinkHeaderToListResult(response);
         }

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
 
         public virtual async Task<int> CountAsync(GiftCardCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"gift_cards/count.json", "count", filter);
+            return await ExecuteGetAsync<int>($"gift_cards/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<ListResult<GiftCard>> ListAsync(ListFilter<GiftCard> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("gift_cards.json", "gift_cards", filter);
+            return await ExecuteGetListAsync("gift_cards.json", "gift_cards", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<ListResult<GiftCard>> ListAsync(GiftCardListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="GiftCard"/>.</returns>
         public virtual async Task<GiftCard> GetAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<GiftCard>($"gift_cards/{giftCardId}.json", "gift_card");
+            return await ExecuteGetAsync<GiftCard>($"gift_cards/{giftCardId}.json", "gift_card", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace ShopifySharp
                 gift_card = body
             });
 
-            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, content, "gift_card");
+            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, content, "gift_card", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -88,7 +88,7 @@ namespace ShopifySharp
             {
                 gift_card = giftCard
             });
-            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Put, content, "gift_card");
+            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Put, content, "gift_card", cancellationToken: cancellationToken);
             return response.Result;
         }
         
@@ -100,7 +100,7 @@ namespace ShopifySharp
         public virtual async Task<GiftCard> DisableAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"gift_cards/{giftCardId}/disable.json");
-            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, rootElement: "gift_card");
+            var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, rootElement: "gift_card", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -119,7 +119,7 @@ namespace ShopifySharp
             
             req.QueryParams.AddRange(filter.ToQueryParameters());
             
-            var response = await ExecuteRequestAsync<List<GiftCard>>(req, HttpMethod.Get, rootElement: "gift_cards");
+            var response = await ExecuteRequestAsync<List<GiftCard>>(req, HttpMethod.Get, rootElement: "gift_cards", cancellationToken: cancellationToken);
 
             return ParseLinkHeaderToListResult(response);
         }

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -32,6 +32,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the gift cards.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<GiftCard>> ListAsync(ListFilter<GiftCard> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("gift_cards.json", "gift_cards", filter, cancellationToken: cancellationToken);
@@ -41,6 +42,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the gift cards.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<GiftCard>> ListAsync(GiftCardListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter(), cancellationToken);
@@ -50,6 +52,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="GiftCard"/> with the given id.
         /// </summary>
         /// <param name="giftCardId">The id of the GiftCard to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="GiftCard"/>.</returns>
         public virtual async Task<GiftCard> GetAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
@@ -60,6 +63,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="GiftCard"/>.
         /// </summary>
         /// <param name="giftCard">A new <see cref="GiftCard"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="GiftCard"/>.</returns>
         public virtual async Task<GiftCard> CreateAsync(GiftCard giftCard, CancellationToken cancellationToken = default)
         {
@@ -80,6 +84,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="giftCardId">Id of the object being updated.</param>
         /// <param name="giftCard">The <see cref="GiftCard"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="GiftCard"/>.</returns>
         public virtual async Task<GiftCard> UpdateAsync(long giftCardId, GiftCard giftCard, CancellationToken cancellationToken = default)
         {
@@ -96,6 +101,7 @@ namespace ShopifySharp
         /// Disables the <see cref="GiftCard"/> with the given id.
         /// </summary>
         /// <param name="giftCardId">The id of the GiftCard to disable.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="GiftCard"/>.</returns>
         public virtual async Task<GiftCard> DisableAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
@@ -108,6 +114,7 @@ namespace ShopifySharp
         /// Search for gift cards matching supplied query
         /// </summary>
         /// <param name="filter">Options for searching and filtering the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<GiftCard>> SearchAsync(GiftCardSearchFilter filter, CancellationToken cancellationToken = default)
         {
             if (filter == null)

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -22,7 +23,7 @@ namespace ShopifySharp
         {
         }
 
-        public virtual async Task<int> CountAsync(GiftCardCountFilter filter = null)
+        public virtual async Task<int> CountAsync(GiftCardCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"gift_cards/count.json", "count", filter);
         }
@@ -31,7 +32,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the gift cards.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<ListResult<GiftCard>> ListAsync(ListFilter<GiftCard> filter)
+        public virtual async Task<ListResult<GiftCard>> ListAsync(ListFilter<GiftCard> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("gift_cards.json", "gift_cards", filter);
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the gift cards.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<ListResult<GiftCard>> ListAsync(GiftCardListFilter filter = null)
+        public virtual async Task<ListResult<GiftCard>> ListAsync(GiftCardListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -50,7 +51,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="giftCardId">The id of the GiftCard to retrieve.</param>
         /// <returns>The <see cref="GiftCard"/>.</returns>
-        public virtual async Task<GiftCard> GetAsync(long giftCardId)
+        public virtual async Task<GiftCard> GetAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<GiftCard>($"gift_cards/{giftCardId}.json", "gift_card");
         }
@@ -60,7 +61,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="giftCard">A new <see cref="GiftCard"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="GiftCard"/>.</returns>
-        public virtual async Task<GiftCard> CreateAsync(GiftCard giftCard)
+        public virtual async Task<GiftCard> CreateAsync(GiftCard giftCard, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("gift_cards.json");
             var body = giftCard.ToDictionary();
@@ -80,7 +81,7 @@ namespace ShopifySharp
         /// <param name="giftCardId">Id of the object being updated.</param>
         /// <param name="giftCard">The <see cref="GiftCard"/> to update.</param>
         /// <returns>The updated <see cref="GiftCard"/>.</returns>
-        public virtual async Task<GiftCard> UpdateAsync(long giftCardId, GiftCard giftCard)
+        public virtual async Task<GiftCard> UpdateAsync(long giftCardId, GiftCard giftCard, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"gift_cards/{giftCardId}.json");
             var content = new JsonContent(new
@@ -96,7 +97,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="giftCardId">The id of the GiftCard to disable.</param>
         /// <returns>The <see cref="GiftCard"/>.</returns>
-        public virtual async Task<GiftCard> DisableAsync(long giftCardId)
+        public virtual async Task<GiftCard> DisableAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"gift_cards/{giftCardId}/disable.json");
             var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, rootElement: "gift_card");
@@ -107,7 +108,7 @@ namespace ShopifySharp
         /// Search for gift cards matching supplied query
         /// </summary>
         /// <param name="filter">Options for searching and filtering the results.</param>
-        public virtual async Task<ListResult<GiftCard>> SearchAsync(GiftCardSearchFilter filter)
+        public virtual async Task<ListResult<GiftCard>> SearchAsync(GiftCardSearchFilter filter, CancellationToken cancellationToken = default)
         {
             if (filter == null)
             {

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// Gets a list of gift card adjustments belonging to the given gift card.
         /// </summary>
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
-        public virtual async Task<IEnumerable<GiftCardAdjustment>> ListAsync(long giftCardId)
+        public virtual async Task<IEnumerable<GiftCardAdjustment>> ListAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<GiftCardAdjustment>>($"gift_cards/{giftCardId}/adjustments.json", "adjustments");
         }
@@ -37,7 +38,7 @@ namespace ShopifySharp
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
         /// <param name="adjustmentId">The id of the adjustment to retrieve.</param>
         /// <returns></returns>
-        public virtual async Task<GiftCardAdjustment> GetAsync(long giftCardId, long adjustmentId)
+        public virtual async Task<GiftCardAdjustment> GetAsync(long giftCardId, long adjustmentId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync< GiftCardAdjustment>($"gift_cards/{giftCardId}/adjustments/{adjustmentId}.json", "adjustment");
         }
@@ -48,7 +49,7 @@ namespace ShopifySharp
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
         /// <param name="adjustment">A new <see cref="GiftCardAdjustment"/>. Signed amount and note should be the only properties set.</param>
         /// <returns></returns>
-        public virtual async Task<GiftCardAdjustment> CreateAsync(long giftCardId, GiftCardAdjustment adjustment)
+        public virtual async Task<GiftCardAdjustment> CreateAsync(long giftCardId, GiftCardAdjustment adjustment, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"gift_cards/{giftCardId}/adjustments.json");
             var content = new JsonContent(new

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
         public virtual async Task<IEnumerable<GiftCardAdjustment>> ListAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<GiftCardAdjustment>>($"gift_cards/{giftCardId}/adjustments.json", "adjustments");
+            return await ExecuteGetAsync<IEnumerable<GiftCardAdjustment>>($"gift_cards/{giftCardId}/adjustments.json", "adjustments", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <returns></returns>
         public virtual async Task<GiftCardAdjustment> GetAsync(long giftCardId, long adjustmentId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync< GiftCardAdjustment>($"gift_cards/{giftCardId}/adjustments/{adjustmentId}.json", "adjustment");
+            return await ExecuteGetAsync< GiftCardAdjustment>($"gift_cards/{giftCardId}/adjustments/{adjustmentId}.json", "adjustment", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace ShopifySharp
                 adjustment = adjustment
             });
 
-            var response = await ExecuteRequestAsync<GiftCardAdjustment>(req, HttpMethod.Post, content, "adjustment");
+            var response = await ExecuteRequestAsync<GiftCardAdjustment>(req, HttpMethod.Post, content, "adjustment", cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -60,7 +60,7 @@ namespace ShopifySharp
                 adjustment = adjustment
             });
 
-            var response = await ExecuteRequestAsync<GiftCardAdjustment>(req, HttpMethod.Post, content, "adjustment", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<GiftCardAdjustment>(req, HttpMethod.Post, cancellationToken, content, "adjustment");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -27,6 +27,7 @@ namespace ShopifySharp
         /// Gets a list of gift card adjustments belonging to the given gift card.
         /// </summary>
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<GiftCardAdjustment>> ListAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<GiftCardAdjustment>>($"gift_cards/{giftCardId}/adjustments.json", "adjustments", cancellationToken: cancellationToken);
@@ -37,6 +38,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
         /// <param name="adjustmentId">The id of the adjustment to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns></returns>
         public virtual async Task<GiftCardAdjustment> GetAsync(long giftCardId, long adjustmentId, CancellationToken cancellationToken = default)
         {
@@ -48,6 +50,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="giftCardId">The gift card that the adjustment was applied to.</param>
         /// <param name="adjustment">A new <see cref="GiftCardAdjustment"/>. Signed amount and note should be the only properties set.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns></returns>
         public virtual async Task<GiftCardAdjustment> CreateAsync(long giftCardId, GiftCardAdjustment adjustment, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using Newtonsoft.Json;
 using System.Net;
+using System.Threading;
 
 namespace ShopifySharp
 {
@@ -27,7 +28,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="body">The query you would like to execute. Please see documentation for formatting.</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        public virtual async Task<JToken> PostAsync(string body)
+        public virtual async Task<JToken> PostAsync(string body, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("graphql.json");
 
@@ -41,7 +42,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="body">The query you would like to execute, as a JToken. Please see documentation for formatting.</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        public virtual async Task<JToken> PostAsync(JToken body)
+        public virtual async Task<JToken> PostAsync(JToken body, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("graphql.json");
 
@@ -56,7 +57,7 @@ namespace ShopifySharp
         /// <param name="req">The RequestUri.</param>
         /// <param name="content">The HttpContent, be it GraphQL or Json.</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        private async Task<JToken> SendAsync(RequestUri req, HttpContent content)
+        private async Task<JToken> SendAsync(RequestUri req, HttpContent content, CancellationToken cancellationToken = default)
         {
             var response = await ExecuteRequestAsync(req, HttpMethod.Post, content);
 

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <returns>A JToken containing the data from the request.</returns>
         private async Task<JToken> SendAsync(RequestUri req, HttpContent content, CancellationToken cancellationToken = default)
         {
-            var response = await ExecuteRequestAsync(req, HttpMethod.Post, content);
+            var response = await ExecuteRequestAsync(req, HttpMethod.Post, content, cancellationToken: cancellationToken);
 
             CheckForErrors(response);
 

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -27,6 +27,7 @@ namespace ShopifySharp
         /// Executes a Graph API Call.
         /// </summary>
         /// <param name="body">The query you would like to execute. Please see documentation for formatting.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A JToken containing the data from the request.</returns>
         public virtual async Task<JToken> PostAsync(string body, CancellationToken cancellationToken = default)
         {
@@ -41,6 +42,7 @@ namespace ShopifySharp
         /// Executes a Graph API Call.
         /// </summary>
         /// <param name="body">The query you would like to execute, as a JToken. Please see documentation for formatting.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A JToken containing the data from the request.</returns>
         public virtual async Task<JToken> PostAsync(JToken body, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -35,7 +35,7 @@ namespace ShopifySharp
 
             var content = new StringContent(body, Encoding.UTF8, "application/graphql");
 
-            return await SendAsync(req, content);
+            return await SendAsync(req, content, cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ShopifySharp
         /// <returns>A JToken containing the data from the request.</returns>
         private async Task<JToken> SendAsync(RequestUri req, HttpContent content, CancellationToken cancellationToken = default)
         {
-            var response = await ExecuteRequestAsync(req, HttpMethod.Post, content, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content);
 
             CheckForErrors(response);
 

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<InventoryItem>> ListAsync(ListFilter<InventoryItem> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter, cancellationToken);
         }
 
         public virtual async Task<ListResult<InventoryItem>> ListAsync(InventoryItemListFilter filter, CancellationToken cancellationToken = default)
@@ -60,7 +60,7 @@ namespace ShopifySharp
                 inventory_item = inventoryItem
             } );
 
-            var response = await ExecuteRequestAsync<InventoryItem>( req, HttpMethod.Put, content, rootElement: "inventory_item" , cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<InventoryItem>( req, HttpMethod.Put, cancellationToken, content, "inventory_item");
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -27,12 +27,12 @@ namespace ShopifySharp
         /// <param name="ids">Show only inventory items specified by a list of IDs. Maximum: 100.</param>
         public virtual async Task<ListResult<InventoryItem>> ListAsync(ListFilter<InventoryItem> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter);
+            return await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter, cancellationToken: cancellationToken);
         }
 
         public virtual async Task<ListResult<InventoryItem>> ListAsync(InventoryItemListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <param name="inventoryItemId">The id of the inventory item to retrieve.</param>
         public virtual async Task<InventoryItem> GetAsync(long inventoryItemId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<InventoryItem>($"inventory_items/{inventoryItemId}.json", "inventory_item");
+            return await ExecuteGetAsync<InventoryItem>($"inventory_items/{inventoryItemId}.json", "inventory_item", cancellationToken: cancellationToken);
         }
 
 
@@ -57,7 +57,7 @@ namespace ShopifySharp
                 inventory_item = inventoryItem
             } );
 
-            var response = await ExecuteRequestAsync<InventoryItem>( req, HttpMethod.Put, content, rootElement: "inventory_item" );
+            var response = await ExecuteRequestAsync<InventoryItem>( req, HttpMethod.Put, content, rootElement: "inventory_item" , cancellationToken: cancellationToken);
             return response.Result;
         }
     }

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -24,12 +25,12 @@ namespace ShopifySharp
         /// Gets a list of inventory items.
         /// </summary>
         /// <param name="ids">Show only inventory items specified by a list of IDs. Maximum: 100.</param>
-        public virtual async Task<ListResult<InventoryItem>> ListAsync(ListFilter<InventoryItem> filter)
+        public virtual async Task<ListResult<InventoryItem>> ListAsync(ListFilter<InventoryItem> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter);
         }
 
-        public virtual async Task<ListResult<InventoryItem>> ListAsync(InventoryItemListFilter filter)
+        public virtual async Task<ListResult<InventoryItem>> ListAsync(InventoryItemListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -38,7 +39,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="InventoryItem"/> with the given id.
         /// </summary>
         /// <param name="inventoryItemId">The id of the inventory item to retrieve.</param>
-        public virtual async Task<InventoryItem> GetAsync(long inventoryItemId)
+        public virtual async Task<InventoryItem> GetAsync(long inventoryItemId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<InventoryItem>($"inventory_items/{inventoryItemId}.json", "inventory_item");
         }
@@ -48,7 +49,7 @@ namespace ShopifySharp
         /// Updates an existing <see cref="InventoryItem"/>.
         /// </summary>
         /// <param name="inventoryItemId">The id of the inventory item to retrieve.</param>
-        public virtual async Task<InventoryItem> UpdateAsync( long inventoryItemId, InventoryItem inventoryItem)
+        public virtual async Task<InventoryItem> UpdateAsync( long inventoryItemId, InventoryItem inventoryItem, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest( $"inventory_items/{inventoryItemId}.json" );
             var content = new JsonContent( new

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -25,6 +25,7 @@ namespace ShopifySharp
         /// Gets a list of inventory items.
         /// </summary>
         /// <param name="ids">Show only inventory items specified by a list of IDs. Maximum: 100.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<InventoryItem>> ListAsync(ListFilter<InventoryItem> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter, cancellationToken: cancellationToken);
@@ -39,6 +40,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="InventoryItem"/> with the given id.
         /// </summary>
         /// <param name="inventoryItemId">The id of the inventory item to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<InventoryItem> GetAsync(long inventoryItemId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<InventoryItem>($"inventory_items/{inventoryItemId}.json", "inventory_item", cancellationToken: cancellationToken);
@@ -49,6 +51,7 @@ namespace ShopifySharp
         /// Updates an existing <see cref="InventoryItem"/>.
         /// </summary>
         /// <param name="inventoryItemId">The id of the inventory item to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<InventoryItem> UpdateAsync( long inventoryItemId, InventoryItem inventoryItem, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest( $"inventory_items/{inventoryItemId}.json" );

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -42,6 +42,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="inventoryItemId">The ID of the inventory item.</param>
         /// <param name="locationId">The ID of the location that the inventory level belongs to.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default)
         {
             await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete, cancellationToken: cancellationToken);
@@ -52,6 +53,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="updatedInventoryLevel">The updated <see cref="InventoryLevel"/></param>
         /// <param name="disconnectIfNecessary">Whether inventory for any previously connected locations will be set to 0 and the locations disconnected. This property is ignored when no fulfillment service is involved.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="InventoryLevel"/></returns>
         public virtual async Task<InventoryLevel> SetAsync(InventoryLevel updatedInventoryLevel, bool disconnectIfNecessary = false, CancellationToken cancellationToken = default)
         {
@@ -70,6 +72,7 @@ namespace ShopifySharp
         /// Adjusts the given <see cref="InventoryLevel"/>.
         /// </summary>
         /// <param name="updatedInventoryLevel">The updated <see cref="InventoryLevel"/></param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="InventoryLevel"/></returns>
         public virtual async Task<InventoryLevel> AdjustAsync(InventoryLevelAdjust adjustInventoryLevel, CancellationToken cancellationToken = default)
         {
@@ -87,6 +90,7 @@ namespace ShopifySharp
         /// <param name="inventoryItemId">The ID of the inventory item</param>
         /// <param name="locationId">The ID of the location that the inventory level belongs to</param>
         /// <param name="relocateIfNecessary">Whether inventory for any previously connected locations will be relocated. This property is ignored when no fulfillment service location is involved</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="InventoryLevel"/>.</returns>
         public virtual async Task<InventoryLevel> ConnectAsync(long inventoryItemId, long locationId, bool relocateIfNecessary = false, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -23,7 +24,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of inventory items. 
         /// </summary>
-        public virtual async Task<ListResult<InventoryLevel>> ListAsync(ListFilter<InventoryLevel> filter)
+        public virtual async Task<ListResult<InventoryLevel>> ListAsync(ListFilter<InventoryLevel> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"inventory_levels.json", "inventory_levels", filter);
         }
@@ -31,7 +32,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of inventory items
         /// </summary>
-        public virtual async Task<ListResult<InventoryLevel>> ListAsync(InventoryLevelListFilter filter)
+        public virtual async Task<ListResult<InventoryLevel>> ListAsync(InventoryLevelListFilter filter, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -41,7 +42,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="inventoryItemId">The ID of the inventory item.</param>
         /// <param name="locationId">The ID of the location that the inventory level belongs to.</param>
-        public virtual async Task DeleteAsync(long inventoryItemId, long locationId)
+        public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default)
         {
             await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete);
         }
@@ -52,7 +53,7 @@ namespace ShopifySharp
         /// <param name="updatedInventoryLevel">The updated <see cref="InventoryLevel"/></param>
         /// <param name="disconnectIfNecessary">Whether inventory for any previously connected locations will be set to 0 and the locations disconnected. This property is ignored when no fulfillment service is involved.</param>
         /// <returns>The updated <see cref="InventoryLevel"/></returns>
-        public virtual async Task<InventoryLevel> SetAsync(InventoryLevel updatedInventoryLevel, bool disconnectIfNecessary = false)
+        public virtual async Task<InventoryLevel> SetAsync(InventoryLevel updatedInventoryLevel, bool disconnectIfNecessary = false, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"inventory_levels/set.json");
             var body = updatedInventoryLevel.ToDictionary();
@@ -70,7 +71,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="updatedInventoryLevel">The updated <see cref="InventoryLevel"/></param>
         /// <returns>The updated <see cref="InventoryLevel"/></returns>
-        public virtual async Task<InventoryLevel> AdjustAsync(InventoryLevelAdjust adjustInventoryLevel)
+        public virtual async Task<InventoryLevel> AdjustAsync(InventoryLevelAdjust adjustInventoryLevel, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"inventory_levels/adjust.json");
             var body = adjustInventoryLevel.ToDictionary();
@@ -87,7 +88,7 @@ namespace ShopifySharp
         /// <param name="locationId">The ID of the location that the inventory level belongs to</param>
         /// <param name="relocateIfNecessary">Whether inventory for any previously connected locations will be relocated. This property is ignored when no fulfillment service location is involved</param>
         /// <returns>The new <see cref="InventoryLevel"/>.</returns>
-        public virtual async Task<InventoryLevel> ConnectAsync(long inventoryItemId, long locationId, bool relocateIfNecessary = false)
+        public virtual async Task<InventoryLevel> ConnectAsync(long inventoryItemId, long locationId, bool relocateIfNecessary = false, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"inventory_levels/connect.json");
             var content = new JsonContent(new

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<InventoryLevel>> ListAsync(ListFilter<InventoryLevel> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"inventory_levels.json", "inventory_levels", filter);
+            return await ExecuteGetListAsync($"inventory_levels.json", "inventory_levels", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<InventoryLevel>> ListAsync(InventoryLevelListFilter filter, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <param name="locationId">The ID of the location that the inventory level belongs to.</param>
         public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default)
         {
-            await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete);
+            await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ShopifySharp
             body.Add("disconnect_if_necessary", disconnectIfNecessary);
             
             var content = new JsonContent(body);
-            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level");
+            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level", cancellationToken: cancellationToken);
             
             return response.Result;
         }
@@ -76,7 +76,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"inventory_levels/adjust.json");
             var body = adjustInventoryLevel.ToDictionary();
             var content = new JsonContent(body);
-            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level");
+            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level", cancellationToken: cancellationToken);
             
             return response.Result;
         }
@@ -97,7 +97,7 @@ namespace ShopifySharp
                 inventory_item_id = inventoryItemId,
                 relocate_if_necessary = relocateIfNecessary
             });
-            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level");
+            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level", cancellationToken: cancellationToken);
             
             return response.Result;
         }

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<InventoryLevel>> ListAsync(ListFilter<InventoryLevel> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"inventory_levels.json", "inventory_levels", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"inventory_levels.json", "inventory_levels", filter, cancellationToken);
         }
         
         /// <summary>
@@ -45,7 +45,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default)
         {
-            await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace ShopifySharp
             body.Add("disconnect_if_necessary", disconnectIfNecessary);
             
             var content = new JsonContent(body);
-            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, cancellationToken, content, "inventory_level");
             
             return response.Result;
         }
@@ -79,7 +79,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"inventory_levels/adjust.json");
             var body = adjustInventoryLevel.ToDictionary();
             var content = new JsonContent(body);
-            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, cancellationToken, content, "inventory_level");
             
             return response.Result;
         }
@@ -101,7 +101,7 @@ namespace ShopifySharp
                 inventory_item_id = inventoryItemId,
                 relocate_if_necessary = relocateIfNecessary
             });
-            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, content, "inventory_level", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, cancellationToken, content, "inventory_level");
             
             return response.Result;
         }

--- a/ShopifySharp/Services/Location/LocationService.cs
+++ b/ShopifySharp/Services/Location/LocationService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Location"/>.</returns>
         public virtual async Task<Location> GetAsync(long id, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Location>($"locations/{id}.json", "location");
+            return await ExecuteGetAsync<Location>($"locations/{id}.json", "location", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <returns>The list of <see cref="Location"/> objects.</returns>
         public virtual async Task<IEnumerable<Location>> ListAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Location>>($"locations.json", "locations");
+            return await ExecuteGetAsync<IEnumerable<Location>>($"locations.json", "locations", cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Location/LocationService.cs
+++ b/ShopifySharp/Services/Location/LocationService.cs
@@ -24,6 +24,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="Location"/> with the given id.
         /// </summary>
         /// <param name="id">The id of the charge to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Location"/>.</returns>
         public virtual async Task<Location> GetAsync(long id, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Location/LocationService.cs
+++ b/ShopifySharp/Services/Location/LocationService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <returns>The <see cref="Location"/>.</returns>
-        public virtual async Task<Location> GetAsync(long id)
+        public virtual async Task<Location> GetAsync(long id, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Location>($"locations/{id}.json", "location");
         }
@@ -33,7 +34,7 @@ namespace ShopifySharp
         /// Retrieves a list of all <see cref="Location"/> objects.
         /// </summary>
         /// <returns>The list of <see cref="Location"/> objects.</returns>
-        public virtual async Task<IEnumerable<Location>> ListAsync()
+        public virtual async Task<IEnumerable<Location>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<Location>>($"locations.json", "locations");
         }

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -32,7 +33,7 @@ namespace ShopifySharp
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
-        public virtual async Task<int> CountAsync()
+        public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default)
         {
             return await _CountAsync("metafields/count.json");
         }
@@ -45,7 +46,7 @@ namespace ShopifySharp
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
-        public virtual async Task<int> CountAsync(long resourceId, string resourceType)
+        public virtual async Task<int> CountAsync(long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
             return await _CountAsync($"{resourceType}/{resourceId}/metafields/count.json");
         }
@@ -60,7 +61,7 @@ namespace ShopifySharp
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
-        public virtual async Task<int> CountAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType)
+        public virtual async Task<int> CountAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
             return await _CountAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields/count.json");
         }
@@ -74,7 +75,7 @@ namespace ShopifySharp
         /// Gets a list of the metafields for the shop itself.
         /// </summary>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<ListResult<MetaField>> ListAsync(ListFilter<MetaField> filter)
+        public virtual async Task<ListResult<MetaField>> ListAsync(ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
             return await _ListAsync("metafields.json", filter);
         }
@@ -85,7 +86,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, ListFilter<MetaField> filter)
+        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter);
         }
@@ -98,7 +99,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, ListFilter<MetaField> filter)
+        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter);
         }
@@ -109,7 +110,7 @@ namespace ShopifySharp
         /// Gets a list of the metafields for the shop itself.
         /// </summary>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<ListResult<MetaField>> ListAsync(MetaFieldFilter filter = null)
+        public virtual async Task<ListResult<MetaField>> ListAsync(MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await _ListAsync("metafields.json", filter);
         }
@@ -120,7 +121,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, MetaFieldFilter filter = null)
+        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter);
         }
@@ -133,7 +134,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
-        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, MetaFieldFilter filter = null)
+        public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter);
         }
@@ -143,7 +144,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="metafieldId">The id of the metafield to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
-        public virtual async Task<MetaField> GetAsync(long metafieldId, string fields = null)
+        public virtual async Task<MetaField> GetAsync(long metafieldId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<MetaField>($"metafields/{metafieldId}.json", "metafield", fields);
         }
@@ -152,7 +153,7 @@ namespace ShopifySharp
         /// Creates a new metafield on the shop itself.
         /// </summary>
         /// <param name="metafield">A new metafield. Id should be set to null.</param>
-        public virtual async Task<MetaField> CreateAsync(MetaField metafield)
+        public virtual async Task<MetaField> CreateAsync(MetaField metafield, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("metafields.json");
             var content = new JsonContent(new
@@ -172,7 +173,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The resource type the metaifeld will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
         /// <param name="parentResourceId">The Id of the parent resource the metafield will be associated with. This can be blogs, products.</param>
         /// <param name="parentResourceType">The resource type the metaifeld will be associated with. This can be articles, variants.</param>
-        public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, long parentResourceId, string parentResourceType)
+        public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json");
             var content = new JsonContent(new
@@ -190,7 +191,7 @@ namespace ShopifySharp
         /// <param name="metafield">A new metafield. Id should be set to null.</param>
         /// <param name="resourceId">The Id of the resource the metafield will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
         /// <param name="resourceType">The resource type the metaifeld will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
-        public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType)
+        public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{resourceType}/{resourceId}/metafields.json");
             var content = new JsonContent(new
@@ -207,7 +208,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="metafieldId">Id of the object being updated.</param>
         /// <param name="metafield">The metafield to update.</param>
-        public virtual async Task<MetaField> UpdateAsync(long metafieldId, MetaField metafield)
+        public virtual async Task<MetaField> UpdateAsync(long metafieldId, MetaField metafield, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"metafields/{metafieldId}.json");
             var content = new JsonContent(new
@@ -223,7 +224,7 @@ namespace ShopifySharp
         /// Deletes a metafield with the given Id.
         /// </summary>
         /// <param name="metafieldId">The metafield object's Id.</param>
-        public virtual async Task DeleteAsync(long metafieldId)
+        public virtual async Task DeleteAsync(long metafieldId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"metafields/{metafieldId}.json");
 

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -22,9 +22,9 @@ namespace ShopifySharp
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public MetaFieldService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
-        private async Task<int> _CountAsync(string path)
+        private async Task<int> _CountAsync(string path, CancellationToken cancellationToken)
         {
-            return await ExecuteGetAsync<int>(path, "count");
+            return await ExecuteGetAsync<int>(path, "count", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default)
         {
-            return await _CountAsync("metafields/count.json");
+            return await _CountAsync("metafields/count.json", cancellationToken);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
-            return await _CountAsync($"{resourceType}/{resourceId}/metafields/count.json");
+            return await _CountAsync($"{resourceType}/{resourceId}/metafields/count.json", cancellationToken);
         }
 
         /// <summary>
@@ -63,12 +63,13 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
-            return await _CountAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields/count.json");
+            return await _CountAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields/count.json", cancellationToken);
         }
 
-        private async Task<ListResult<MetaField>> _ListAsync(string path, ListFilter<MetaField> filter)
+        private async Task<ListResult<MetaField>> _ListAsync(string path, ListFilter<MetaField> filter,
+            CancellationToken cancellationToken)
         {
-            return await ExecuteGetListAsync(path, "metafields", filter);
+            return await ExecuteGetListAsync(path, "metafields", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace ShopifySharp
         /// <param name="filter">Options to filter the results.</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync("metafields.json", filter);
+            return await _ListAsync("metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace ShopifySharp
         /// <param name="filter">Options to filter the results.</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter);
+            return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace ShopifySharp
         /// <param name="filter">Options to filter the results.</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter);
+            return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
 
@@ -112,7 +113,7 @@ namespace ShopifySharp
         /// <param name="filter">Options to filter the results.</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync("metafields.json", filter);
+            return await _ListAsync("metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace ShopifySharp
         /// <param name="filter">Options to filter the results.</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter);
+            return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -136,7 +137,7 @@ namespace ShopifySharp
         /// <param name="filter">Options to filter the results.</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter);
+            return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -146,7 +147,7 @@ namespace ShopifySharp
         /// <param name="fields">A comma-separated list of fields to return.</param>
         public virtual async Task<MetaField> GetAsync(long metafieldId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<MetaField>($"metafields/{metafieldId}.json", "metafield", fields);
+            return await ExecuteGetAsync<MetaField>($"metafields/{metafieldId}.json", "metafield", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -161,7 +162,7 @@ namespace ShopifySharp
                 metafield = metafield
             });
 
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield");
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -181,7 +182,7 @@ namespace ShopifySharp
                 metafield = metafield
             });
 
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield");
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -199,7 +200,7 @@ namespace ShopifySharp
                 metafield = metafield
             });
 
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield");
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -215,7 +216,7 @@ namespace ShopifySharp
             {
                 metafield = metafield
             });
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Put, content, "metafield");
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Put, content, "metafield", cancellationToken: cancellationToken);
             
             return response.Result;
         }
@@ -228,7 +229,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"metafields/{metafieldId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -76,6 +76,7 @@ namespace ShopifySharp
         /// Gets a list of the metafields for the shop itself.
         /// </summary>
         /// <param name="filter">Options to filter the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
             return await _ListAsync("metafields.json", filter, cancellationToken);
@@ -87,6 +88,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
@@ -100,6 +102,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
@@ -111,6 +114,7 @@ namespace ShopifySharp
         /// Gets a list of the metafields for the shop itself.
         /// </summary>
         /// <param name="filter">Options to filter the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await _ListAsync("metafields.json", filter, cancellationToken);
@@ -122,6 +126,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
@@ -135,6 +140,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="filter">Options to filter the results.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
@@ -145,6 +151,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="metafieldId">The id of the metafield to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> GetAsync(long metafieldId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<MetaField>($"metafields/{metafieldId}.json", "metafield", fields, cancellationToken: cancellationToken);
@@ -154,6 +161,7 @@ namespace ShopifySharp
         /// Creates a new metafield on the shop itself.
         /// </summary>
         /// <param name="metafield">A new metafield. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("metafields.json");
@@ -174,6 +182,7 @@ namespace ShopifySharp
         /// <param name="resourceType">The resource type the metaifeld will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
         /// <param name="parentResourceId">The Id of the parent resource the metafield will be associated with. This can be blogs, products.</param>
         /// <param name="parentResourceType">The resource type the metaifeld will be associated with. This can be articles, variants.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json");
@@ -192,6 +201,7 @@ namespace ShopifySharp
         /// <param name="metafield">A new metafield. Id should be set to null.</param>
         /// <param name="resourceId">The Id of the resource the metafield will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
         /// <param name="resourceType">The resource type the metaifeld will be associated with. This can be variants, products, orders, customers, custom_collections, etc.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"{resourceType}/{resourceId}/metafields.json");
@@ -209,6 +219,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="metafieldId">Id of the object being updated.</param>
         /// <param name="metafield">The metafield to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> UpdateAsync(long metafieldId, MetaField metafield, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"metafields/{metafieldId}.json");
@@ -225,6 +236,7 @@ namespace ShopifySharp
         /// Deletes a metafield with the given Id.
         /// </summary>
         /// <param name="metafieldId">The metafield object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long metafieldId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"metafields/{metafieldId}.json");

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -43,6 +43,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="resourceType">The type of shopify resource to obtain metafields for. This could be variants, products, orders, customers, custom_collections.</param>
         /// <param name="resourceId">The Id for the resource type.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
@@ -58,6 +59,7 @@ namespace ShopifySharp
         /// <param name="resourceId">The Id for the resource type.</param>
         /// <param name="parentResourceType">The type of shopify parent resource to obtain metafields for. This could be blogs, products.</param>
         /// <param name="parentResourceId">The Id for the resource type.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
@@ -69,7 +71,7 @@ namespace ShopifySharp
         private async Task<ListResult<MetaField>> _ListAsync(string path, ListFilter<MetaField> filter,
             CancellationToken cancellationToken)
         {
-            return await ExecuteGetListAsync(path, "metafields", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync(path, "metafields", filter, cancellationToken);
         }
 
         /// <summary>
@@ -154,7 +156,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> GetAsync(long metafieldId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<MetaField>($"metafields/{metafieldId}.json", "metafield", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<MetaField>($"metafields/{metafieldId}.json", "metafield", fields, cancellationToken);
         }
 
         /// <summary>
@@ -170,7 +172,7 @@ namespace ShopifySharp
                 metafield = metafield
             });
 
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, cancellationToken, content, "metafield");
             return response.Result;
         }
 
@@ -191,7 +193,7 @@ namespace ShopifySharp
                 metafield = metafield
             });
 
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, cancellationToken, content, "metafield");
             return response.Result;
         }
 
@@ -210,7 +212,7 @@ namespace ShopifySharp
                 metafield = metafield
             });
 
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, content, "metafield", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Post, cancellationToken, content, "metafield");
             return response.Result;
         }
 
@@ -227,7 +229,7 @@ namespace ShopifySharp
             {
                 metafield = metafield
             });
-            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Put, content, "metafield", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<MetaField>(req, HttpMethod.Put, cancellationToken, content, "metafield");
             
             return response.Result;
         }
@@ -241,7 +243,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"metafields/{metafieldId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// <returns>The count of all orders for the shop.</returns>
         public virtual async Task<int> CountAsync(OrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("orders/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("orders/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <returns>The list of orders matching the filter.</returns>
         public virtual async Task<ListResult<Order>> ListAsync(ListFilter<Order> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("orders.json", "orders", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("orders.json", "orders", filter, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Order"/>.</returns>
         public virtual async Task<Order> GetAsync(long orderId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Order>($"orders/{orderId}.json", "order", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Order>($"orders/{orderId}.json", "order", fields, cancellationToken);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace ShopifySharp
         public virtual async Task<Order> CloseAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/close.json");
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, rootElement: "order");
 
             return response.Result;
         }
@@ -88,7 +88,7 @@ namespace ShopifySharp
         public virtual async Task<Order> OpenAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/open.json");
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, rootElement: "order");
 
             return response.Result;
         }
@@ -117,7 +117,7 @@ namespace ShopifySharp
             {
                 order = body
             });
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, content, "order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, content, "order");
 
             return response.Result;
         }
@@ -136,7 +136,7 @@ namespace ShopifySharp
             {
                 order = order
             });
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Put, content, "order", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Put, cancellationToken, content, "order");
 
             return response.Result;
         }
@@ -150,7 +150,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"orders/{orderId}/cancel.json");
             var content = new JsonContent(options ?? new OrderCancelOptions());
 
-            await ExecuteRequestAsync(req, HttpMethod.Post, content, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content);
         }
 
         /// <summary>
@@ -176,7 +176,7 @@ namespace ShopifySharp
         public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/metafields.json");
-            var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, rootElement: "metafields", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, cancellationToken, rootElement: "metafields");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
         /// <returns>The count of all orders for the shop.</returns>
-        public virtual async Task<int> CountAsync(OrderCountFilter filter = null)
+        public virtual async Task<int> CountAsync(OrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("orders/count.json", "count", filter);
         }
@@ -36,7 +37,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
         /// <returns>The list of orders matching the filter.</returns>
-        public virtual async Task<ListResult<Order>> ListAsync(ListFilter<Order> filter)
+        public virtual async Task<ListResult<Order>> ListAsync(ListFilter<Order> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("orders.json", "orders", filter);
         }
@@ -46,7 +47,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
         /// <returns>The list of orders matching the filter.</returns>
-        public virtual async Task<ListResult<Order>> ListAsync(OrderListFilter filter = null)
+        public virtual async Task<ListResult<Order>> ListAsync(OrderListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -57,7 +58,7 @@ namespace ShopifySharp
         /// <param name="orderId">The id of the order to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Order"/>.</returns>
-        public virtual async Task<Order> GetAsync(long orderId, string fields = null)
+        public virtual async Task<Order> GetAsync(long orderId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Order>($"orders/{orderId}.json", "order", fields);
         }
@@ -66,7 +67,7 @@ namespace ShopifySharp
         /// Closes an order.
         /// </summary>
         /// <param name="id">The order's id.</param>
-        public virtual async Task<Order> CloseAsync(long id)
+        public virtual async Task<Order> CloseAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/close.json");
             var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order");
@@ -78,7 +79,7 @@ namespace ShopifySharp
         /// Opens a closed order.
         /// </summary>
         /// <param name="id">The order's id.</param>
-        public virtual async Task<Order> OpenAsync(long id)
+        public virtual async Task<Order> OpenAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/open.json");
             var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order");
@@ -92,7 +93,7 @@ namespace ShopifySharp
         /// <param name="order">A new <see cref="Order"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the order.</param>
         /// <returns>The new <see cref="Order"/>.</returns>
-        public virtual async Task<Order> CreateAsync(Order order, OrderCreateOptions options = null)
+        public virtual async Task<Order> CreateAsync(Order order, OrderCreateOptions options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("orders.json");
             var body = order.ToDictionary();
@@ -120,7 +121,7 @@ namespace ShopifySharp
         /// <param name="orderId">Id of the object being updated.</param>
         /// <param name="order">The <see cref="Order"/> to update.</param>
         /// <returns>The updated <see cref="Order"/>.</returns>
-        public virtual async Task<Order> UpdateAsync(long orderId, Order order)
+        public virtual async Task<Order> UpdateAsync(long orderId, Order order, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}.json");
             var content = new JsonContent(new
@@ -136,7 +137,7 @@ namespace ShopifySharp
         /// Deletes an order with the given Id.
         /// </summary>
         /// <param name="orderId">The order object's Id.</param>
-        public virtual async Task DeleteAsync(long orderId)
+        public virtual async Task DeleteAsync(long orderId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}.json");
 
@@ -148,7 +149,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order's id.</param>
         /// <returns>The cancelled <see cref="Order"/>.</returns>
-        public virtual async Task CancelAsync(long orderId, OrderCancelOptions options = null)
+        public virtual async Task CancelAsync(long orderId, OrderCancelOptions options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/cancel.json");
             var content = new JsonContent(options ?? new OrderCancelOptions());
@@ -161,7 +162,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order's id.</param>
         /// <returns>The set of <see cref="MetaField"/> for the order.</returns>
-        public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId)
+        public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/metafields.json");
             var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, rootElement: "metafields");

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's orders.
         /// </summary>
         /// <param name="filter">Options for filtering the count.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The count of all orders for the shop.</returns>
         public virtual async Task<int> CountAsync(OrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
@@ -36,6 +37,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's orders.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The list of orders matching the filter.</returns>
         public virtual async Task<ListResult<Order>> ListAsync(ListFilter<Order> filter, CancellationToken cancellationToken = default)
         {
@@ -46,6 +48,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's orders.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The list of orders matching the filter.</returns>
         public virtual async Task<ListResult<Order>> ListAsync(OrderListFilter filter = null, CancellationToken cancellationToken = default)
         {
@@ -57,6 +60,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The id of the order to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Order"/>.</returns>
         public virtual async Task<Order> GetAsync(long orderId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -67,6 +71,7 @@ namespace ShopifySharp
         /// Closes an order.
         /// </summary>
         /// <param name="id">The order's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Order> CloseAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/close.json");
@@ -79,6 +84,7 @@ namespace ShopifySharp
         /// Opens a closed order.
         /// </summary>
         /// <param name="id">The order's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Order> OpenAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/open.json");
@@ -92,6 +98,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="order">A new <see cref="Order"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the order.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Order"/>.</returns>
         public virtual async Task<Order> CreateAsync(Order order, OrderCreateOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -120,6 +127,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">Id of the object being updated.</param>
         /// <param name="order">The <see cref="Order"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Order"/>.</returns>
         public virtual async Task<Order> UpdateAsync(long orderId, Order order, CancellationToken cancellationToken = default)
         {
@@ -137,6 +145,7 @@ namespace ShopifySharp
         /// Deletes an order with the given Id.
         /// </summary>
         /// <param name="orderId">The order object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long orderId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}.json");
@@ -148,6 +157,7 @@ namespace ShopifySharp
         /// Cancels an order.
         /// </summary>
         /// <param name="orderId">The order's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The cancelled <see cref="Order"/>.</returns>
         public virtual async Task CancelAsync(long orderId, OrderCancelOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -161,6 +171,7 @@ namespace ShopifySharp
         /// Get MetaField's for an order.
         /// </summary>
         /// <param name="orderId">The order's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The set of <see cref="MetaField"/> for the order.</returns>
         public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <returns>The count of all orders for the shop.</returns>
         public virtual async Task<int> CountAsync(OrderCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("orders/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("orders/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <returns>The list of orders matching the filter.</returns>
         public virtual async Task<ListResult<Order>> ListAsync(ListFilter<Order> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("orders.json", "orders", filter);
+            return await ExecuteGetListAsync("orders.json", "orders", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <returns>The list of orders matching the filter.</returns>
         public virtual async Task<ListResult<Order>> ListAsync(OrderListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Order"/>.</returns>
         public virtual async Task<Order> GetAsync(long orderId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Order>($"orders/{orderId}.json", "order", fields);
+            return await ExecuteGetAsync<Order>($"orders/{orderId}.json", "order", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ShopifySharp
         public virtual async Task<Order> CloseAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/close.json");
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order");
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -82,7 +82,7 @@ namespace ShopifySharp
         public virtual async Task<Order> OpenAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{id}/open.json");
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order");
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, rootElement: "order", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -110,7 +110,7 @@ namespace ShopifySharp
             {
                 order = body
             });
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, content, "order");
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, content, "order", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -128,7 +128,7 @@ namespace ShopifySharp
             {
                 order = order
             });
-            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Put, content, "order");
+            var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Put, content, "order", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -141,7 +141,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"orders/{orderId}/cancel.json");
             var content = new JsonContent(options ?? new OrderCancelOptions());
 
-            await ExecuteRequestAsync(req, HttpMethod.Post, content);
+            await ExecuteRequestAsync(req, HttpMethod.Post, content, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace ShopifySharp
         public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/metafields.json");
-            var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, rootElement: "metafields");
+            var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, rootElement: "metafields", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risks belong to.</param>
         /// <param name="filter">Options for filtering the request.</param>
-        public virtual async Task<ListResult<OrderRisk>> ListAsync(long orderId, ListFilter<OrderRisk> filter = null)
+        public virtual async Task<ListResult<OrderRisk>> ListAsync(long orderId, ListFilter<OrderRisk> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter);
         }
@@ -35,7 +36,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="riskId">The id of the risk to retrieve.</param>
-        public virtual async Task<OrderRisk> GetAsync(long orderId, long riskId)
+        public virtual async Task<OrderRisk> GetAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<OrderRisk>($"orders/{orderId}/risks/{riskId}.json", "risk");
         }
@@ -45,7 +46,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="risk">A new <see cref="OrderRisk"/>. Id should be set to null.</param>
-        public virtual async Task<OrderRisk> CreateAsync(long orderId, OrderRisk risk)
+        public virtual async Task<OrderRisk> CreateAsync(long orderId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/risks.json");
             var content = new JsonContent(new
@@ -63,7 +64,7 @@ namespace ShopifySharp
         /// <param name="orderRiskId">Id of the object being updated.</param>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="risk">The risk to update.</param>
-        public virtual async Task<OrderRisk> UpdateAsync(long orderId, long orderRiskId, OrderRisk risk)
+        public virtual async Task<OrderRisk> UpdateAsync(long orderId, long orderRiskId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/risks/{orderRiskId}.json");
             var content = new JsonContent(new
@@ -80,7 +81,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="riskId">The risk's id.</param>
-        public virtual async Task DeleteAsync(long orderId, long riskId)
+        public virtual async Task DeleteAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/risks/{riskId}.json");
 

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risks belong to.</param>
         /// <param name="filter">Options for filtering the request.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<OrderRisk>> ListAsync(long orderId, ListFilter<OrderRisk> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter, cancellationToken: cancellationToken);
@@ -36,6 +37,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="riskId">The id of the risk to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<OrderRisk> GetAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<OrderRisk>($"orders/{orderId}/risks/{riskId}.json", "risk", cancellationToken: cancellationToken);
@@ -46,6 +48,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="risk">A new <see cref="OrderRisk"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<OrderRisk> CreateAsync(long orderId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/risks.json");
@@ -64,6 +67,7 @@ namespace ShopifySharp
         /// <param name="orderRiskId">Id of the object being updated.</param>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="risk">The risk to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<OrderRisk> UpdateAsync(long orderId, long orderRiskId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/risks/{orderRiskId}.json");
@@ -81,6 +85,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order the risk belongs to.</param>
         /// <param name="riskId">The risk's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/risks/{riskId}.json");

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the request.</param>
         public virtual async Task<ListResult<OrderRisk>> ListAsync(long orderId, ListFilter<OrderRisk> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter);
+            return await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <param name="riskId">The id of the risk to retrieve.</param>
         public virtual async Task<OrderRisk> GetAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<OrderRisk>($"orders/{orderId}/risks/{riskId}.json", "risk");
+            return await ExecuteGetAsync<OrderRisk>($"orders/{orderId}/risks/{riskId}.json", "risk", cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
             {
                 risk = risk
             });
-            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Post, content, "risk");
+            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Post, content, "risk", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -72,7 +72,7 @@ namespace ShopifySharp
                 risk = risk
             });
 
-            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Put, content, "risk");
+            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Put, content, "risk", cancellationToken: cancellationToken);
             return response.Result;
         }
 
@@ -85,7 +85,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/risks/{riskId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<OrderRisk>> ListAsync(long orderId, ListFilter<OrderRisk> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter, cancellationToken);
         }
         
         /// <summary>
@@ -56,7 +56,7 @@ namespace ShopifySharp
             {
                 risk = risk
             });
-            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Post, content, "risk", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Post, cancellationToken, content, "risk");
 
             return response.Result;
         }
@@ -76,7 +76,7 @@ namespace ShopifySharp
                 risk = risk
             });
 
-            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Put, content, "risk", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<OrderRisk>(req, HttpMethod.Put, cancellationToken, content, "risk");
             return response.Result;
         }
 
@@ -90,7 +90,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/risks/{riskId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -51,6 +51,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="pageId">The id of the page to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Page"/>.</returns>
         public virtual async Task<Page> GetAsync(long pageId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -71,6 +72,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="page">A new <see cref="Page"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the page.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Page"/>.</returns>
         public virtual async Task<Page> CreateAsync(Page page, PageCreateOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -99,6 +101,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="pageId">Id of the object being updated.</param>
         /// <param name="page">The <see cref="Page"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Page"/>.</returns>
         public virtual async Task<Page> UpdateAsync(long pageId, Page page, CancellationToken cancellationToken = default)
         {
@@ -116,6 +119,7 @@ namespace ShopifySharp
         /// Deletes a page with the given Id.
         /// </summary>
         /// <param name="pageId">The page object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long pageId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"pages/{pageId}.json");

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a count of all of the shop's pages.
         /// </summary>
-        public virtual async Task<int> CountAsync(PageCountFilter filter = null)
+        public virtual async Task<int> CountAsync(PageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("pages/count.json", "count", filter);
         }
@@ -32,7 +33,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's pages.
         /// </summary>
-        public virtual async Task<ListResult<Page>> ListAsync(ListFilter<Page> filter)
+        public virtual async Task<ListResult<Page>> ListAsync(ListFilter<Page> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("pages.json", "pages", filter);
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's pages.
         /// </summary>
-        public virtual async Task<ListResult<Page>> ListAsync(PageListFilter filter = null)
+        public virtual async Task<ListResult<Page>> ListAsync(PageListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -51,7 +52,7 @@ namespace ShopifySharp
         /// <param name="pageId">The id of the page to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Page"/>.</returns>
-        public virtual async Task<Page> GetAsync(long pageId, string fields = null)
+        public virtual async Task<Page> GetAsync(long pageId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"pages/{pageId}.json");
 
@@ -71,7 +72,7 @@ namespace ShopifySharp
         /// <param name="page">A new <see cref="Page"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the page.</param>
         /// <returns>The new <see cref="Page"/>.</returns>
-        public virtual async Task<Page> CreateAsync(Page page, PageCreateOptions options = null)
+        public virtual async Task<Page> CreateAsync(Page page, PageCreateOptions options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("pages.json");
             var body = page.ToDictionary();
@@ -99,7 +100,7 @@ namespace ShopifySharp
         /// <param name="pageId">Id of the object being updated.</param>
         /// <param name="page">The <see cref="Page"/> to update.</param>
         /// <returns>The updated <see cref="Page"/>.</returns>
-        public virtual async Task<Page> UpdateAsync(long pageId, Page page)
+        public virtual async Task<Page> UpdateAsync(long pageId, Page page, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"pages/{pageId}.json");
             var content = new JsonContent(new
@@ -115,7 +116,7 @@ namespace ShopifySharp
         /// Deletes a page with the given Id.
         /// </summary>
         /// <param name="pageId">The page object's Id.</param>
-        public virtual async Task DeleteAsync(long pageId)
+        public virtual async Task DeleteAsync(long pageId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"pages/{pageId}.json");
 

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<int> CountAsync(PageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("pages/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("pages/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Page>> ListAsync(ListFilter<Page> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("pages.json", "pages", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("pages.json", "pages", filter, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Get, rootElement: "page", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Get, cancellationToken, rootElement: "page");
 
             return response.Result;
         }
@@ -91,7 +91,7 @@ namespace ShopifySharp
             {
                 page = body
             });
-            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Post, content, "page", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Post, cancellationToken, content, "page");
 
             return response.Result;
         }
@@ -110,7 +110,7 @@ namespace ShopifySharp
             {
                 page = page
             });
-            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Put, content, "page", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Put, cancellationToken, content, "page");
 
             return response.Result;
         }
@@ -124,7 +124,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"pages/{pageId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<int> CountAsync(PageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("pages/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("pages/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Page>> ListAsync(ListFilter<Page> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("pages.json", "pages", filter);
+            return await ExecuteGetListAsync("pages.json", "pages", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Page>> ListAsync(PageListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Get, rootElement: "page");
+            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Get, rootElement: "page", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -89,7 +89,7 @@ namespace ShopifySharp
             {
                 page = body
             });
-            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Post, content, "page");
+            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Post, content, "page", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -107,7 +107,7 @@ namespace ShopifySharp
             {
                 page = page
             });
-            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Put, content, "page");
+            var response = await ExecuteRequestAsync<Page>(req, HttpMethod.Put, content, "page", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -120,7 +120,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"pages/{pageId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Policy/PolicyService.cs
+++ b/ShopifySharp/Services/Policy/PolicyService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         public virtual async Task<IEnumerable<Policy>> ListAsync(CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest("policies.json");
-            var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, rootElement: "policies");
+            var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, rootElement: "policies", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/Policy/PolicyService.cs
+++ b/ShopifySharp/Services/Policy/PolicyService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         public virtual async Task<IEnumerable<Policy>> ListAsync(CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest("policies.json");
-            var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, rootElement: "policies", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, cancellationToken, rootElement: "policies");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/Policy/PolicyService.cs
+++ b/ShopifySharp/Services/Policy/PolicyService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ShopifySharp
@@ -16,7 +17,7 @@ namespace ShopifySharp
         /// <summary>
         /// Get the policies and their contents for a shop
         /// </summary>
-        public virtual async Task<IEnumerable<Policy>> ListAsync()
+        public virtual async Task<IEnumerable<Policy>> ListAsync(CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest("policies.json");
             var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, rootElement: "policies");

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<PriceRule>> ListAsync(ListFilter<PriceRule> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("price_rules.json", "price_rules", filter);
+            return await ExecuteGetListAsync("price_rules.json", "price_rules", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<PriceRule>> ListAsync(PriceRuleListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
         
         // /// <summary>
@@ -49,7 +49,7 @@ namespace ShopifySharp
         //         req.QueryParams.AddRange(options);
         //     }
         //
-        //     return await ExecuteRequestAsync<List<PriceRule>>(req, HttpMethod.Get, rootElement: "price_rules");
+        //     return await ExecuteRequestAsync<List<PriceRule>>(req, HttpMethod.Get, rootElement: "price_rules", cancellationToken: cancellationToken);
         // }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Get, rootElement: "price_rule");
+            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Get, rootElement: "price_rule", cancellationToken: cancellationToken);
             
             return response.Result;
         }
@@ -83,7 +83,7 @@ namespace ShopifySharp
             {
                 price_rule = body
             });
-            var response =  await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Post, content, "price_rule");
+            var response =  await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Post, content, "price_rule", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -100,7 +100,7 @@ namespace ShopifySharp
             {
                 price_rule = rule
             });
-            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Put, content, "price_rule");
+            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Put, content, "price_rule", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -113,7 +113,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"price_rules/{id}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -57,6 +57,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the object to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<PriceRule> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{id}.json");
@@ -75,6 +76,7 @@ namespace ShopifySharp
         /// Creates a new price rule.
         /// </summary>
         /// <param name="rule">A new price rule. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<PriceRule> CreateAsync(PriceRule rule, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("price_rules.json");
@@ -93,6 +95,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">Id of the object being updated.</param>
         /// <param name="rule">The updated rule.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<PriceRule> UpdateAsync(long id, PriceRule rule, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{id}.json");
@@ -109,6 +112,7 @@ namespace ShopifySharp
         /// Deletes the object with the given Id.
         /// </summary>
         /// <param name="id">The object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{id}.json");

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's price rules.
         /// </summary>
-        public virtual async Task<ListResult<PriceRule>> ListAsync(ListFilter<PriceRule> filter)
+        public virtual async Task<ListResult<PriceRule>> ListAsync(ListFilter<PriceRule> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("price_rules.json", "price_rules", filter);
         }
@@ -30,7 +31,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's price rules.
         /// </summary>
-        public virtual async Task<ListResult<PriceRule>> ListAsync(PriceRuleListFilter filter = null)
+        public virtual async Task<ListResult<PriceRule>> ListAsync(PriceRuleListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -38,7 +39,7 @@ namespace ShopifySharp
         // /// <summary>
         // /// Gets a list of up to 250 of the shop's price rules.
         // /// </summary>
-        // public virtual async Task<IEnumerable<PriceRule>> ListAsync(IListFilter filter)
+        // public virtual async Task<IEnumerable<PriceRule>> ListAsync(IListFilter filter, CancellationToken cancellationToken = default)
         // {
         //     throw new Exception("not yet implemented");
         //     var req = PrepareRequest("price_rules.json");
@@ -56,7 +57,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the object to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
-        public virtual async Task<PriceRule> GetAsync(long id, string fields = null)
+        public virtual async Task<PriceRule> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{id}.json");
 
@@ -74,7 +75,7 @@ namespace ShopifySharp
         /// Creates a new price rule.
         /// </summary>
         /// <param name="rule">A new price rule. Id should be set to null.</param>
-        public virtual async Task<PriceRule> CreateAsync(PriceRule rule)
+        public virtual async Task<PriceRule> CreateAsync(PriceRule rule, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("price_rules.json");
             var body = rule.ToDictionary();
@@ -92,7 +93,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">Id of the object being updated.</param>
         /// <param name="rule">The updated rule.</param>
-        public virtual async Task<PriceRule> UpdateAsync(long id, PriceRule rule)
+        public virtual async Task<PriceRule> UpdateAsync(long id, PriceRule rule, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{id}.json");
             var content = new JsonContent(new
@@ -108,7 +109,7 @@ namespace ShopifySharp
         /// Deletes the object with the given Id.
         /// </summary>
         /// <param name="id">The object's Id.</param>
-        public virtual async Task DeleteAsync(long id)
+        public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"price_rules/{id}.json");
 

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<PriceRule>> ListAsync(ListFilter<PriceRule> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("price_rules.json", "price_rules", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("price_rules.json", "price_rules", filter, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Get, rootElement: "price_rule", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Get, cancellationToken, rootElement: "price_rule");
             
             return response.Result;
         }
@@ -85,7 +85,7 @@ namespace ShopifySharp
             {
                 price_rule = body
             });
-            var response =  await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Post, content, "price_rule", cancellationToken: cancellationToken);
+            var response =  await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Post, cancellationToken, content, "price_rule");
 
             return response.Result;
         }
@@ -103,7 +103,7 @@ namespace ShopifySharp
             {
                 price_rule = rule
             });
-            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Put, content, "price_rule", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<PriceRule>(req, HttpMethod.Put, cancellationToken, content, "price_rule");
 
             return response.Result;
         }
@@ -117,7 +117,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"price_rules/{id}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <returns>The count of all products for the shop.</returns>
         public virtual async Task<int> CountAsync(ProductCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("products/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("products/count.json", "count", filter, cancellationToken);
         }
         
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Product>> ListAsync(ListFilter<Product> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("products.json", "products", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("products.json", "products", filter, cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Product"/>.</returns>
         public virtual async Task<Product> GetAsync(long productId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields, cancellationToken);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace ShopifySharp
             {
                 product = body
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Post, content, "product", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Post, cancellationToken, content, "product");
 
             return response.Result;
         }
@@ -99,7 +99,7 @@ namespace ShopifySharp
             {
                 product = product
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, cancellationToken, content, "product");
 
             return response.Result;
         }
@@ -113,7 +113,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"products/{productId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace ShopifySharp
                     published = true
                 }
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, cancellationToken, content, "product");
 
             return response.Result;
         }
@@ -155,7 +155,7 @@ namespace ShopifySharp
                     published = false
                 }
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, cancellationToken, content, "product");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -49,6 +49,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Product"/>.</returns>
         public virtual async Task<Product> GetAsync(long productId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -60,6 +61,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="product">A new <see cref="Product"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the product.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Product"/>.</returns>
         public virtual async Task<Product> CreateAsync(Product product, ProductCreateOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -88,6 +90,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">Id of the object being updated.</param>
         /// <param name="product">The <see cref="Product"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Product"/>.</returns>
         public virtual async Task<Product> UpdateAsync(long productId, Product product, CancellationToken cancellationToken = default)
         {
@@ -105,6 +108,7 @@ namespace ShopifySharp
         /// Deletes a product with the given Id.
         /// </summary>
         /// <param name="productId">The product object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long productId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}.json");
@@ -116,6 +120,7 @@ namespace ShopifySharp
         /// Publishes an unpublished <see cref="Product"/>.
         /// </summary>
         /// <param name="id">The product's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The published <see cref="Product"/></returns>
         public virtual async Task<Product> PublishAsync(long id, CancellationToken cancellationToken = default)
         {
@@ -137,6 +142,7 @@ namespace ShopifySharp
         /// Unpublishes an published <see cref="Product"/>.
         /// </summary>
         /// <param name="id">The product's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The unpublished <see cref="Product"/></returns>
         public virtual async Task<Product> UnpublishAsync(long id, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using ShopifySharp.Filters;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's products.
         /// </summary>
         /// <returns>The count of all products for the shop.</returns>
-        public virtual async Task<int> CountAsync(ProductCountFilter filter = null)
+        public virtual async Task<int> CountAsync(ProductCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("products/count.json", "count", filter);
         }
@@ -30,7 +31,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's products.
         /// </summary>
-        public virtual async Task<ListResult<Product>> ListAsync(ListFilter<Product> filter)
+        public virtual async Task<ListResult<Product>> ListAsync(ListFilter<Product> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("products.json", "products", filter);
         }
@@ -38,7 +39,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's products.
         /// </summary>
-        public virtual async Task<ListResult<Product>> ListAsync(ProductListFilter filter = null)
+        public virtual async Task<ListResult<Product>> ListAsync(ProductListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Product"/>.</returns>
-        public virtual async Task<Product> GetAsync(long productId, string fields = null)
+        public virtual async Task<Product> GetAsync(long productId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields);
         }
@@ -60,7 +61,7 @@ namespace ShopifySharp
         /// <param name="product">A new <see cref="Product"/>. Id should be set to null.</param>
         /// <param name="options">Options for creating the product.</param>
         /// <returns>The new <see cref="Product"/>.</returns>
-        public virtual async Task<Product> CreateAsync(Product product, ProductCreateOptions options = null)
+        public virtual async Task<Product> CreateAsync(Product product, ProductCreateOptions options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("products.json");
             var body = product.ToDictionary();
@@ -88,7 +89,7 @@ namespace ShopifySharp
         /// <param name="productId">Id of the object being updated.</param>
         /// <param name="product">The <see cref="Product"/> to update.</param>
         /// <returns>The updated <see cref="Product"/>.</returns>
-        public virtual async Task<Product> UpdateAsync(long productId, Product product)
+        public virtual async Task<Product> UpdateAsync(long productId, Product product, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}.json");
             var content = new JsonContent(new
@@ -104,7 +105,7 @@ namespace ShopifySharp
         /// Deletes a product with the given Id.
         /// </summary>
         /// <param name="productId">The product object's Id.</param>
-        public virtual async Task DeleteAsync(long productId)
+        public virtual async Task DeleteAsync(long productId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}.json");
 
@@ -116,7 +117,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The product's id.</param>
         /// <returns>The published <see cref="Product"/></returns>
-        public virtual async Task<Product> PublishAsync(long id)
+        public virtual async Task<Product> PublishAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{id}.json");
             var content = new JsonContent(new
@@ -137,7 +138,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The product's id.</param>
         /// <returns>The unpublished <see cref="Product"/></returns>
-        public virtual async Task<Product> UnpublishAsync(long id)
+        public virtual async Task<Product> UnpublishAsync(long id, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{id}.json");
             var content = new JsonContent(new

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <returns>The count of all products for the shop.</returns>
         public virtual async Task<int> CountAsync(ProductCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("products/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("products/count.json", "count", filter, cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -33,7 +33,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Product>> ListAsync(ListFilter<Product> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("products.json", "products", filter);
+            return await ExecuteGetListAsync("products.json", "products", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Product>> ListAsync(ProductListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Product"/>.</returns>
         public virtual async Task<Product> GetAsync(long productId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields);
+            return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace ShopifySharp
             {
                 product = body
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Post, content, "product");
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Post, content, "product", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -96,7 +96,7 @@ namespace ShopifySharp
             {
                 product = product
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product");
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -109,7 +109,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"products/{productId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace ShopifySharp
                     published = true
                 }
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product");
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -149,7 +149,7 @@ namespace ShopifySharp
                     published = false
                 }
             });
-            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product");
+            var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, content, "product", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(long productId, ProductImageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"products/{productId}/images/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>($"products/{productId}/images/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ProductImage>> ListAsync(long productId, ListFilter<ProductImage> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"products/{productId}/images.json", "images", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"products/{productId}/images.json", "images", filter, cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="ProductImage"/>.</returns>
         public virtual async Task<ProductImage> GetAsync(long productId, long imageId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<ProductImage>($"products/{productId}/images/{imageId}.json", "image", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<ProductImage>($"products/{productId}/images/{imageId}.json", "image", fields, cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ShopifySharp
             {
                 image = image
             });
-            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Post, content, "image", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Post, cancellationToken, content, "image");
 
             return response.Result;
         }
@@ -90,7 +90,7 @@ namespace ShopifySharp
             {
                 image = image
             });
-            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Put, content, "image", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Put, cancellationToken, content, "image");
 
             return response.Result;
         }
@@ -105,7 +105,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"products/{productId}/images/{imageId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<int> CountAsync(long productId, ProductImageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"products/{productId}/images/count.json", "count", filter);
+            return await ExecuteGetAsync<int>($"products/{productId}/images/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         public virtual async Task<ListResult<ProductImage>> ListAsync(long productId, ListFilter<ProductImage> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"products/{productId}/images.json", "images", filter);
+            return await ExecuteGetListAsync($"products/{productId}/images.json", "images", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="ProductImage"/>.</returns>
         public virtual async Task<ProductImage> GetAsync(long productId, long imageId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<ProductImage>($"products/{productId}/images/{imageId}.json", "image", fields);
+            return await ExecuteGetAsync<ProductImage>($"products/{productId}/images/{imageId}.json", "image", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace ShopifySharp
             {
                 image = image
             });
-            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Post, content, "image");
+            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Post, content, "image", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -85,7 +85,7 @@ namespace ShopifySharp
             {
                 image = image
             });
-            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Put, content, "image");
+            var response = await ExecuteRequestAsync<ProductImage>(req, HttpMethod.Put, content, "image", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -99,7 +99,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"products/{productId}/images/{imageId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -27,6 +27,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(long productId, ProductImageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"products/{productId}/images/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -36,6 +37,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's ProductImages.
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ProductImage>> ListAsync(long productId, ListFilter<ProductImage> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"products/{productId}/images.json", "images", filter, cancellationToken: cancellationToken);
@@ -47,6 +49,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="imageId">The id of the ProductImage to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="ProductImage"/>.</returns>
         public virtual async Task<ProductImage> GetAsync(long productId, long imageId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -58,6 +61,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="image">The new <see cref="ProductImage"/>.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="ProductImage"/>.</returns>
         public virtual async Task<ProductImage> CreateAsync(long productId, ProductImage image, CancellationToken cancellationToken = default)
         {
@@ -77,6 +81,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="productImageId">Id of the object being updated.</param>
         /// <param name="image">The <see cref="ProductImage"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="ProductImage"/>.</returns>
         public virtual async Task<ProductImage> UpdateAsync(long productId, long productImageId, ProductImage image, CancellationToken cancellationToken = default)
         {
@@ -95,6 +100,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="imageId">The ProductImage object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long productId, long imageId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/images/{imageId}.json");

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<int> CountAsync(long productId, ProductImageCountFilter filter = null)
+        public virtual async Task<int> CountAsync(long productId, ProductImageCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"products/{productId}/images/count.json", "count", filter);
         }
@@ -35,7 +36,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's ProductImages.
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
-        public virtual async Task<ListResult<ProductImage>> ListAsync(long productId, ListFilter<ProductImage> filter = null)
+        public virtual async Task<ListResult<ProductImage>> ListAsync(long productId, ListFilter<ProductImage> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"products/{productId}/images.json", "images", filter);
         }
@@ -47,7 +48,7 @@ namespace ShopifySharp
         /// <param name="imageId">The id of the ProductImage to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ProductImage"/>.</returns>
-        public virtual async Task<ProductImage> GetAsync(long productId, long imageId, string fields = null)
+        public virtual async Task<ProductImage> GetAsync(long productId, long imageId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<ProductImage>($"products/{productId}/images/{imageId}.json", "image", fields);
         }
@@ -58,7 +59,7 @@ namespace ShopifySharp
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="image">The new <see cref="ProductImage"/>.</param>
         /// <returns>The new <see cref="ProductImage"/>.</returns>
-        public virtual async Task<ProductImage> CreateAsync(long productId, ProductImage image)
+        public virtual async Task<ProductImage> CreateAsync(long productId, ProductImage image, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/images.json");
             var content = new JsonContent(new
@@ -77,7 +78,7 @@ namespace ShopifySharp
         /// <param name="productImageId">Id of the object being updated.</param>
         /// <param name="image">The <see cref="ProductImage"/> to update.</param>
         /// <returns>The updated <see cref="ProductImage"/>.</returns>
-        public virtual async Task<ProductImage> UpdateAsync(long productId, long productImageId, ProductImage image)
+        public virtual async Task<ProductImage> UpdateAsync(long productId, long productImageId, ProductImage image, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/images/{productImageId}.json");
             var content = new JsonContent(new
@@ -94,7 +95,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The id of the product that counted images belong to.</param>
         /// <param name="imageId">The ProductImage object's Id.</param>
-        public virtual async Task DeleteAsync(long productId, long imageId)
+        public virtual async Task DeleteAsync(long productId, long imageId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/images/{imageId}.json");
 

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -28,7 +29,7 @@ namespace ShopifySharp
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
-        public virtual async Task<int> CountAsync(long productId)
+        public virtual async Task<int> CountAsync(long productId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"products/{productId}/variants/count.json", "count");
         }
@@ -37,7 +38,7 @@ namespace ShopifySharp
         /// Gets a list of variants belonging to the given product.
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
-        public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ListFilter<ProductVariant> filter)
+        public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ListFilter<ProductVariant> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"products/{productId}/variants.json", "variants", filter);
         }
@@ -46,7 +47,7 @@ namespace ShopifySharp
         /// Gets a list of variants belonging to the given product.
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
-        public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ProductVariantListFilter filter = null)
+        public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ProductVariantListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(productId, filter?.AsListFilter());
         }
@@ -55,7 +56,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="ProductVariant"/> with the given id.
         /// </summary>
         /// <param name="variantId">The id of the product variant to retrieve.</param>
-        public virtual async Task<ProductVariant> GetAsync(long variantId)
+        public virtual async Task<ProductVariant> GetAsync(long variantId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<ProductVariant>($"variants/{variantId}.json", "variant");
         }
@@ -65,7 +66,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the new variant will belong to.</param>
         /// <param name="variant">A new <see cref="ProductVariant"/>. Id should be set to null.</param>
-        public virtual async Task<ProductVariant> CreateAsync(long productId, ProductVariant variant)
+        public virtual async Task<ProductVariant> CreateAsync(long productId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/variants.json");
             var content = new JsonContent(new
@@ -82,7 +83,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productVariantId">Id of the object being updated.</param>
         /// <param name="variant">The variant to update.</param>
-        public virtual async Task<ProductVariant> UpdateAsync(long productVariantId, ProductVariant variant)
+        public virtual async Task<ProductVariant> UpdateAsync(long productVariantId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"variants/{productVariantId}.json");
             var content = new JsonContent(new
@@ -99,7 +100,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the variant belongs to.</param>
         /// <param name="variantId">The product variant's id.</param>
-        public virtual async Task DeleteAsync(long productId, long variantId)
+        public virtual async Task DeleteAsync(long productId, long variantId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/variants/{variantId}.json");
 

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ListFilter<ProductVariant> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"products/{productId}/variants.json", "variants", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"products/{productId}/variants.json", "variants", filter, cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ShopifySharp
             {
                 variant = variant
             });
-            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Post, content, "variant", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Post, cancellationToken, content, "variant");
 
             return response.Result;
         }
@@ -95,7 +95,7 @@ namespace ShopifySharp
             {
                 variant = variant
             });
-            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Put, content, "variant", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Put, cancellationToken, content, "variant");
 
             return response.Result;
         }
@@ -110,7 +110,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"products/{productId}/variants/{variantId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(long productId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"products/{productId}/variants/count.json", "count");
+            return await ExecuteGetAsync<int>($"products/{productId}/variants/count.json", "count", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <param name="productId">The product that the variants belong to.</param>
         public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ListFilter<ProductVariant> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"products/{productId}/variants.json", "variants", filter);
+            return await ExecuteGetListAsync($"products/{productId}/variants.json", "variants", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <param name="productId">The product that the variants belong to.</param>
         public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ProductVariantListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(productId, filter?.AsListFilter());
+            return await ListAsync(productId, filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// <param name="variantId">The id of the product variant to retrieve.</param>
         public virtual async Task<ProductVariant> GetAsync(long variantId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<ProductVariant>($"variants/{variantId}.json", "variant");
+            return await ExecuteGetAsync<ProductVariant>($"variants/{variantId}.json", "variant", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace ShopifySharp
             {
                 variant = variant
             });
-            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Post, content, "variant");
+            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Post, content, "variant", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -90,7 +90,7 @@ namespace ShopifySharp
             {
                 variant = variant
             });
-            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Put, content, "variant");
+            var response = await ExecuteRequestAsync<ProductVariant>(req, HttpMethod.Put, content, "variant", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -104,7 +104,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"products/{productId}/variants/{variantId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -38,6 +38,7 @@ namespace ShopifySharp
         /// Gets a list of variants belonging to the given product.
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ListFilter<ProductVariant> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"products/{productId}/variants.json", "variants", filter, cancellationToken: cancellationToken);
@@ -47,6 +48,7 @@ namespace ShopifySharp
         /// Gets a list of variants belonging to the given product.
         /// </summary>
         /// <param name="productId">The product that the variants belong to.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ProductVariant>> ListAsync(long productId, ProductVariantListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(productId, filter?.AsListFilter(), cancellationToken);
@@ -56,6 +58,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="ProductVariant"/> with the given id.
         /// </summary>
         /// <param name="variantId">The id of the product variant to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ProductVariant> GetAsync(long variantId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<ProductVariant>($"variants/{variantId}.json", "variant", cancellationToken: cancellationToken);
@@ -66,6 +69,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the new variant will belong to.</param>
         /// <param name="variant">A new <see cref="ProductVariant"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ProductVariant> CreateAsync(long productId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/variants.json");
@@ -83,6 +87,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productVariantId">Id of the object being updated.</param>
         /// <param name="variant">The variant to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ProductVariant> UpdateAsync(long productVariantId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"variants/{productVariantId}.json");
@@ -100,6 +105,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="productId">The product that the variant belongs to.</param>
         /// <param name="variantId">The product variant's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long productId, long variantId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"products/{productId}/variants/{variantId}.json");

--- a/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
+++ b/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
@@ -24,6 +24,7 @@ namespace ShopifySharp
         /// Creates a <see cref="RecurringCharge"/>.
         /// </summary>
         /// <param name="charge">The <see cref="RecurringCharge"/> to create.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="RecurringCharge"/>.</returns>
         public virtual async Task<RecurringCharge> CreateAsync(RecurringCharge charge, CancellationToken cancellationToken = default)
         {
@@ -35,6 +36,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="RecurringCharge"/>.</returns>
         public virtual async Task<RecurringCharge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -53,6 +55,7 @@ namespace ShopifySharp
         /// Activates a <see cref="RecurringCharge"/> that the shop owner has accepted.
         /// </summary>
         /// <param name="id">The id of the charge to activate.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<RecurringCharge> ActivateAsync(long id, CancellationToken cancellationToken = default)
         {
             return await ExecutePostAsync<RecurringCharge>($"recurring_application_charges/{id}/activate.json", "recurring_application_charge");
@@ -62,6 +65,7 @@ namespace ShopifySharp
         /// Deletes a <see cref="RecurringCharge"/>.
         /// </summary>
         /// <param name="id">The id of the charge to delete.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             await ExecuteDeleteAsync($"recurring_application_charges/{id}.json", cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
+++ b/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <returns>The new <see cref="RecurringCharge"/>.</returns>
         public virtual async Task<RecurringCharge> CreateAsync(RecurringCharge charge, CancellationToken cancellationToken = default)
         {
-            return await ExecutePostAsync<RecurringCharge>("recurring_application_charges.json", "recurring_application_charge", new { recurring_application_charge = charge });
+            return await ExecutePostAsync<RecurringCharge>("recurring_application_charges.json", "recurring_application_charge", cancellationToken, new { recurring_application_charge = charge });
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="RecurringCharge"/>.</returns>
         public virtual async Task<RecurringCharge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<RecurringCharge>($"recurring_application_charges/{id}.json", "recurring_application_charge", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<RecurringCharge>($"recurring_application_charges/{id}.json", "recurring_application_charge", fields, cancellationToken);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<RecurringCharge>> ListAsync(RecurringChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<RecurringCharge>>("recurring_application_charges.json", "recurring_application_charges", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<IEnumerable<RecurringCharge>>("recurring_application_charges.json", "recurring_application_charges", filter, cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<RecurringCharge> ActivateAsync(long id, CancellationToken cancellationToken = default)
         {
-            return await ExecutePostAsync<RecurringCharge>($"recurring_application_charges/{id}/activate.json", "recurring_application_charge");
+            return await ExecutePostAsync<RecurringCharge>($"recurring_application_charges/{id}/activate.json", "recurring_application_charge", cancellationToken);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            await ExecuteDeleteAsync($"recurring_application_charges/{id}.json", cancellationToken: cancellationToken);
+            await ExecuteDeleteAsync($"recurring_application_charges/{id}.json", cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
+++ b/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="charge">The <see cref="RecurringCharge"/> to create.</param>
         /// <returns>The new <see cref="RecurringCharge"/>.</returns>
-        public virtual async Task<RecurringCharge> CreateAsync(RecurringCharge charge)
+        public virtual async Task<RecurringCharge> CreateAsync(RecurringCharge charge, CancellationToken cancellationToken = default)
         {
             return await ExecutePostAsync<RecurringCharge>("recurring_application_charges.json", "recurring_application_charge", new { recurring_application_charge = charge });
         }
@@ -35,7 +36,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="RecurringCharge"/>.</returns>
-        public virtual async Task<RecurringCharge> GetAsync(long id, string fields = null)
+        public virtual async Task<RecurringCharge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<RecurringCharge>($"recurring_application_charges/{id}.json", "recurring_application_charge", fields);
         }
@@ -43,7 +44,7 @@ namespace ShopifySharp
         /// <summary>
         /// Retrieves a list of all past and present <see cref="RecurringCharge"/> objects.
         /// </summary>
-        public virtual async Task<IEnumerable<RecurringCharge>> ListAsync(RecurringChargeListFilter filter = null)
+        public virtual async Task<IEnumerable<RecurringCharge>> ListAsync(RecurringChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<RecurringCharge>>("recurring_application_charges.json", "recurring_application_charges", filter);
         }
@@ -52,7 +53,7 @@ namespace ShopifySharp
         /// Activates a <see cref="RecurringCharge"/> that the shop owner has accepted.
         /// </summary>
         /// <param name="id">The id of the charge to activate.</param>
-        public virtual async Task<RecurringCharge> ActivateAsync(long id)
+        public virtual async Task<RecurringCharge> ActivateAsync(long id, CancellationToken cancellationToken = default)
         {
             return await ExecutePostAsync<RecurringCharge>($"recurring_application_charges/{id}/activate.json", "recurring_application_charge");
         }
@@ -61,7 +62,7 @@ namespace ShopifySharp
         /// Deletes a <see cref="RecurringCharge"/>.
         /// </summary>
         /// <param name="id">The id of the charge to delete.</param>
-        public virtual async Task DeleteAsync(long id)
+        public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
             await ExecuteDeleteAsync($"recurring_application_charges/{id}.json");
         }

--- a/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
+++ b/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="RecurringCharge"/>.</returns>
         public virtual async Task<RecurringCharge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<RecurringCharge>($"recurring_application_charges/{id}.json", "recurring_application_charge", fields);
+            return await ExecuteGetAsync<RecurringCharge>($"recurring_application_charges/{id}.json", "recurring_application_charge", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<RecurringCharge>> ListAsync(RecurringChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<RecurringCharge>>("recurring_application_charges.json", "recurring_application_charges", filter);
+            return await ExecuteGetAsync<IEnumerable<RecurringCharge>>("recurring_application_charges.json", "recurring_application_charges", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to delete.</param>
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            await ExecuteDeleteAsync($"recurring_application_charges/{id}.json");
+            await ExecuteDeleteAsync($"recurring_application_charges/{id}.json", cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's redirects.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<int> CountAsync(RedirectCountFilter filter = null)
+        public virtual async Task<int> CountAsync(RedirectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("redirects/count.json", "count", filter);
         }
@@ -33,7 +34,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's redirects.
         /// </summary>
-        public virtual async Task<ListResult<Redirect>> ListAsync(ListFilter<Redirect> filter)
+        public virtual async Task<ListResult<Redirect>> ListAsync(ListFilter<Redirect> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("redirects.json", "redirects", filter);
         }
@@ -41,7 +42,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's redirects.
         /// </summary>
-        public virtual async Task<ListResult<Redirect>> ListAsync(RedirectListFilter filter = null)
+        public virtual async Task<ListResult<Redirect>> ListAsync(RedirectListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -52,7 +53,7 @@ namespace ShopifySharp
         /// <param name="redirectId">The id of the redirect to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Redirect"/>.</returns>
-        public virtual async Task<Redirect> GetAsync(long redirectId, string fields = null)
+        public virtual async Task<Redirect> GetAsync(long redirectId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"redirects/{redirectId}.json");
 
@@ -73,7 +74,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="redirect">The new <see cref="Redirect"/>.</param>
         /// <returns>The new <see cref="Redirect"/>.</returns>
-        public virtual async Task<Redirect> CreateAsync(Redirect redirect)
+        public virtual async Task<Redirect> CreateAsync(Redirect redirect, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("redirects.json");
             var content = new JsonContent(new
@@ -91,7 +92,7 @@ namespace ShopifySharp
         /// <param name="redirectId">Id of the object being updated.</param>
         /// <param name="redirect">The <see cref="Redirect"/> to update.</param>
         /// <returns>The updated <see cref="Redirect"/>.</returns>
-        public virtual async Task<Redirect> UpdateAsync(long redirectId, Redirect redirect)
+        public virtual async Task<Redirect> UpdateAsync(long redirectId, Redirect redirect, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"redirects/{redirectId}.json");
             var content = new JsonContent(new
@@ -107,7 +108,7 @@ namespace ShopifySharp
         /// Deletes a redirect with the given Id.
         /// </summary>
         /// <param name="redirectId">The redirect object's Id.</param>
-        public virtual async Task DeleteAsync(long redirectId)
+        public virtual async Task DeleteAsync(long redirectId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"redirects/{redirectId}.json");
 

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's redirects.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(RedirectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("redirects/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -52,6 +53,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="redirectId">The id of the redirect to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Redirect"/>.</returns>
         public virtual async Task<Redirect> GetAsync(long redirectId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -73,6 +75,7 @@ namespace ShopifySharp
         /// files have been extracted and stored by Shopify (which might take a couple of minutes).
         /// </summary>
         /// <param name="redirect">The new <see cref="Redirect"/>.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Redirect"/>.</returns>
         public virtual async Task<Redirect> CreateAsync(Redirect redirect, CancellationToken cancellationToken = default)
         {
@@ -91,6 +94,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="redirectId">Id of the object being updated.</param>
         /// <param name="redirect">The <see cref="Redirect"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Redirect"/>.</returns>
         public virtual async Task<Redirect> UpdateAsync(long redirectId, Redirect redirect, CancellationToken cancellationToken = default)
         {
@@ -108,6 +112,7 @@ namespace ShopifySharp
         /// Deletes a redirect with the given Id.
         /// </summary>
         /// <param name="redirectId">The redirect object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long redirectId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"redirects/{redirectId}.json");

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<int> CountAsync(RedirectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("redirects/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("redirects/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Redirect>> ListAsync(ListFilter<Redirect> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("redirects.json", "redirects", filter);
+            return await ExecuteGetListAsync("redirects.json", "redirects", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Redirect>> ListAsync(RedirectListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
         
         /// <summary>
@@ -62,7 +62,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Get, rootElement: "redirect");
+            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Get, rootElement: "redirect", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -81,7 +81,7 @@ namespace ShopifySharp
             {
                 redirect = redirect
             });
-            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Post, content, "redirect");
+            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Post, content, "redirect", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -99,7 +99,7 @@ namespace ShopifySharp
             {
                 redirect = redirect
             });
-            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Put, content, "redirect");
+            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Put, content, "redirect", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -112,7 +112,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"redirects/{redirectId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(RedirectCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("redirects/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("redirects/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<Redirect>> ListAsync(ListFilter<Redirect> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("redirects.json", "redirects", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("redirects.json", "redirects", filter, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Get, rootElement: "redirect", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Get, cancellationToken, rootElement: "redirect");
 
             return response.Result;
         }
@@ -84,7 +84,7 @@ namespace ShopifySharp
             {
                 redirect = redirect
             });
-            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Post, content, "redirect", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Post, cancellationToken, content, "redirect");
 
             return response.Result;
         }
@@ -103,7 +103,7 @@ namespace ShopifySharp
             {
                 redirect = redirect
             });
-            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Put, content, "redirect", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Redirect>(req, HttpMethod.Put, cancellationToken, content, "redirect");
 
             return response.Result;
         }
@@ -117,7 +117,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"redirects/{redirectId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// Retrieves a list of refunds for an order.
         /// </summary>
         /// <param name="orderId">The id of the order to list orders for.</param>
-        public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, ListFilter<Refund> filter)
+        public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, ListFilter<Refund> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter);
         }
@@ -34,7 +35,7 @@ namespace ShopifySharp
         /// Retrieves a list of refunds for an order.
         /// </summary>
         /// <param name="orderId">The id of the order to list orders for.</param>
-        public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, RefundListFilter filter = null)
+        public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, RefundListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListForOrderAsync(orderId, filter?.AsListFilter());
         }
@@ -46,7 +47,7 @@ namespace ShopifySharp
         /// <param name="orderId"></param>
         /// <param name="refundId"></param>
         /// <returns></returns>
-        public virtual async Task<Refund> GetAsync(long orderId, long refundId, string fields = null)
+        public virtual async Task<Refund> GetAsync(long orderId, long refundId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Refund>($"orders/{orderId}/refunds/{refundId}.json", "refund", fields);
         }
@@ -59,7 +60,7 @@ namespace ShopifySharp
         /// You can then use the response in the body of the request to create the actual refund.
         /// The response includes a transactions object with "kind": "suggested_refund", which must to be changed to "kind" : "refund" for the refund to be accepted.
         /// </summary>
-        public virtual async Task<Refund> CalculateAsync(long orderId, Refund options = null)
+        public virtual async Task<Refund> CalculateAsync(long orderId, Refund options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/refunds/calculate.json");
             var content = new JsonContent(new { refund = options ?? new Refund() });
@@ -71,7 +72,7 @@ namespace ShopifySharp
         /// <summary>
         /// Creates a <see cref="Refund"/>. Use the calculate endpoint to produce the transactions to submit.
         /// </summary>
-        public virtual async Task<Refund> RefundAsync(long orderId, Refund options = null)
+        public virtual async Task<Refund> RefundAsync(long orderId, Refund options = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/refunds.json");
             var content = new JsonContent(new { refund = options ?? new Refund() });

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// Retrieves a list of refunds for an order.
         /// </summary>
         /// <param name="orderId">The id of the order to list orders for.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, ListFilter<Refund> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter, cancellationToken: cancellationToken);
@@ -35,6 +36,7 @@ namespace ShopifySharp
         /// Retrieves a list of refunds for an order.
         /// </summary>
         /// <param name="orderId">The id of the order to list orders for.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, RefundListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListForOrderAsync(orderId, filter?.AsListFilter());
@@ -46,6 +48,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId"></param>
         /// <param name="refundId"></param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns></returns>
         public virtual async Task<Refund> GetAsync(long orderId, long refundId, string fields = null, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, ListFilter<Refund> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter, cancellationToken);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, RefundListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListForOrderAsync(orderId, filter?.AsListFilter());
+            return await ListForOrderAsync(orderId, filter?.AsListFilter(), cancellationToken);
         }
         
 
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <returns></returns>
         public virtual async Task<Refund> GetAsync(long orderId, long refundId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Refund>($"orders/{orderId}/refunds/{refundId}.json", "refund", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Refund>($"orders/{orderId}/refunds/{refundId}.json", "refund", fields, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/refunds/calculate.json");
             var content = new JsonContent(new { refund = options ?? new Refund() });
-            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, cancellationToken, content, "refund");
 
             return response.Result;
         }
@@ -79,7 +79,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/refunds.json");
             var content = new JsonContent(new { refund = options ?? new Refund() });
-            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, cancellationToken, content, "refund");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="orderId">The id of the order to list orders for.</param>
         public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, ListFilter<Refund> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter);
+            return await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <returns></returns>
         public virtual async Task<Refund> GetAsync(long orderId, long refundId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Refund>($"orders/{orderId}/refunds/{refundId}.json", "refund", fields);
+            return await ExecuteGetAsync<Refund>($"orders/{orderId}/refunds/{refundId}.json", "refund", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/refunds/calculate.json");
             var content = new JsonContent(new { refund = options ?? new Refund() });
-            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund");
+            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -76,7 +76,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"orders/{orderId}/refunds.json");
             var content = new JsonContent(new { refund = options ?? new Refund() });
-            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund");
+            var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, content, "refund", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(ScriptTagCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("script_tags/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("script_tags/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<ScriptTag>> ListAsync(ListFilter<ScriptTag> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("script_tags.json", "script_tags", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("script_tags.json", "script_tags", filter, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Get, rootElement: "script_tag", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Get, cancellationToken, rootElement: "script_tag");
 
             return response.Result;
         }
@@ -82,7 +82,7 @@ namespace ShopifySharp
             {
                 script_tag = tag
             });
-            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, content, "script_tag", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, cancellationToken, content, "script_tag");
 
             return response.Result;
         }
@@ -101,7 +101,7 @@ namespace ShopifySharp
             {
                 script_tag = tag
             });
-            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, content, "script_tag", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, cancellationToken, content, "script_tag");
 
             return response.Result;
         }
@@ -115,7 +115,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"script_tags/{tagId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<int> CountAsync(ScriptTagCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("script_tags/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("script_tags/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<ScriptTag>> ListAsync(ListFilter<ScriptTag> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("script_tags.json", "script_tags", filter);
+            return await ExecuteGetListAsync("script_tags.json", "script_tags", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<ScriptTag>> ListAsync(ScriptTagListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Get, rootElement: "script_tag");
+            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Get, rootElement: "script_tag", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -79,7 +79,7 @@ namespace ShopifySharp
             {
                 script_tag = tag
             });
-            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, content, "script_tag");
+            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, content, "script_tag", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -97,7 +97,7 @@ namespace ShopifySharp
             {
                 script_tag = tag
             });
-            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, content, "script_tag");
+            var response = await ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, content, "script_tag", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -110,7 +110,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"script_tags/{tagId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's <see cref="ScriptTag"/>s.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<int> CountAsync(ScriptTagCountFilter filter = null)
+        public virtual async Task<int> CountAsync(ScriptTagCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("script_tags/count.json", "count", filter);
         }
@@ -33,7 +34,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's script tags.
         /// </summary>
-        public virtual async Task<ListResult<ScriptTag>> ListAsync(ListFilter<ScriptTag> filter)
+        public virtual async Task<ListResult<ScriptTag>> ListAsync(ListFilter<ScriptTag> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("script_tags.json", "script_tags", filter);
         }
@@ -41,7 +42,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's script tags.
         /// </summary>
-        public virtual async Task<ListResult<ScriptTag>> ListAsync(ScriptTagListFilter filter = null)
+        public virtual async Task<ListResult<ScriptTag>> ListAsync(ScriptTagListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -52,7 +53,7 @@ namespace ShopifySharp
         /// <param name="tagId">The id of the <see cref="ScriptTag"/> to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="ScriptTag"/>.</returns>
-        public virtual async Task<ScriptTag> GetAsync(long tagId, string fields = null)
+        public virtual async Task<ScriptTag> GetAsync(long tagId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"script_tags/{tagId}.json");
 
@@ -71,7 +72,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="tag">A new <see cref="ScriptTag"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="ScriptTag"/>.</returns>
-        public virtual async Task<ScriptTag> CreateAsync(ScriptTag tag)
+        public virtual async Task<ScriptTag> CreateAsync(ScriptTag tag, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("script_tags.json");
             var content = new JsonContent(new
@@ -89,7 +90,7 @@ namespace ShopifySharp
         /// <param name="scriptTagId">Id of the object being updated.</param>
         /// <param name="tag">The <see cref="ScriptTag"/> to update.</param>
         /// <returns>The updated <see cref="ScriptTag"/>.</returns>
-        public virtual async Task<ScriptTag> UpdateAsync(long scriptTagId, ScriptTag tag)
+        public virtual async Task<ScriptTag> UpdateAsync(long scriptTagId, ScriptTag tag, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"script_tags/{scriptTagId}.json");
             var content = new JsonContent(new
@@ -105,7 +106,7 @@ namespace ShopifySharp
         /// Deletes the <see cref="ScriptTag"/> with the given Id.
         /// </summary>
         /// <param name="tagId">The tag's Id.</param>
-        public virtual async Task DeleteAsync(long tagId)
+        public virtual async Task DeleteAsync(long tagId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"script_tags/{tagId}.json");
 

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's <see cref="ScriptTag"/>s.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(ScriptTagCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("script_tags/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -52,6 +53,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="tagId">The id of the <see cref="ScriptTag"/> to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="ScriptTag"/>.</returns>
         public virtual async Task<ScriptTag> GetAsync(long tagId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -71,6 +73,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="ScriptTag"/> on the store.
         /// </summary>
         /// <param name="tag">A new <see cref="ScriptTag"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="ScriptTag"/>.</returns>
         public virtual async Task<ScriptTag> CreateAsync(ScriptTag tag, CancellationToken cancellationToken = default)
         {
@@ -89,6 +92,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="scriptTagId">Id of the object being updated.</param>
         /// <param name="tag">The <see cref="ScriptTag"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="ScriptTag"/>.</returns>
         public virtual async Task<ScriptTag> UpdateAsync(long scriptTagId, ScriptTag tag, CancellationToken cancellationToken = default)
         {
@@ -106,6 +110,7 @@ namespace ShopifySharp
         /// Deletes the <see cref="ScriptTag"/> with the given Id.
         /// </summary>
         /// <param name="tagId">The tag's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long tagId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"script_tags/{tagId}.json");

--- a/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
+++ b/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
@@ -32,7 +32,7 @@ namespace ShopifySharp
                 req.QueryParams.AddRange(filter.ToQueryParameters());
             }
             
-            var response = await ExecuteRequestAsync<List<ShippingZone>>(req, HttpMethod.Get, rootElement: "shipping_zones");
+            var response = await ExecuteRequestAsync<List<ShippingZone>>(req, HttpMethod.Get, rootElement: "shipping_zones", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
+++ b/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
@@ -32,7 +32,7 @@ namespace ShopifySharp
                 req.QueryParams.AddRange(filter.ToQueryParameters());
             }
             
-            var response = await ExecuteRequestAsync<List<ShippingZone>>(req, HttpMethod.Get, rootElement: "shipping_zones", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<ShippingZone>>(req, HttpMethod.Get, cancellationToken, rootElement: "shipping_zones");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
+++ b/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 
@@ -22,7 +23,7 @@ namespace ShopifySharp
         /// <summary>
         /// Retrieves a list of all shipping zones. 
         /// </summary>
-        public virtual async Task<IEnumerable<ShippingZone>> ListAsync(ShippingZoneListFilter filter = null)
+        public virtual async Task<IEnumerable<ShippingZone>> ListAsync(ShippingZoneListFilter filter = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("shipping_zones.json");
             

--- a/ShopifySharp/Services/Shop/ShopService.cs
+++ b/ShopifySharp/Services/Shop/ShopService.cs
@@ -18,7 +18,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<Shop> GetAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Shop>("shop.json", "shop");
+            return await ExecuteGetAsync<Shop>("shop.json", "shop", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace ShopifySharp
         {
             var request = PrepareRequest("api_permissions/current.json");
 
-            await ExecuteRequestAsync(request, HttpMethod.Delete);
+            await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Shop/ShopService.cs
+++ b/ShopifySharp/Services/Shop/ShopService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ShopifySharp
@@ -15,7 +16,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets the shop's data.
         /// </summary>
-        public virtual async Task<Shop> GetAsync()
+        public virtual async Task<Shop> GetAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Shop>("shop.json", "shop");
         }
@@ -23,7 +24,7 @@ namespace ShopifySharp
         /// <summary>
         /// Forces the shop to uninstall your Shopify app. Uninstalling an application is an irreversible operation. Be entirely sure that you no longer need to make API calls for the shop in which the application has been installed.
         /// </summary>
-        public virtual async Task UninstallAppAsync()
+        public virtual async Task UninstallAppAsync(CancellationToken cancellationToken = default)
         {
             var request = PrepareRequest("api_permissions/current.json");
 

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Filters;
 using System.Net;
+using System.Threading;
 using ShopifySharp.Lists;
 
 namespace ShopifySharp
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// Checks whether the Shopify Payments API is enabled on this store.
         /// If not enabled, all Shopify Payments API endpoints will return HTTP 404 / Not Found
         /// </summary>
-        public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync()
+        public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default)
         {
             try
             {
@@ -44,7 +45,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <returns>The count of all fulfillments for the shop.</returns>
-        public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync()
+        public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync < IEnumerable < ShopifyPaymentsBalance >>("shopify_payments/balance.json", "balance");
         }
@@ -53,7 +54,7 @@ namespace ShopifySharp
         /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter)
+        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter);
         }
@@ -62,37 +63,37 @@ namespace ShopifySharp
         /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null)
+        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListPayoutsAsync(filter?.AsListFilter());
         }
         
-        public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId)
+        public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout");
         }
 
-        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter)
+        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter);
         }
 
-        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null)
+        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListDisputesAsync(filter?.AsListFilter());
         }
 
-        public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId)
+        public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync< ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute");
         }
 
-        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter)
+        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter);
         }
 
-        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null)
+        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListTransactionsAsync(filter?.AsListFilter());
         }

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
             try
             {
                 //calling any method endpoint would do, but choosing GetBalance because it is likely the most lightweight
-                await this.GetBalanceAsync();
+                await this.GetBalanceAsync(cancellationToken);
                 return true;
             }
             catch (ShopifyException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// <returns>The count of all fulfillments for the shop.</returns>
         public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync < IEnumerable < ShopifyPaymentsBalance >>("shopify_payments/balance.json", "balance");
+            return await ExecuteGetAsync<IEnumerable<ShopifyPaymentsBalance>>("shopify_payments/balance.json", "balance", cancellationToken: cancellationToken);
         }
         
         /// <summary>
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter);
+            return await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -65,37 +65,37 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListPayoutsAsync(filter?.AsListFilter());
+            return await ListPayoutsAsync(filter?.AsListFilter(), cancellationToken);
         }
         
         public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout");
+            return await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout", cancellationToken: cancellationToken);
         }
 
         public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter);
+            return await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter, cancellationToken: cancellationToken);
         }
 
         public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListDisputesAsync(filter?.AsListFilter());
+            return await ListDisputesAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync< ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute");
+            return await ExecuteGetAsync< ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute", cancellationToken: cancellationToken);
         }
 
         public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter);
+            return await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
         }
 
         public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListTransactionsAsync(filter?.AsListFilter());
+            return await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -44,6 +44,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's transactions.
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The count of all fulfillments for the shop.</returns>
         public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default)
         {
@@ -54,6 +55,7 @@ namespace ShopifySharp
         /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter, cancellationToken: cancellationToken);
@@ -63,6 +65,7 @@ namespace ShopifySharp
         /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListPayoutsAsync(filter?.AsListFilter(), cancellationToken);

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using ShopifySharp.Infrastructure;
 using Newtonsoft.Json;
 using System.IO;
+using System.Threading;
 using ShopifySharp.Lists;
 using ShopifySharp.Filters;
 
@@ -144,13 +145,13 @@ namespace ShopifySharp
         /// <remarks>
         /// This method will automatically dispose the <paramref name="baseClient"/> and <paramref name="content" /> when finished.
         /// </remarks>
-        protected async Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method, HttpContent content = null)
+        protected async Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method, HttpContent content = null, CancellationToken cancellationToken = default)
         {
             using (var baseRequestMessage = PrepareRequestMessage(uri, method, content))
             {
                 var policyResult = await _ExecutionPolicy.Run(baseRequestMessage, async (requestMessage) =>
                 {
-                    var request = _Client.SendAsync(requestMessage);
+                    var request = _Client.SendAsync(requestMessage, cancellationToken);
 
                     using (var response = await request)
                     {
@@ -167,13 +168,13 @@ namespace ShopifySharp
                             // Make sure that dates are not stripped of any timezone information if tokens are de-serialised into strings/DateTime/DateTimeZoneOffset
                             using (var reader = new JsonTextReader(new StringReader(rawResult)) { DateParseHandling = DateParseHandling.None })
                             {
-                                jtoken = JObject.Load(reader);
+                                jtoken = await JObject.LoadAsync(reader, cancellationToken);
                             }
                         }
 
                         return new RequestResult<JToken>(response, jtoken, rawResult, ReadLinkHeader(response));
                     }
-                });
+                }, cancellationToken);
 
                 return policyResult;
             }
@@ -186,13 +187,13 @@ namespace ShopifySharp
         /// <remarks>
         /// This method will automatically dispose the <paramref name="baseRequestMessage" /> when finished.
         /// </remarks>
-        protected async Task<RequestResult<T>> ExecuteRequestAsync<T>(RequestUri uri, HttpMethod method, HttpContent content = null, string rootElement = null)
+        protected async Task<RequestResult<T>> ExecuteRequestAsync<T>(RequestUri uri, HttpMethod method, HttpContent content = null, string rootElement = null, CancellationToken cancellationToken = default)
         {
             using (var baseRequestMessage = PrepareRequestMessage(uri, method, content))
             {
                 var policyResult = await _ExecutionPolicy.Run(baseRequestMessage, async (requestMessage) =>
                 {
-                    var request = _Client.SendAsync(requestMessage);
+                    var request = _Client.SendAsync(requestMessage, cancellationToken);
 
                     using (var response = await request)
                     {
@@ -214,35 +215,35 @@ namespace ShopifySharp
 
                         return new RequestResult<T>(response, result, rawResult, ReadLinkHeader(response));
                     }
-                });
+                }, cancellationToken);
 
                 return policyResult;
             }
         }
 
-        private async Task<T> ExecuteWithContentCoreAsync<T>(string path, string resultRootElt, HttpMethod method, JsonContent content)
+        private async Task<T> ExecuteWithContentCoreAsync<T>(string path, string resultRootElt, HttpMethod method, JsonContent content, CancellationToken cancellationToken)
         {
             var req = PrepareRequest(path);
-            var response = await ExecuteRequestAsync<T>(req, method, content, resultRootElt);
+            var response = await ExecuteRequestAsync<T>(req, method, content, resultRootElt, cancellationToken: cancellationToken);
             return response.Result;
         }
 
-        protected async Task<T> ExecutePostAsync<T>(string path, string resultRootElt, object jsonContent = null)
+        protected async Task<T> ExecutePostAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteWithContentCoreAsync<T>(path, resultRootElt, HttpMethod.Post, jsonContent == null ? null : new JsonContent(jsonContent));
+            return await ExecuteWithContentCoreAsync<T>(path, resultRootElt, HttpMethod.Post, jsonContent == null ? null : new JsonContent(jsonContent), cancellationToken);
         }
 
-        protected async Task<T> ExecutePutAsync<T>(string path, string resultRootElt, object jsonContent = null)
+        protected async Task<T> ExecutePutAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteWithContentCoreAsync<T>(path, resultRootElt, HttpMethod.Put, jsonContent == null ? null : new JsonContent(jsonContent));
+            return await ExecuteWithContentCoreAsync<T>(path, resultRootElt, HttpMethod.Put, jsonContent == null ? null : new JsonContent(jsonContent), cancellationToken);
         }
 
-        protected async Task ExecuteDeleteAsync(string path)
+        protected async Task ExecuteDeleteAsync(string path, CancellationToken cancellationToken)
         {
-            await ExecuteWithContentCoreAsync<JToken>(path, null, HttpMethod.Delete, null);
+            await ExecuteWithContentCoreAsync<JToken>(path, null, HttpMethod.Delete, null, cancellationToken);
         }
 
-        private async Task<RequestResult<T>> ExecuteGetCoreAsync<T>(string path, string resultRootElt, Parameterizable queryParams, string fields)
+        private async Task<RequestResult<T>> ExecuteGetCoreAsync<T>(string path, string resultRootElt, Parameterizable queryParams, string fields, CancellationToken cancellationToken)
         {
             var req = PrepareRequest(path);
 
@@ -256,22 +257,22 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            return await ExecuteRequestAsync<T>(req, HttpMethod.Get, rootElement: resultRootElt);
+            return await ExecuteRequestAsync<T>(req, HttpMethod.Get, rootElement: resultRootElt, cancellationToken: cancellationToken);
         }
 
-        protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, string fields)
+        protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, string fields, CancellationToken cancellationToken)
         {
-            return (await ExecuteGetCoreAsync<T>(path, resultRootElt, null, fields)).Result;
+            return (await ExecuteGetCoreAsync<T>(path, resultRootElt, null, fields, cancellationToken)).Result;
         }
 
-        protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, Parameterizable queryParams = null)
+        protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, Parameterizable queryParams = null, CancellationToken cancellationToken = default)
         {
-            return (await ExecuteGetCoreAsync<T>(path, resultRootElt, queryParams, null)).Result;
+            return (await ExecuteGetCoreAsync<T>(path, resultRootElt, queryParams, null, cancellationToken)).Result;
         }
 
-        protected async Task<ListResult<T>> ExecuteGetListAsync<T>(string path, string resultRootElt, ListFilter<T> filter)
+        protected async Task<ListResult<T>> ExecuteGetListAsync<T>(string path, string resultRootElt, ListFilter<T> filter, CancellationToken cancellationToken)
         {
-            var result = await ExecuteGetCoreAsync<List<T>>(path, resultRootElt, filter, null);
+            var result = await ExecuteGetCoreAsync<List<T>>(path, resultRootElt, filter, null, cancellationToken);
             return ParseLinkHeaderToListResult(result);
         }
 

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -260,7 +260,7 @@ namespace ShopifySharp
             return await ExecuteRequestAsync<T>(req, HttpMethod.Get, rootElement: resultRootElt, cancellationToken: cancellationToken);
         }
 
-        protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, string fields, CancellationToken cancellationToken)
+        protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, string fields, CancellationToken cancellationToken = default)
         {
             return (await ExecuteGetCoreAsync<T>(path, resultRootElt, null, fields, cancellationToken)).Result;
         }
@@ -270,7 +270,7 @@ namespace ShopifySharp
             return (await ExecuteGetCoreAsync<T>(path, resultRootElt, queryParams, null, cancellationToken)).Result;
         }
 
-        protected async Task<ListResult<T>> ExecuteGetListAsync<T>(string path, string resultRootElt, ListFilter<T> filter, CancellationToken cancellationToken)
+        protected async Task<ListResult<T>> ExecuteGetListAsync<T>(string path, string resultRootElt, ListFilter<T> filter, CancellationToken cancellationToken = default)
         {
             var result = await ExecuteGetCoreAsync<List<T>>(path, resultRootElt, filter, null, cancellationToken);
             return ParseLinkHeaderToListResult(result);

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -145,7 +145,8 @@ namespace ShopifySharp
         /// <remarks>
         /// This method will automatically dispose the <paramref name="baseClient"/> and <paramref name="content" /> when finished.
         /// </remarks>
-        protected async Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method, HttpContent content = null, CancellationToken cancellationToken = default)
+        protected async Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method,
+            CancellationToken cancellationToken, HttpContent content = null)
         {
             using (var baseRequestMessage = PrepareRequestMessage(uri, method, content))
             {
@@ -187,7 +188,8 @@ namespace ShopifySharp
         /// <remarks>
         /// This method will automatically dispose the <paramref name="baseRequestMessage" /> when finished.
         /// </remarks>
-        protected async Task<RequestResult<T>> ExecuteRequestAsync<T>(RequestUri uri, HttpMethod method, HttpContent content = null, string rootElement = null, CancellationToken cancellationToken = default)
+        protected async Task<RequestResult<T>> ExecuteRequestAsync<T>(RequestUri uri, HttpMethod method,
+            CancellationToken cancellationToken, HttpContent content = null, string rootElement = null)
         {
             using (var baseRequestMessage = PrepareRequestMessage(uri, method, content))
             {
@@ -224,16 +226,16 @@ namespace ShopifySharp
         private async Task<T> ExecuteWithContentCoreAsync<T>(string path, string resultRootElt, HttpMethod method, JsonContent content, CancellationToken cancellationToken)
         {
             var req = PrepareRequest(path);
-            var response = await ExecuteRequestAsync<T>(req, method, content, resultRootElt, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<T>(req, method, cancellationToken: cancellationToken, content: content, rootElement: resultRootElt);
             return response.Result;
         }
 
-        protected async Task<T> ExecutePostAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
+        protected async Task<T> ExecutePostAsync<T>(string path, string resultRootElt, CancellationToken cancellationToken, object jsonContent = null)
         {
             return await ExecuteWithContentCoreAsync<T>(path, resultRootElt, HttpMethod.Post, jsonContent == null ? null : new JsonContent(jsonContent), cancellationToken);
         }
 
-        protected async Task<T> ExecutePutAsync<T>(string path, string resultRootElt, object jsonContent = null, CancellationToken cancellationToken = default)
+        protected async Task<T> ExecutePutAsync<T>(string path, string resultRootElt, CancellationToken cancellationToken, object jsonContent = null)
         {
             return await ExecuteWithContentCoreAsync<T>(path, resultRootElt, HttpMethod.Put, jsonContent == null ? null : new JsonContent(jsonContent), cancellationToken);
         }
@@ -257,7 +259,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            return await ExecuteRequestAsync<T>(req, HttpMethod.Get, rootElement: resultRootElt, cancellationToken: cancellationToken);
+            return await ExecuteRequestAsync<T>(req, HttpMethod.Get, cancellationToken: cancellationToken, rootElement: resultRootElt);
         }
 
         protected async Task<T> ExecuteGetAsync<T>(string path, string resultRootElt, string fields, CancellationToken cancellationToken = default)

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(SmartCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<SmartCollection>> ListAsync(ListFilter<SmartCollection> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"smart_collections.json", "smart_collections", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync($"smart_collections.json", "smart_collections", filter, cancellationToken);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace ShopifySharp
             {
                 smart_collection = body
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Post, content, "smart_collection", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Post, cancellationToken, content, "smart_collection");
 
             return response.Result;
         }
@@ -91,7 +91,7 @@ namespace ShopifySharp
             {
                 smart_collection = collection
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, cancellationToken, content, "smart_collection");
 
             return response.Result;
         }
@@ -113,7 +113,7 @@ namespace ShopifySharp
             {
                 smart_collection = body
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, cancellationToken, content, "smart_collection");
 
             return response.Result;
         }
@@ -135,7 +135,7 @@ namespace ShopifySharp
             {
                 smart_collection = body
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, cancellationToken, content, "smart_collection");
 
             return response.Result;
         }
@@ -154,13 +154,14 @@ namespace ShopifySharp
                 sort_order = sortOrder,
                 products = productIds
             });
-            await ExecuteRequestAsync(req, HttpMethod.Put, content);
+            await ExecuteRequestAsync(req, HttpMethod.Put, CancellationToken.None, content);
         }
-        
+
         /// <summary>
         /// Updates the order of products when a SmartCollection's sort-by method is set to "manual".
         /// </summary>
         /// <param name="smartCollectionId">Id of the object being updated.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <param name="sortOrder">The order in which products in the smart collection appear. Note that specifying productIds parameter will have no effect unless the sort order is "manual"</param>
         /// <param name="productIds">An array of product ids sorted in the order you want them to appear in.</param>
         public virtual async Task UpdateProductOrderAsync(long smartCollectionId, CancellationToken cancellationToken, string sortOrder = null, params long[] productIds)
@@ -171,7 +172,7 @@ namespace ShopifySharp
                 sort_order = sortOrder,
                 products = productIds
             });
-            await ExecuteRequestAsync(req, HttpMethod.Put, content, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Put, cancellationToken, content);
         }
 
         /// <summary>
@@ -183,7 +184,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"smart_collections/{collectionId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// Gets a count of all smart collections on the store.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<int> CountAsync(SmartCollectionCountFilter filter = null)
+        public virtual async Task<int> CountAsync(SmartCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter);
         }
@@ -32,7 +33,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 smart collections.
         /// </summary>
-        public virtual async Task<ListResult<SmartCollection>> ListAsync(ListFilter<SmartCollection> filter)
+        public virtual async Task<ListResult<SmartCollection>> ListAsync(ListFilter<SmartCollection> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync($"smart_collections.json", "smart_collections", filter);
         }
@@ -40,7 +41,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 smart collections.
         /// </summary>
-        public virtual async Task<ListResult<SmartCollection>> ListAsync(SmartCollectionListFilter filter = null)
+        public virtual async Task<ListResult<SmartCollection>> ListAsync(SmartCollectionListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="SmartCollection"/> with the given id.
         /// </summary>
         /// <param name="collectionId">The id of the smart collection to retrieve.</param>
-        public virtual async Task<SmartCollection> GetAsync(long collectionId)
+        public virtual async Task<SmartCollection> GetAsync(long collectionId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<SmartCollection>($"smart_collections/{collectionId}.json", "smart_collection");
         }
@@ -58,7 +59,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="SmartCollection"/>.
         /// </summary>
         /// <param name="collection">A new <see cref="SmartCollection"/>. Id should be set to null.</param>
-        public virtual async Task<SmartCollection> CreateAsync(SmartCollection collection, bool published = true)
+        public virtual async Task<SmartCollection> CreateAsync(SmartCollection collection, bool published = true, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections.json");
             var body = collection.ToDictionary();
@@ -79,7 +80,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="smartCollectionId">Id of the object being updated.</param>
         /// <param name="collection">The smart collection to update.</param>
-        public virtual async Task<SmartCollection> UpdateAsync(long smartCollectionId, SmartCollection collection)
+        public virtual async Task<SmartCollection> UpdateAsync(long smartCollectionId, SmartCollection collection, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
             var content = new JsonContent(new
@@ -95,7 +96,7 @@ namespace ShopifySharp
         /// Publishes an unpublished smart collection.
         /// </summary>
         /// <param name="smartCollectionId">The collection's id.</param>
-        public virtual async Task<SmartCollection> PublishAsync(long smartCollectionId)
+        public virtual async Task<SmartCollection> PublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
             var body = new Dictionary<string, object>()
@@ -116,7 +117,7 @@ namespace ShopifySharp
         /// Publishes an unpublished smart collection.
         /// </summary>
         /// <param name="smartCollectionId">The collection's id.</param>
-        public virtual async Task<SmartCollection> UnpublishAsync(long smartCollectionId)
+        public virtual async Task<SmartCollection> UnpublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
             var body = new Dictionary<string, object>()
@@ -149,12 +150,29 @@ namespace ShopifySharp
             });
             await ExecuteRequestAsync(req, HttpMethod.Put, content);
         }
+        
+        /// <summary>
+        /// Updates the order of products when a SmartCollection's sort-by method is set to "manual".
+        /// </summary>
+        /// <param name="smartCollectionId">Id of the object being updated.</param>
+        /// <param name="sortOrder">The order in which products in the smart collection appear. Note that specifying productIds parameter will have no effect unless the sort order is "manual"</param>
+        /// <param name="productIds">An array of product ids sorted in the order you want them to appear in.</param>
+        public virtual async Task UpdateProductOrderAsync(long smartCollectionId, CancellationToken cancellationToken, string sortOrder = null, params long[] productIds)
+        {
+            var req = PrepareRequest($"smart_collections/{smartCollectionId}/order.json");
+            var content = new JsonContent(new
+            {
+                sort_order = sortOrder,
+                products = productIds
+            });
+            await ExecuteRequestAsync(req, HttpMethod.Put, content);
+        }
 
         /// <summary>
         /// Deletes a smart collection with the given Id.
         /// </summary>
         /// <param name="collectionId">The smart collection's id.</param>
-        public virtual async Task DeleteAsync(long collectionId)
+        public virtual async Task DeleteAsync(long collectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{collectionId}.json");
 

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<int> CountAsync(SmartCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<SmartCollection>> ListAsync(ListFilter<SmartCollection> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync($"smart_collections.json", "smart_collections", filter);
+            return await ExecuteGetListAsync($"smart_collections.json", "smart_collections", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<ListResult<SmartCollection>> ListAsync(SmartCollectionListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <param name="collectionId">The id of the smart collection to retrieve.</param>
         public virtual async Task<SmartCollection> GetAsync(long collectionId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<SmartCollection>($"smart_collections/{collectionId}.json", "smart_collection");
+            return await ExecuteGetAsync<SmartCollection>($"smart_collections/{collectionId}.json", "smart_collection", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ShopifySharp
             {
                 smart_collection = body
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Post, content, "smart_collection");
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Post, content, "smart_collection", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -87,7 +87,7 @@ namespace ShopifySharp
             {
                 smart_collection = collection
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection");
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -108,7 +108,7 @@ namespace ShopifySharp
             {
                 smart_collection = body
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection");
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -129,7 +129,7 @@ namespace ShopifySharp
             {
                 smart_collection = body
             });
-            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection");
+            var response = await ExecuteRequestAsync<SmartCollection>(req, HttpMethod.Put, content, "smart_collection", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -165,7 +165,7 @@ namespace ShopifySharp
                 sort_order = sortOrder,
                 products = productIds
             });
-            await ExecuteRequestAsync(req, HttpMethod.Put, content);
+            await ExecuteRequestAsync(req, HttpMethod.Put, content, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -176,7 +176,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"smart_collections/{collectionId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -25,6 +25,7 @@ namespace ShopifySharp
         /// Gets a count of all smart collections on the store.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<int> CountAsync(SmartCollectionCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter, cancellationToken: cancellationToken);
@@ -50,6 +51,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="SmartCollection"/> with the given id.
         /// </summary>
         /// <param name="collectionId">The id of the smart collection to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<SmartCollection> GetAsync(long collectionId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<SmartCollection>($"smart_collections/{collectionId}.json", "smart_collection", cancellationToken: cancellationToken);
@@ -59,6 +61,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="SmartCollection"/>.
         /// </summary>
         /// <param name="collection">A new <see cref="SmartCollection"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<SmartCollection> CreateAsync(SmartCollection collection, bool published = true, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections.json");
@@ -80,6 +83,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="smartCollectionId">Id of the object being updated.</param>
         /// <param name="collection">The smart collection to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<SmartCollection> UpdateAsync(long smartCollectionId, SmartCollection collection, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
@@ -96,6 +100,7 @@ namespace ShopifySharp
         /// Publishes an unpublished smart collection.
         /// </summary>
         /// <param name="smartCollectionId">The collection's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<SmartCollection> PublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
@@ -117,6 +122,7 @@ namespace ShopifySharp
         /// Publishes an unpublished smart collection.
         /// </summary>
         /// <param name="smartCollectionId">The collection's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<SmartCollection> UnpublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
@@ -172,6 +178,7 @@ namespace ShopifySharp
         /// Deletes a smart collection with the given Id.
         /// </summary>
         /// <param name="collectionId">The smart collection's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long collectionId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"smart_collections/{collectionId}.json");

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -23,7 +24,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's themes.
         /// </summary>
-        public virtual async Task<IEnumerable<Theme>> ListAsync(ThemeListFilter filter = null)
+        public virtual async Task<IEnumerable<Theme>> ListAsync(ThemeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<Theme>>("themes.json", "themes", filter);
         }
@@ -34,7 +35,7 @@ namespace ShopifySharp
         /// <param name="themeId">The id of the theme to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Theme"/>.</returns>
-        public virtual async Task<Theme> GetAsync(long themeId, string fields = null)
+        public virtual async Task<Theme> GetAsync(long themeId, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}.json");
 
@@ -74,7 +75,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="theme">The new theme.</param>
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
-        public virtual async Task<Theme> CreateAsync(Theme theme)
+        public virtual async Task<Theme> CreateAsync(Theme theme, CancellationToken cancellationToken = default)
         {
             return await _CreateAsync(theme);
         }
@@ -86,7 +87,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="theme">The new theme.</param>
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
-        public virtual async Task<Theme> CreateAsync(Theme theme, string sourceUrl)
+        public virtual async Task<Theme> CreateAsync(Theme theme, string sourceUrl, CancellationToken cancellationToken = default)
         {
             return await _CreateAsync(theme, sourceUrl);
         }
@@ -97,7 +98,7 @@ namespace ShopifySharp
         /// <param name="themeId">Id of the object being updated.</param>
         /// <param name="theme">The <see cref="Theme"/> to update.</param>
         /// <returns>The updated <see cref="Theme"/>.</returns>
-        public virtual async Task<Theme> UpdateAsync(long themeId, Theme theme)
+        public virtual async Task<Theme> UpdateAsync(long themeId, Theme theme, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}.json");
             var content = new JsonContent(new
@@ -113,7 +114,7 @@ namespace ShopifySharp
         /// Deletes a Theme with the given Id.
         /// </summary>
         /// <param name="themeId">The Theme object's Id.</param>
-        public virtual async Task DeleteAsync(long themeId)
+        public virtual async Task DeleteAsync(long themeId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}.json");
 

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<Theme>> ListAsync(ThemeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Theme>>("themes.json", "themes", filter);
+            return await ExecuteGetAsync<IEnumerable<Theme>>("themes.json", "themes", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -44,12 +44,12 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Get, rootElement: "theme");
+            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Get, rootElement: "theme", cancellationToken: cancellationToken);
 
             return response.Result;
         }
 
-        private async Task<Theme> _CreateAsync(Theme theme, string sourceUrl = null)
+        private async Task<Theme> _CreateAsync(Theme theme, CancellationToken cancellationToken, string sourceUrl = null)
         {
             var req = PrepareRequest("themes.json");
             var body = theme.ToDictionary();
@@ -63,7 +63,7 @@ namespace ShopifySharp
             {
                 theme = body
             });
-            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Post, content, "theme");
+            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Post, content, "theme", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -77,7 +77,7 @@ namespace ShopifySharp
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
         public virtual async Task<Theme> CreateAsync(Theme theme, CancellationToken cancellationToken = default)
         {
-            return await _CreateAsync(theme);
+            return await _CreateAsync(theme, cancellationToken);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace ShopifySharp
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
         public virtual async Task<Theme> CreateAsync(Theme theme, string sourceUrl, CancellationToken cancellationToken = default)
         {
-            return await _CreateAsync(theme, sourceUrl);
+            return await _CreateAsync(theme, cancellationToken, sourceUrl);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace ShopifySharp
             {
                 theme = theme
             });
-            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Put, content, "theme");
+            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Put, content, "theme", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -118,7 +118,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"themes/{themeId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<Theme>> ListAsync(ThemeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Theme>>("themes.json", "themes", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<IEnumerable<Theme>>("themes.json", "themes", filter, cancellationToken);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Get, rootElement: "theme", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Get, cancellationToken, rootElement: "theme");
 
             return response.Result;
         }
@@ -64,7 +64,7 @@ namespace ShopifySharp
             {
                 theme = body
             });
-            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Post, content, "theme", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Post, cancellationToken, content, "theme");
 
             return response.Result;
         }
@@ -109,7 +109,7 @@ namespace ShopifySharp
             {
                 theme = theme
             });
-            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Put, content, "theme", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Theme>(req, HttpMethod.Put, cancellationToken, content, "theme");
 
             return response.Result;
         }
@@ -123,7 +123,7 @@ namespace ShopifySharp
         {
             var req = PrepareRequest($"themes/{themeId}.json");
 
-            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
+            await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -34,6 +34,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">The id of the theme to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Theme"/>.</returns>
         public virtual async Task<Theme> GetAsync(long themeId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -75,6 +76,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="theme">The new theme.</param>
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Theme> CreateAsync(Theme theme, CancellationToken cancellationToken = default)
         {
             return await _CreateAsync(theme, cancellationToken);
@@ -87,6 +89,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="theme">The new theme.</param>
         /// <param name="sourceUrl">A URL that points to the .zip file containing the theme's source files.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Theme> CreateAsync(Theme theme, string sourceUrl, CancellationToken cancellationToken = default)
         {
             return await _CreateAsync(theme, cancellationToken, sourceUrl);
@@ -97,6 +100,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="themeId">Id of the object being updated.</param>
         /// <param name="theme">The <see cref="Theme"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Theme"/>.</returns>
         public virtual async Task<Theme> UpdateAsync(long themeId, Theme theme, CancellationToken cancellationToken = default)
         {
@@ -114,6 +118,7 @@ namespace ShopifySharp
         /// Deletes a Theme with the given Id.
         /// </summary>
         /// <param name="themeId">The Theme object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long themeId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"themes/{themeId}.json");

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>($"orders/{orderId}/transactions/count.json", "count");
+            return await ExecuteGetAsync<int>($"orders/{orderId}/transactions/count.json", "count", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter);
+            return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the result.</param>
         public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter);
+            return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace ShopifySharp
             {
                 transaction = transaction
             });
-            var response = await ExecuteRequestAsync<Transaction>(req, HttpMethod.Post, content, "transaction");
+            var response = await ExecuteRequestAsync<Transaction>(req, HttpMethod.Post, content, "transaction", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -36,6 +36,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
@@ -47,6 +48,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="transactionId">The id of the Transaction to retrieve.</param>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter, cancellationToken: cancellationToken);
@@ -57,6 +59,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="transaction">The transaction.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Transaction"/>.</returns>
         public virtual async Task<Transaction> CreateAsync(long orderId, Transaction transaction, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -25,7 +26,7 @@ namespace ShopifySharp
         /// <remarks>
         /// According to Shopify's documentation, this endpoint does not currently support any additional filter parameters for counting.
         /// </remarks>
-        public virtual async Task<int> CountAsync(long orderId)
+        public virtual async Task<int> CountAsync(long orderId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>($"orders/{orderId}/transactions/count.json", "count");
         }
@@ -35,7 +36,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null)
+        public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter);
         }
@@ -46,7 +47,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="transactionId">The id of the Transaction to retrieve.</param>
         /// <param name="filter">Options for filtering the result.</param>
-        public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null)
+        public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter);
         }
@@ -57,7 +58,7 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="transaction">The transaction.</param>
         /// <returns>The new <see cref="Transaction"/>.</returns>
-        public virtual async Task<Transaction> CreateAsync(long orderId, Transaction transaction)
+        public virtual async Task<Transaction> CreateAsync(long orderId, Transaction transaction, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"orders/{orderId}/transactions.json");
             var content = new JsonContent(new

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter, cancellationToken);
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter, cancellationToken);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace ShopifySharp
             {
                 transaction = transaction
             });
-            var response = await ExecuteRequestAsync<Transaction>(req, HttpMethod.Post, content, "transaction", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<Transaction>(req, HttpMethod.Post, cancellationToken, content, "transaction");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
                     price = price
                 }
             });
-            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, content, "usage_charge");
+            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, content, "usage_charge", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -59,7 +59,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Get, rootElement: "usage_charge");
+            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Get, rootElement: "usage_charge", cancellationToken: cancellationToken);
 
             return response.Result;
         }
@@ -78,7 +78,7 @@ namespace ShopifySharp
                 req.QueryParams.AddRange(filter.ToQueryParameters());
             }
             
-            var response = await ExecuteRequestAsync<List<UsageCharge>>(req, HttpMethod.Get, rootElement: "usage_charges");
+            var response = await ExecuteRequestAsync<List<UsageCharge>>(req, HttpMethod.Get, rootElement: "usage_charges", cancellationToken: cancellationToken);
 
             return response.Result;
         }

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// <param name="recurringChargeId">The id of the <see cref="UsageCharge"/> that this usage charge belongs to.</param>
         /// <param name="description">The name or description of the usage charge.</param>
         /// <param name="price">The price of the usage charge.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="UsageCharge"/>.</returns>
         public virtual async Task<UsageCharge> CreateAsync(long recurringChargeId, string description, decimal price, CancellationToken cancellationToken = default)
         {
@@ -49,6 +50,7 @@ namespace ShopifySharp
         /// <param name="recurringChargeId">The id of the recurring charge that this usage charge belongs to.</param>
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="UsageCharge"/>.</returns>
         public virtual async Task<UsageCharge> GetAsync(long recurringChargeId, long id, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -69,6 +71,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="recurringChargeId">The id of the recurring charge that these usage charges belong to.</param>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, UsageChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// <param name="description">The name or description of the usage charge.</param>
         /// <param name="price">The price of the usage charge.</param>
         /// <returns>The new <see cref="UsageCharge"/>.</returns>
-        public virtual async Task<UsageCharge> CreateAsync(long recurringChargeId, string description, decimal price)
+        public virtual async Task<UsageCharge> CreateAsync(long recurringChargeId, string description, decimal price, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
             var content = new JsonContent(new
@@ -49,7 +50,7 @@ namespace ShopifySharp
         /// <param name="id">The id of the charge to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="UsageCharge"/>.</returns>
-        public virtual async Task<UsageCharge> GetAsync(long recurringChargeId, long id, string fields = null)
+        public virtual async Task<UsageCharge> GetAsync(long recurringChargeId, long id, string fields = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges/{id}.json");
 
@@ -68,7 +69,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="recurringChargeId">The id of the recurring charge that these usage charges belong to.</param>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, UsageChargeListFilter filter = null)
+        public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, UsageChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
 

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
                     price = price
                 }
             });
-            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, content, "usage_charge", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, cancellationToken, content, "usage_charge");
 
             return response.Result;
         }
@@ -61,7 +61,7 @@ namespace ShopifySharp
                 req.QueryParams.Add("fields", fields);
             }
 
-            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Get, rootElement: "usage_charge", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Get, cancellationToken, rootElement: "usage_charge");
 
             return response.Result;
         }
@@ -81,7 +81,7 @@ namespace ShopifySharp
                 req.QueryParams.AddRange(filter.ToQueryParameters());
             }
             
-            var response = await ExecuteRequestAsync<List<UsageCharge>>(req, HttpMethod.Get, rootElement: "usage_charges", cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<List<UsageCharge>>(req, HttpMethod.Get, cancellationToken, rootElement: "usage_charges");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/User/UserService.cs
+++ b/ShopifySharp/Services/User/UserService.cs
@@ -34,6 +34,7 @@ namespace ShopifySharp
         /// Retrieves the <see cref="User"/> with the given id.
         /// </summary>
         /// <param name="userId">The id of the User to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="User"/>.</returns>
         public virtual async Task<User> GetAsync(long userId, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/User/UserService.cs
+++ b/ShopifySharp/Services/User/UserService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
@@ -24,7 +25,7 @@ namespace ShopifySharp
         /// <summary>
         /// Gets all the users.
         /// </summary>
-        public virtual async Task<IEnumerable<User>> ListAsync()
+        public virtual async Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<IEnumerable<User>>("users.json", "users");
         }
@@ -34,7 +35,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="userId">The id of the User to retrieve.</param>
         /// <returns>The <see cref="User"/>.</returns>
-        public virtual async Task<User> GetAsync(long userId)
+        public virtual async Task<User> GetAsync(long userId, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<User>($"users/{userId}.json", "user");
         }
@@ -43,7 +44,7 @@ namespace ShopifySharp
         /// Retrieves the current logged-in <see cref="User"/> (useful only when the access token was created for a specific user of the shop).
         /// </summary>
         /// <returns>The <see cref="User"/>.</returns>
-        public virtual async Task<User> GetCurrentAsync()
+        public virtual async Task<User> GetCurrentAsync(CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<User>("users/current.json", "user");
         }

--- a/ShopifySharp/Services/User/UserService.cs
+++ b/ShopifySharp/Services/User/UserService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         public virtual async Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<User>>("users.json", "users");
+            return await ExecuteGetAsync<IEnumerable<User>>("users.json", "users", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="User"/>.</returns>
         public virtual async Task<User> GetAsync(long userId, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<User>($"users/{userId}.json", "user");
+            return await ExecuteGetAsync<User>($"users/{userId}.json", "user", cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="User"/>.</returns>
         public virtual async Task<User> GetCurrentAsync(CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<User>("users/current.json", "user");
+            return await ExecuteGetAsync<User>("users/current.json", "user", cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Webhook/WebhookService.cs
+++ b/ShopifySharp/Services/Webhook/WebhookService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -26,7 +27,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
         /// <returns>The count of all webhooks for the shop.</returns>
-        public virtual async Task<int> CountAsync(WebhookCountFilter filter = null)
+        public virtual async Task<int> CountAsync(WebhookCountFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<int>("webhooks/count.json", "count", filter);
         }
@@ -35,7 +36,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's webhooks.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<ListResult<Webhook>> ListAsync(ListFilter<Webhook> filter)
+        public virtual async Task<ListResult<Webhook>> ListAsync(ListFilter<Webhook> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("webhooks.json", "webhooks", filter);
         }
@@ -44,7 +45,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's webhooks.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
-        public virtual async Task<ListResult<Webhook>> ListAsync(WebhookListFilter filter = null)
+        public virtual async Task<ListResult<Webhook>> ListAsync(WebhookListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter());
         }
@@ -55,7 +56,7 @@ namespace ShopifySharp
         /// <param name="webhookId">The id of the webhook to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <returns>The <see cref="Webhook"/>.</returns>
-        public virtual async Task<Webhook> GetAsync(long webhookId, string fields = null)
+        public virtual async Task<Webhook> GetAsync(long webhookId, string fields = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", fields);
         }
@@ -65,7 +66,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="webhook">A new <see cref="Webhook"/>. Id should be set to null.</param>
         /// <returns>The new <see cref="Webhook"/>.</returns>
-        public virtual async Task<Webhook> CreateAsync(Webhook webhook)
+        public virtual async Task<Webhook> CreateAsync(Webhook webhook, CancellationToken cancellationToken = default)
         {
             return await ExecutePostAsync<Webhook>("webhooks.json", "webhook", new { webhook = webhook });
         }
@@ -76,7 +77,7 @@ namespace ShopifySharp
         /// <param name="webhookId">Id of the object being updated.</param>
         /// <param name="webhook">The <see cref="Webhook"/> to update.</param>
         /// <returns>The updated <see cref="Webhook"/>.</returns>
-        public virtual async Task<Webhook> UpdateAsync(long webhookId, Webhook webhook)
+        public virtual async Task<Webhook> UpdateAsync(long webhookId, Webhook webhook, CancellationToken cancellationToken = default)
         {
             return await ExecutePutAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", new { webhook = webhook });
         }
@@ -85,7 +86,7 @@ namespace ShopifySharp
         /// Deletes the webhook with the given Id.
         /// </summary>
         /// <param name="webhookId">The order object's Id.</param>
-        public virtual async Task DeleteAsync(long webhookId)
+        public virtual async Task DeleteAsync(long webhookId, CancellationToken cancellationToken = default)
         {
             await ExecuteDeleteAsync($"webhooks/{webhookId}.json");
         }

--- a/ShopifySharp/Services/Webhook/WebhookService.cs
+++ b/ShopifySharp/Services/Webhook/WebhookService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <returns>The count of all webhooks for the shop.</returns>
         public virtual async Task<int> CountAsync(WebhookCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("webhooks/count.json", "count", filter);
+            return await ExecuteGetAsync<int>("webhooks/count.json", "count", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<ListResult<Webhook>> ListAsync(ListFilter<Webhook> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("webhooks.json", "webhooks", filter);
+            return await ExecuteGetListAsync("webhooks.json", "webhooks", filter, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// <param name="filter">Options for filtering the list.</param>
         public virtual async Task<ListResult<Webhook>> ListAsync(WebhookListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter());
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> GetAsync(long webhookId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", fields);
+            return await ExecuteGetAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", fields, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace ShopifySharp
         /// <param name="webhookId">The order object's Id.</param>
         public virtual async Task DeleteAsync(long webhookId, CancellationToken cancellationToken = default)
         {
-            await ExecuteDeleteAsync($"webhooks/{webhookId}.json");
+            await ExecuteDeleteAsync($"webhooks/{webhookId}.json", cancellationToken: cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Webhook/WebhookService.cs
+++ b/ShopifySharp/Services/Webhook/WebhookService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
         /// <returns>The count of all webhooks for the shop.</returns>
         public virtual async Task<int> CountAsync(WebhookCountFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<int>("webhooks/count.json", "count", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<int>("webhooks/count.json", "count", filter, cancellationToken);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Webhook>> ListAsync(ListFilter<Webhook> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("webhooks.json", "webhooks", filter, cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("webhooks.json", "webhooks", filter, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <returns>The <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> GetAsync(long webhookId, string fields = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", fields, cancellationToken: cancellationToken);
+            return await ExecuteGetAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", fields, cancellationToken);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace ShopifySharp
         /// <returns>The new <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> CreateAsync(Webhook webhook, CancellationToken cancellationToken = default)
         {
-            return await ExecutePostAsync<Webhook>("webhooks.json", "webhook", new { webhook = webhook });
+            return await ExecutePostAsync<Webhook>("webhooks.json", "webhook", cancellationToken, new { webhook = webhook });
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// <returns>The updated <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> UpdateAsync(long webhookId, Webhook webhook, CancellationToken cancellationToken = default)
         {
-            return await ExecutePutAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", new { webhook = webhook });
+            return await ExecutePutAsync<Webhook>($"webhooks/{webhookId}.json", "webhook", cancellationToken, new { webhook = webhook });
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long webhookId, CancellationToken cancellationToken = default)
         {
-            await ExecuteDeleteAsync($"webhooks/{webhookId}.json", cancellationToken: cancellationToken);
+            await ExecuteDeleteAsync($"webhooks/{webhookId}.json", cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/Webhook/WebhookService.cs
+++ b/ShopifySharp/Services/Webhook/WebhookService.cs
@@ -26,6 +26,7 @@ namespace ShopifySharp
         /// Gets a count of all of the shop's webhooks.
         /// </summary>
         /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The count of all webhooks for the shop.</returns>
         public virtual async Task<int> CountAsync(WebhookCountFilter filter = null, CancellationToken cancellationToken = default)
         {
@@ -36,6 +37,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's webhooks.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Webhook>> ListAsync(ListFilter<Webhook> filter, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("webhooks.json", "webhooks", filter, cancellationToken: cancellationToken);
@@ -45,6 +47,7 @@ namespace ShopifySharp
         /// Gets a list of up to 250 of the shop's webhooks.
         /// </summary>
         /// <param name="filter">Options for filtering the list.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<Webhook>> ListAsync(WebhookListFilter filter = null, CancellationToken cancellationToken = default)
         {
             return await ListAsync(filter?.AsListFilter(), cancellationToken);
@@ -55,6 +58,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="webhookId">The id of the webhook to retrieve.</param>
         /// <param name="fields">A comma-separated list of fields to return.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> GetAsync(long webhookId, string fields = null, CancellationToken cancellationToken = default)
         {
@@ -65,6 +69,7 @@ namespace ShopifySharp
         /// Creates a new <see cref="Webhook"/> on the store.
         /// </summary>
         /// <param name="webhook">A new <see cref="Webhook"/>. Id should be set to null.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The new <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> CreateAsync(Webhook webhook, CancellationToken cancellationToken = default)
         {
@@ -76,6 +81,7 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="webhookId">Id of the object being updated.</param>
         /// <param name="webhook">The <see cref="Webhook"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The updated <see cref="Webhook"/>.</returns>
         public virtual async Task<Webhook> UpdateAsync(long webhookId, Webhook webhook, CancellationToken cancellationToken = default)
         {
@@ -86,6 +92,7 @@ namespace ShopifySharp
         /// Deletes the webhook with the given Id.
         /// </summary>
         /// <param name="webhookId">The order object's Id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task DeleteAsync(long webhookId, CancellationToken cancellationToken = default)
         {
             await ExecuteDeleteAsync($"webhooks/{webhookId}.json", cancellationToken: cancellationToken);


### PR DESCRIPTION
- `ShopifyService` ExecuteXXX calls leverage a cancellation token for the underlying `HttpClient` request and the execution policy timeout
- All existing Service public API methods now take an optional `CancellationToken`

I included some tests on the ShopifyService just to ensure the token is leveraged properly.  I did not add tests to every single service API call, as they proxy requests to the base class, and token use there is tested.  Therefore, please review the public service calls to ensure I didn't miss anything.