### PR TITLE
Fix for IsAuthenticRequest bug when ids[] contains a single value.

### DIFF
--- a/ShopifySharp.Tests/Authorization_Tests.cs
+++ b/ShopifySharp.Tests/Authorization_Tests.cs
@@ -75,7 +75,16 @@ namespace ShopifySharp.Tests
         [Fact(Skip = "TODO: Generate a real query string with the shop and secret key used by the build server, which contains an ids[] parameter")]
         public void Validates_Web_Requests_WithArrayParameter()
         {
-            string query = "hmac=123....";
+            string query = "hmac=...";
+            var qs = QueryHelpers.ParseQuery(query);
+            bool isValid = AuthorizationService.IsAuthenticRequest(qs, Utils.SecretKey);
+            Assert.True(isValid);
+        }
+
+        [Fact(Skip = "TODO: Generate a real query string with the shop and secret key used by the build server, which contains an ids[] parameter with a single value")]
+        public void Validates_Web_Requests_WithArrayParameter_SingleValue()
+        {
+            string query = "hmac=...";
             var qs = QueryHelpers.ParseQuery(query);
             bool isValid = AuthorizationService.IsAuthenticRequest(qs, Utils.SecretKey);
             Assert.True(isValid);


### PR DESCRIPTION
Fixes #530

@nozzlegear  if possible, complete the tests with a real query string value. I cannot do it myself as I don't know the keys used by the test server.