### PR TITLE
Add missing read and write translations scopes.

### DIFF
--- a/ShopifySharp/Enums/AuthorizationScope.cs
+++ b/ShopifySharp/Enums/AuthorizationScope.cs
@@ -137,6 +137,12 @@ namespace ShopifySharp.Enums
         UnauthenticatedReadContent,
 
         [EnumMember(Value = "read_locations")]
-        ReadLocations
+        ReadLocations,
+
+        [EnumMember(Value = "read_translations")]
+        ReadTranslations,
+
+        [EnumMember(Value = "write_translations")]
+        WriteTranslations
     }
 }


### PR DESCRIPTION
Hello,

I was unable to create translations, so I added the missing read and write translation scopes. Please let me know if you have any questions.

Reference documenation: https://shopify.dev/api/usage/access-scopes

Thanks!