### PR TITLE
Fix compile time error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -260,8 +260,11 @@ var scopes = new List<string>()
     "write_customers"
 }
 
+//You can find your API key over at https://shopify.dev/tutorials/authenticate-a-private-app-with-shopify-admin
+string shopifyApiKey = "";
+
 //All AuthorizationService methods are static.
-string authUrl = AuthorizationService.BuildAuthorizationUrl(scopes, usersMyShopifyUrl, shopifyApiKey, redirectUrl);
+Uri authUrl = AuthorizationService.BuildAuthorizationUrl(scopes, usersMyShopifyUrl, shopifyApiKey, redirectUrl);
 ```
 
 ### Authorize an installation and generate an access token


### PR DESCRIPTION
It's going to throw you a compile time error if you try assigning it to a string. I suspect that this hasn't been updated in a while where as the actual library has. I'm also letting the user know how to generate their own API key by referencing the official documentation.