### PR TITLE
Ability to pass HTTP headers + New Transaction.CurrencyExchangeAdjustment property

### DIFF
--- a/ShopifySharp/Entities/CurrencyExchangeAdjustment.cs
+++ b/ShopifySharp/Entities/CurrencyExchangeAdjustment.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace ShopifySharp
+{
+    public class CurrencyExchangeAdjustment : ShopifyObject
+    {
+        /// <summary>
+        /// The difference between the amounts on the associated transaction and the parent transaction.
+        /// </summary>
+        [JsonProperty("adjustment")]
+        public decimal? Adjustment { get; set; }
+
+        /// <summary>
+        /// The amount of the parent transaction in the shop currency.
+        /// </summary>
+        [JsonProperty("original_amount")]
+        public decimal? OriginalAmount { get; set; }
+
+        /// <summary>
+        /// The amount of the associated transaction in the shop currency.
+        /// </summary>
+        [JsonProperty("final_amount")]
+        public decimal? FinalAmount { get; set; }
+
+        /// <summary>
+        /// The shop currency.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/Transaction.cs
+++ b/ShopifySharp/Entities/Transaction.cs
@@ -133,5 +133,12 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("maximum_refundable")]
         public decimal? MaximumRefundable { get; set; }
+
+        /// <summary>
+        /// An adjustment on the transaction showing the amount lost or gained due to fluctuations in the currency exchange rate
+        /// Requires the header X-Shopify-Api-Features = include-currency-exchange-adjustments
+        /// </summary>
+        [JsonProperty("currency_exchange_adjustment")]
+        public CurrencyExchangeAdjustment CurrencyExchangeAdjustment { get; set; }
     }
 }

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Filters;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
+using System.Collections.Generic;
 
 namespace ShopifySharp
 {
@@ -31,17 +32,17 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the shop's products.
         /// </summary>
-        public virtual async Task<ListResult<Product>> ListAsync(ListFilter<Product> filter, CancellationToken cancellationToken = default)
+        public virtual async Task<ListResult<Product>> ListAsync(ListFilter<Product> filter, bool includePresentmentPrices = false, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetListAsync("products.json", "products", filter, cancellationToken);
+            return await ExecuteGetListAsync("products.json", "products", filter, cancellationToken, GetHeaders(includePresentmentPrices));
         }
 
         /// <summary>
         /// Gets a list of up to 250 of the shop's products.
         /// </summary>
-        public virtual async Task<ListResult<Product>> ListAsync(ProductListFilter filter = null, CancellationToken cancellationToken = default)
+        public virtual async Task<ListResult<Product>> ListAsync(ProductListFilter filter = null, bool includePresentmentPrices = false, CancellationToken cancellationToken = default)
         {
-            return await ListAsync(filter?.AsListFilter(), cancellationToken);
+            return await ListAsync(filter?.AsListFilter(), includePresentmentPrices, cancellationToken);
         }
 
         /// <summary>
@@ -51,9 +52,9 @@ namespace ShopifySharp
         /// <param name="fields">A comma-separated list of fields to return.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>The <see cref="Product"/>.</returns>
-        public virtual async Task<Product> GetAsync(long productId, string fields = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Product> GetAsync(long productId, string fields = null, bool includePresentmentPrices = false, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields, cancellationToken);
+            return await ExecuteGetAsync<Product>($"products/{productId}.json", "product", fields, cancellationToken, GetHeaders(includePresentmentPrices));
         }
 
         /// <summary>
@@ -158,6 +159,17 @@ namespace ShopifySharp
             var response = await ExecuteRequestAsync<Product>(req, HttpMethod.Put, cancellationToken, content, "product");
 
             return response.Result;
+        }
+
+        private Dictionary<string, string> GetHeaders(bool includePresentmentPrices)
+        {
+            if (!includePresentmentPrices)
+                return null;
+
+            return new Dictionary<string, string>
+            {
+                { "X-Shopify-Api-Features", "include-presentment-prices" }
+            };
         }
     }
 }

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -37,9 +37,9 @@ namespace ShopifySharp
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
         /// <param name="filter">Options for filtering the list.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null, CancellationToken cancellationToken = default)
+        public virtual async Task<IEnumerable<Transaction>> ListAsync(long orderId, TransactionListFilter filter = null, bool includeCurrencyExchangeAdjustments = false, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter, cancellationToken);
+            return await ExecuteGetAsync<IEnumerable<Transaction>>($"orders/{orderId}/transactions.json", "transactions", filter, cancellationToken, GetHeaders(includeCurrencyExchangeAdjustments));
         }
 
         /// <summary>
@@ -49,9 +49,9 @@ namespace ShopifySharp
         /// <param name="transactionId">The id of the Transaction to retrieve.</param>
         /// <param name="filter">Options for filtering the result.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Transaction> GetAsync(long orderId, long transactionId, TransactionGetFilter filter = null, bool includeCurrencyExchangeAdjustments = false, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter, cancellationToken);
+            return await ExecuteGetAsync<Transaction>($"orders/{orderId}/transactions/{transactionId}.json", "transaction", filter, cancellationToken, GetHeaders(includeCurrencyExchangeAdjustments));
         }
 
         /// <summary>
@@ -71,6 +71,17 @@ namespace ShopifySharp
             var response = await ExecuteRequestAsync<Transaction>(req, HttpMethod.Post, cancellationToken, content, "transaction");
 
             return response.Result;
+        }
+
+        private Dictionary<string, string> GetHeaders(bool includeCurrencyExchangeAdjustments)
+        {
+            if (!includeCurrencyExchangeAdjustments)
+                return null;
+
+            return new Dictionary<string, string>
+            {
+                { "X-Shopify-Api-Features", "include-currency-exchange-adjustments" }
+            };
         }
     }
 }


### PR DESCRIPTION
- New mechanism to pass HTTP headers to activate some fields
- Added Transaction.CurrencyExchangeAdjustment
- Fixes https://github.com/nozzlegear/ShopifySharp/issues/628