### PR TITLE
Added Merchant's Access Scopes

### DIFF
--- a/ShopifySharp/Enums/AuthorizationScope.cs
+++ b/ShopifySharp/Enums/AuthorizationScope.cs
@@ -104,10 +104,10 @@ namespace ShopifySharp.Enums
         WriteDraftOrders,
 
         [EnumMember(Value = "write_merchant_managed_fulfillment_orders")]
-        WriteMerchantManagedOrders,
+        WriteMerchantManagedFulfillmentOrders,
 
         [EnumMember(Value = "read_merchant_managed_fulfillment_orders")]
-        ReadMerchantManagedOrders,
+        ReadMerchantManagedFulfillmentOrders,
 
         [EnumMember(Value = "read_marketing_events")]
         ReadMarketingEvents,

--- a/ShopifySharp/Enums/AuthorizationScope.cs
+++ b/ShopifySharp/Enums/AuthorizationScope.cs
@@ -103,6 +103,12 @@ namespace ShopifySharp.Enums
         [EnumMember(Value = "write_draft_orders")]
         WriteDraftOrders,
 
+        [EnumMember(Value = "write_merchant_managed_fulfillment_orders")]
+        WriteMerchantManagedOrders,
+
+        [EnumMember(Value = "read_merchant_managed_fulfillment_orders")]
+        ReadMerchantManagedOrders,
+
         [EnumMember(Value = "read_marketing_events")]
         ReadMarketingEvents,
 


### PR DESCRIPTION
Hi
I was unable to cancel the orders after updating to Shopify API Version: **2020-07**, SDK: **5.7.0**

Added merchant Access Scopes (https://shopify.dev/docs/admin-api/access-scopes)
- read_merchant_managed_fulfillment_orders
- write_merchant_managed_fulfillment_orders

I am able to cancel the orders now.

Thanks!
