### PR TITLE
Changed InventoryLevel.Available from int to long

### DIFF
--- a/ShopifySharp/Entities/InventoryLevel.cs
+++ b/ShopifySharp/Entities/InventoryLevel.cs
@@ -24,7 +24,7 @@ namespace ShopifySharp
         /// The quantity of inventory items available for sale. Returns null if the inventory item is not tracked.
         /// </summary>
         [JsonProperty("available")]
-        public int? Available { get; set; }
+        public long? Available { get; set; }
 
         /// <summary>
         /// The date and time when the inventory level was last modified.

--- a/ShopifySharp/Entities/ProductVariant.cs
+++ b/ShopifySharp/Entities/ProductVariant.cs
@@ -131,7 +131,7 @@ namespace ShopifySharp
         /// NOTE: After 2018-07-01, this field will be read-only in the Shopify API. Use the `InventoryLevelService` instead.
         /// </summary>
         [JsonProperty("inventory_quantity")]
-        public int? InventoryQuantity { get; set; }
+        public long? InventoryQuantity { get; set; }
 
         /// <summary>
         /// The unique numeric identifier for one of the product's images.

--- a/ShopifySharp/Infrastructure/ShopifyException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyException.cs
@@ -31,7 +31,8 @@ namespace ShopifySharp
 
         public ShopifyException(string message) : base(message) { }
 
-        public ShopifyException(HttpResponseMessage response, HttpStatusCode httpStatusCode, IEnumerable<string> errors, string message, string rawBody, string requestId) : base(message)
+        public ShopifyException(HttpResponseMessage response, HttpStatusCode httpStatusCode, IEnumerable<string> errors, string message, string rawBody, string requestId) : 
+            base($"Request-Id: {requestId ?? "None"}\r\n{message}")
         {
             HttpResponse = response;
             HttpStatusCode = httpStatusCode;

--- a/ShopifySharp/Infrastructure/ShopifyException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyException.cs
@@ -31,8 +31,7 @@ namespace ShopifySharp
 
         public ShopifyException(string message) : base(message) { }
 
-        public ShopifyException(HttpResponseMessage response, HttpStatusCode httpStatusCode, IEnumerable<string> errors, string message, string rawBody, string requestId) : 
-            base($"Request-Id: {requestId ?? "None"}\r\n{message}")
+        public ShopifyException(HttpResponseMessage response, HttpStatusCode httpStatusCode, IEnumerable<string> errors, string message, string rawBody, string requestId) : base(message)
         {
             HttpResponse = response;
             HttpStatusCode = httpStatusCode;


### PR DESCRIPTION
I came across in production an inventory_level with a available quantity lower than int.MinValue

![image](https://user-images.githubusercontent.com/3426504/82796176-68830280-9e75-11ea-8590-aefc9a647ae5.png)
