### PR TITLE
Bug Fix for GiftCard.ExpiresOn

### DIFF
--- a/ShopifySharp.Tests/GiftCard_Tests.cs
+++ b/ShopifySharp.Tests/GiftCard_Tests.cs
@@ -84,14 +84,21 @@ namespace ShopifySharp.Tests
         }
 
         [Fact(Skip = "Cannot run without a Shopify Plus account.")]
-        public async Task Creates_GiftCards_With_ExpiresOn()
+        public async Task Updates_GiftCards_With_ExpiresOn()
         {
-            var date = DateTimeOffset.UtcNow.AddDays(1);
-            var created = await Fixture.Create(GiftCardValue, expiresOn: date);
+            var date = new DateTimeOffset(DateTimeOffset.UtcNow.Year, DateTimeOffset.UtcNow.Month, DateTimeOffset.UtcNow.Day, 0, 0, 0, TimeSpan.Zero);
+            var created = await Fixture.Create(GiftCardValue);
+            long id = created.Id.Value;
 
-            Assert.NotNull(created);
-            Assert.True(created.Id.HasValue);
-            Assert.Equal(date, created.ExpiresOn);
+            created.ExpiresOn = date;
+            created.Id = null;
+
+            var updated = await Fixture.Service.UpdateAsync(id, created);
+
+            // Reset the id so the Fixture can properly delete this object.
+            created.Id = id;
+
+            Assert.Equal(date.Date, updated.ExpiresOn.Value.Date);
         }
 
         [Fact(Skip = "Cannot run without a Shopify Plus account.")]
@@ -129,7 +136,7 @@ namespace ShopifySharp.Tests
             var customCode = Guid.NewGuid().ToString();
             customCode = customCode.Substring(customCode.Length - 20);
             await Fixture.Create(GiftCardValue, customCode);
-            var search = await Fixture.Service.SearchAsync(new GiftCardSearchFilter { Query = "code:" + customCode });
+            var search = await Fixture.Service.SearchAsync(new GiftCardSearchFilter { Query = "initial_value:" + GiftCardValue });
 
             Assert.True(search.Items.Any());
         }

--- a/ShopifySharp.Tests/GiftCard_Tests.cs
+++ b/ShopifySharp.Tests/GiftCard_Tests.cs
@@ -83,6 +83,16 @@ namespace ShopifySharp.Tests
             Assert.Equal(lastFour, created.LastCharacters);
         }
 
+        [Fact(Skip = "Cannot run without a Shopify Plus account.")]
+        public async Task Creates_GiftCards_With_ExpiresOn()
+        {
+            var date = DateTimeOffset.UtcNow.AddDays(1);
+            var created = await Fixture.Create(GiftCardValue, expiresOn: date);
+
+            Assert.NotNull(created);
+            Assert.True(created.Id.HasValue);
+            Assert.Equal(date, created.ExpiresOn);
+        }
 
         [Fact(Skip = "Cannot run without a Shopify Plus account.")]
         public async Task Updates_GiftCards()
@@ -153,7 +163,7 @@ namespace ShopifySharp.Tests
                 }
             }
         }
-        public async Task<GiftCard> Create(decimal value, string code = null)
+        public async Task<GiftCard> Create(decimal value, string code = null, DateTimeOffset? expiresOn = null)
         {
             var giftCardRequest = new GiftCard() { InitialValue = value };
             if (!string.IsNullOrEmpty(code))
@@ -163,6 +173,10 @@ namespace ShopifySharp.Tests
             if (giftCardRequest.Code != null && giftCardRequest.Code.Length > 20)
             {
                 giftCardRequest.Code = giftCardRequest.Code.Substring(giftCardRequest.Code.Length - 20);
+            }
+            if (expiresOn.HasValue)
+            {
+                giftCardRequest.ExpiresOn = expiresOn;
             }
             var giftCard = await Service.CreateAsync(giftCardRequest);
 

--- a/ShopifySharp.Tests/GiftCard_Tests.cs
+++ b/ShopifySharp.Tests/GiftCard_Tests.cs
@@ -170,7 +170,7 @@ namespace ShopifySharp.Tests
                 }
             }
         }
-        public async Task<GiftCard> Create(decimal value, string code = null, DateTimeOffset? expiresOn = null)
+        public async Task<GiftCard> Create(decimal value, string code = null)
         {
             var giftCardRequest = new GiftCard() { InitialValue = value };
             if (!string.IsNullOrEmpty(code))
@@ -181,10 +181,7 @@ namespace ShopifySharp.Tests
             {
                 giftCardRequest.Code = giftCardRequest.Code.Substring(giftCardRequest.Code.Length - 20);
             }
-            if (expiresOn.HasValue)
-            {
-                giftCardRequest.ExpiresOn = expiresOn;
-            }
+            
             var giftCard = await Service.CreateAsync(giftCardRequest);
 
             Created.Add(giftCard);

--- a/ShopifySharp/Converters/DateFormatConverter.cs
+++ b/ShopifySharp/Converters/DateFormatConverter.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp.Converters
+{
+    /// <summary>
+    /// Converts a Date to and from the provided date format string.
+    /// In Particular, GiftCard.ExpiresOn only accepts the format 'yyyy-MM-dd'. If the time is included the value is ignored
+    /// </summary>
+    public class DateFormatConverter : IsoDateTimeConverter
+    {
+        public DateFormatConverter(string format)
+        {
+            base.DateTimeFormat = format;
+        }
+    }
+}

--- a/ShopifySharp/Entities/GiftCard.cs
+++ b/ShopifySharp/Entities/GiftCard.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
+using ShopifySharp.Converters;
 
 namespace ShopifySharp
 {
@@ -47,6 +48,7 @@ namespace ShopifySharp
         /// The date and time when the gift card will expire. 
         /// </summary>
         [JsonProperty("expires_on")]
+        [JsonConverter(typeof(DateFormatConverter),"yyyy-MM-dd")]
         public DateTimeOffset? ExpiresOn { get; set; }
 
         /// <summary>


### PR DESCRIPTION
When ~~creating~~ updating a gift card with an expiry date, the value is ignored because the date format needs to be 'yyyy-MM-dd'

The Date Format Converter takes a format parameter since it comes from one of my own projects. Let me know if you want to change it.