### PR TITLE
New execution policy that handles both REST and GraphQL limits

### DIFF
--- a/ShopifySharp.Tests/AccessScope_Tests.cs
+++ b/ShopifySharp.Tests/AccessScope_Tests.cs
@@ -32,7 +32,7 @@ namespace ShopifySharp.Tests
 
         public Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             return Task.CompletedTask;
         }

--- a/ShopifySharp.Tests/ApplicationCredit_Tests.cs
+++ b/ShopifySharp.Tests/ApplicationCredit_Tests.cs
@@ -11,7 +11,7 @@ namespace ShopifySharp.Tests
 
         public ApplicationCredit_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact(Skip = "Application Credits cannot be tested because they're unusable in a private application.")]

--- a/ShopifySharp.Tests/Article_Tests.cs
+++ b/ShopifySharp.Tests/Article_Tests.cs
@@ -131,7 +131,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             BlogService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/Asset_Tests.cs
+++ b/ShopifySharp.Tests/Asset_Tests.cs
@@ -122,7 +122,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             ThemeService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/Blog_Tests.cs
+++ b/ShopifySharp.Tests/Blog_Tests.cs
@@ -104,7 +104,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one blog for methods like count, get, list, etc.
             await Create();

--- a/ShopifySharp.Tests/Carrier_Tests.cs
+++ b/ShopifySharp.Tests/Carrier_Tests.cs
@@ -97,7 +97,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one blog for methods like count, get, list, etc.
             await Create();

--- a/ShopifySharp.Tests/Checkout_Tests.cs
+++ b/ShopifySharp.Tests/Checkout_Tests.cs
@@ -10,7 +10,7 @@ namespace ShopifySharp.Tests
 
         public Checkout_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact]

--- a/ShopifySharp.Tests/Collect_Tests.cs
+++ b/ShopifySharp.Tests/Collect_Tests.cs
@@ -107,7 +107,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             CustomCollectionService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/Collection_Tests.cs
+++ b/ShopifySharp.Tests/Collection_Tests.cs
@@ -74,7 +74,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             CustomCollectionService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/Country_Tests.cs
+++ b/ShopifySharp.Tests/Country_Tests.cs
@@ -112,7 +112,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
             
             // Create one for count, list, get, etc. 
             await Create("IT");

--- a/ShopifySharp.Tests/CustomCollection_Tests.cs
+++ b/ShopifySharp.Tests/CustomCollection_Tests.cs
@@ -104,7 +104,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one collection for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/CustomerAddress_Tests.cs
+++ b/ShopifySharp.Tests/CustomerAddress_Tests.cs
@@ -114,7 +114,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             CustomerService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/CustomerSavedSearch_Tests.cs
+++ b/ShopifySharp.Tests/CustomerSavedSearch_Tests.cs
@@ -138,7 +138,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one customer for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/Customer_Tests.cs
+++ b/ShopifySharp.Tests/Customer_Tests.cs
@@ -255,7 +255,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one customer for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/DateTime_Tests.cs
+++ b/ShopifySharp.Tests/DateTime_Tests.cs
@@ -35,6 +35,7 @@ namespace ShopifySharp.Tests
             await Task.Delay(TimeSpan.FromSeconds(11));
 
             var graphService = new GraphService(Utils.MyShopifyUrl, Utils.AccessToken);
+            graphService.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
             var graphQlOrder = await graphService.PostAsync(
                                    @"
 {

--- a/ShopifySharp.Tests/DiscountCode_Tests.cs
+++ b/ShopifySharp.Tests/DiscountCode_Tests.cs
@@ -74,7 +74,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             DiscountCodeService.SetExecutionPolicy(policy);
             PriceRuleService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/DraftOrder_Tests.cs
+++ b/ShopifySharp.Tests/DraftOrder_Tests.cs
@@ -165,7 +165,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one for count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/Event_Tests.cs
+++ b/ShopifySharp.Tests/Event_Tests.cs
@@ -37,7 +37,7 @@ namespace ShopifySharp.Tests
         {
             // Get an order id
             var orderService = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
-            orderService.SetExecutionPolicy(new SmartRetryExecutionPolicy(false));
+            orderService.SetExecutionPolicy(new LeakyBucketExecutionPolicy(false));
             
             long orderId = (await orderService.ListAsync(new OrderListFilter()
             {
@@ -75,7 +75,7 @@ namespace ShopifySharp.Tests
 
         public Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy(false));
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy(false));
 
             return Task.CompletedTask;
         }

--- a/ShopifySharp.Tests/FulfillmentEvents_Tests .cs
+++ b/ShopifySharp.Tests/FulfillmentEvents_Tests .cs
@@ -59,7 +59,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy(false);
+            var policy = new LeakyBucketExecutionPolicy(false);
 
             // Fulfillment API has a stricter rate limit when on a non-paid store.
             FulfillmentService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
@@ -46,7 +46,7 @@ namespace ShopifySharp.Tests
         public async Task InitializeAsync()
         {
             // Fulfillment API has a stricter rate limit when on a non-paid store.
-            var policy = new SmartRetryExecutionPolicy(false);
+            var policy = new LeakyBucketExecutionPolicy(false);
 
             FulfillmentService.SetExecutionPolicy(policy);
             OrderService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/FulfillmentService_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentService_Tests.cs
@@ -85,7 +85,7 @@ namespace ShopifySharp.Tests
         public async Task InitializeAsync()
         {
             // Fulfillment API has a stricter rate limit when on a non-paid store.
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create a fulfillment service for count, list, get, etc. tests.
             var fulfillmentServiceEntity = await Create();

--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -256,7 +256,7 @@ namespace ShopifySharp.Tests
         public async Task InitializeAsync()
         {
             // Fulfillment API has a stricter rate limit when on a non-paid store.
-            var policy = new SmartRetryExecutionPolicy(false);
+            var policy = new LeakyBucketExecutionPolicy(false);
 
             Service.SetExecutionPolicy(policy);
             OrderService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/GiftCardAdjustment_Tests.cs
+++ b/ShopifySharp.Tests/GiftCardAdjustment_Tests.cs
@@ -57,7 +57,7 @@ namespace ShopifySharp.Tests
         public async Task InitializeAsync()
         {
             
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             GiftCardService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/GiftCard_Tests.cs
+++ b/ShopifySharp.Tests/GiftCard_Tests.cs
@@ -150,7 +150,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create an giftCard.
             var giftCard = await Create(GiftCard_Tests.GiftCardValue);

--- a/ShopifySharp.Tests/InventoryItem_Tests.cs
+++ b/ShopifySharp.Tests/InventoryItem_Tests.cs
@@ -66,7 +66,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             VariantService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/InventoryLevel_Tests.cs
+++ b/ShopifySharp.Tests/InventoryLevel_Tests.cs
@@ -118,7 +118,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Get a product id to use with these tests.
             var prod = await ProductTest.Create();

--- a/ShopifySharp.Tests/LeakyBucket_Tests.cs
+++ b/ShopifySharp.Tests/LeakyBucket_Tests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ShopifySharp.Tests
+{
+    [Trait("Category", "LeakyBucket")]
+    public class LeakyBucket_Tests
+    {
+        private DateTime now;
+
+        [Fact]
+        public void RunSynchronouslyIfEnoughAvailable()
+        {
+            now = DateTime.UtcNow;
+
+            var b = new LeakyBucket(40, 2, () => now);
+            Assert.Equal(40, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(1).IsCompleted);
+            Assert.Equal(39, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(1).IsCompleted);
+            Assert.Equal(38, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(1).IsCompleted);
+            Assert.Equal(37, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(1);
+            Assert.Equal(39, b.ComputedCurrentlyAvailable);
+        }
+
+        [Fact]
+        public void WaitIfNotEnoughAvailable()
+        {
+            now = DateTime.UtcNow;
+
+            var b = new LeakyBucket(10, 2, () => now);
+            Assert.Equal(10, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(9).IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+
+            Assert.False(b.WaitForAvailableAsync(4).IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+
+            Assert.False(b.WaitForAvailableAsync(5).IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+        }
+
+        [Fact]
+        public void ReplenishUpToMaximum()
+        {
+            now = DateTime.UtcNow;
+
+            var b = new LeakyBucket(10, 2, () => now);
+            Assert.Equal(10, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(5).IsCompleted);
+            Assert.Equal(5, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(1);
+            Assert.Equal(7, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(1);
+            Assert.Equal(9, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(1);
+            Assert.Equal(10, b.ComputedCurrentlyAvailable);
+
+            b.SetState(20, 3, b.ComputedCurrentlyAvailable);
+            now = now.AddSeconds(1);
+            Assert.Equal(13, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(2);
+            Assert.Equal(19, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(1);
+            Assert.Equal(20, b.ComputedCurrentlyAvailable);
+        }
+
+        [Fact]
+        public async Task BlockedSingleCallsCompleteAfterEnoughTime()
+        {
+            now = DateTime.UtcNow;
+
+            var b = new LeakyBucket(10, 2, () => now);
+            Assert.Equal(10, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(5).IsCompleted);
+            Assert.Equal(5, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(4).IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+
+            Task task = b.WaitForAvailableAsync(3);
+            Assert.False(task.IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+
+            await PassSeconds(2);
+            Assert.True(task.IsCompleted);
+            Assert.Equal(2, b.ComputedCurrentlyAvailable);
+        }
+
+        [Fact]
+        public async Task BlockedMultipleCallsCompleteAfterEnoughTime()
+        {
+            now = DateTime.UtcNow;
+
+            var b = new LeakyBucket(10, 2, () => now);
+            Assert.Equal(10, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(9).IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+
+            var task1 = b.WaitForAvailableAsync(3);
+            Assert.False(task1.IsCompleted);
+
+            var task2 = b.WaitForAvailableAsync(3);
+            Assert.False(task2.IsCompleted);
+
+            var task3 = b.WaitForAvailableAsync(3);
+            Assert.False(task3.IsCompleted);
+
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+            
+            await PassSeconds(1);
+            Assert.True(task1.IsCompleted);
+            Assert.False(task2.IsCompleted);
+            Assert.False(task3.IsCompleted);
+            Assert.Equal(0, b.ComputedCurrentlyAvailable);
+
+            await PassSeconds(2);
+            Assert.True(task2.IsCompleted);
+            Assert.False(task3.IsCompleted);
+            Assert.Equal(1, b.ComputedCurrentlyAvailable);
+
+            await PassSeconds(1);
+            Assert.True(task3.IsCompleted);
+            Assert.Equal(0, b.ComputedCurrentlyAvailable);
+
+            now = now.AddSeconds(5);
+            Assert.Equal(10, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(4).IsCompleted);
+            Assert.Equal(6, b.ComputedCurrentlyAvailable);
+
+            Assert.True(b.WaitForAvailableAsync(4).IsCompleted);
+            Assert.Equal(2, b.ComputedCurrentlyAvailable);
+
+            var task4 = b.WaitForAvailableAsync(4);
+            Assert.False(task4.IsCompleted);
+            Assert.Equal(2, b.ComputedCurrentlyAvailable);
+
+            await PassSeconds(1);
+            Assert.True(task4.IsCompleted);
+            Assert.Equal(0, b.ComputedCurrentlyAvailable);
+        }
+
+        private async Task PassSeconds(int seconds)
+        {
+            now = now.AddSeconds(seconds);
+            await Task.Delay(TimeSpan.FromSeconds(seconds * 1.2));
+        }
+    }
+}

--- a/ShopifySharp.Tests/Location_Tests.cs
+++ b/ShopifySharp.Tests/Location_Tests.cs
@@ -11,7 +11,7 @@ namespace ShopifySharp.Tests
 
         public Location_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact]

--- a/ShopifySharp.Tests/MetaField_Tests.cs
+++ b/ShopifySharp.Tests/MetaField_Tests.cs
@@ -216,7 +216,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             ProductService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/OrderRisk_Tests.cs
+++ b/ShopifySharp.Tests/OrderRisk_Tests.cs
@@ -120,7 +120,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy(false);
+            var policy = new LeakyBucketExecutionPolicy(false);
 
             Service.SetExecutionPolicy(policy);
             OrderService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/Order_Tests.cs
+++ b/ShopifySharp.Tests/Order_Tests.cs
@@ -214,7 +214,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy(false));
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy(false));
             
             // Create an order for count, list, get, etc. orders.
             await Create();

--- a/ShopifySharp.Tests/Page_Tests.cs
+++ b/ShopifySharp.Tests/Page_Tests.cs
@@ -104,7 +104,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one for count, list, get, etc. orders.
             await Create();

--- a/ShopifySharp.Tests/Policy_Tests.cs
+++ b/ShopifySharp.Tests/Policy_Tests.cs
@@ -12,7 +12,7 @@ namespace ShopifySharp.Tests
 
         public Policy_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact]

--- a/ShopifySharp.Tests/PriceRule_Tests.cs
+++ b/ShopifySharp.Tests/PriceRule_Tests.cs
@@ -120,7 +120,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one for count, list, get, etc. orders.
             await Create(Guid.NewGuid().ToString());

--- a/ShopifySharp.Tests/ProductImage_Tests.cs
+++ b/ShopifySharp.Tests/ProductImage_Tests.cs
@@ -107,7 +107,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             ProductService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/ProductVariant_Tests.cs
+++ b/ShopifySharp.Tests/ProductVariant_Tests.cs
@@ -113,7 +113,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
 
             Service.SetExecutionPolicy(policy);
             ProductService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/Product_Tests.cs
+++ b/ShopifySharp.Tests/Product_Tests.cs
@@ -226,7 +226,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one for count, list, get, etc. orders.
             await Create();

--- a/ShopifySharp.Tests/RecurringCharge_Tests.cs
+++ b/ShopifySharp.Tests/RecurringCharge_Tests.cs
@@ -9,7 +9,7 @@ namespace ShopifySharp.Tests
 
         public RecurringCharge_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact(Skip = "Recurring charges cannot be tested with a private application.")]

--- a/ShopifySharp.Tests/Redirect_Tests.cs
+++ b/ShopifySharp.Tests/Redirect_Tests.cs
@@ -106,7 +106,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one collection for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/Refund_Tests.cs
+++ b/ShopifySharp.Tests/Refund_Tests.cs
@@ -143,7 +143,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy(false);
+            var policy = new LeakyBucketExecutionPolicy(false);
             
             OrderService.SetExecutionPolicy(policy);
             Service.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/RetryExecutionPolicies_Tests.cs
+++ b/ShopifySharp.Tests/RetryExecutionPolicies_Tests.cs
@@ -11,6 +11,7 @@ namespace ShopifySharp.Tests
     public class RetryExecutionPolicies_Tests
     {
         private OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
+        private GraphService GraphService { get; } = new GraphService(Utils.MyShopifyUrl, Utils.AccessToken);
 
         private Order Order = new Order()
         {
@@ -28,9 +29,9 @@ namespace ShopifySharp.Tests
         };
 
         [Fact]
-        public async Task NonLeakyBucketBreachShouldNotAttemptRetry()
+        public async Task NonFullLeakyBucketBreachShouldNotAttemptRetry()
         {
-            OrderService.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            OrderService.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
             bool caught = false;
             try
             {
@@ -49,9 +50,9 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
-        public async Task NonLeakyBucketBreachShouldRetryWhenConstructorBoolIsFalse()
+        public async Task NonFullLeakyBucketBreachShouldRetryWhenConstructorBoolIsFalse()
         {
-            OrderService.SetExecutionPolicy(new SmartRetryExecutionPolicy(false));
+            OrderService.SetExecutionPolicy(new LeakyBucketExecutionPolicy(false));
             
             bool caught = false;
             
@@ -72,9 +73,9 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
-        public async Task LeakyBucketBreachShouldAttemptRetry()
+        public async Task LeakyBucketRESTBreachShouldAttemptRetry()
         {
-            OrderService.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            OrderService.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
             
             bool caught = false;
             
@@ -88,6 +89,46 @@ namespace ShopifySharp.Tests
                 caught = true;
             }
             
+            Assert.False(caught);
+        }
+
+        [Fact]
+        public async Task LeakyBucketGraphQLBreachShouldAttemptRetry()
+        {
+            GraphService.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
+
+            bool caught = false;
+
+            try
+            {
+                int queryCost = 862;
+                string query = @"{
+  products(first: 20) {
+    edges {
+      node {
+        title
+        variants(first:40)
+        {
+          edges
+          {
+            node
+            {
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+}
+";
+                await Task.WhenAll(Enumerable.Range(0, 10).Select(async _ => await GraphService.PostAsync(query, queryCost)));
+            }
+            catch (ShopifyRateLimitException)
+            {
+                caught = true;
+            }
+
             Assert.False(caught);
         }
     }

--- a/ShopifySharp.Tests/ScriptTag_Tests.cs
+++ b/ShopifySharp.Tests/ScriptTag_Tests.cs
@@ -110,7 +110,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one collection for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/ShippingZone_Tests.cs
+++ b/ShopifySharp.Tests/ShippingZone_Tests.cs
@@ -14,7 +14,7 @@ namespace ShopifySharp.Tests
 
         public ShippingZone_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact]

--- a/ShopifySharp.Tests/Shop_Tests.cs
+++ b/ShopifySharp.Tests/Shop_Tests.cs
@@ -12,7 +12,7 @@ namespace ShopifySharp.Tests
 
         public Shop_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact]

--- a/ShopifySharp.Tests/ShopifyException_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyException_Tests.cs
@@ -263,7 +263,7 @@ namespace ShopifySharp.Tests
             int requestCount = 60;
             IEnumerable<ListResult<Order>> list = null;
             var service = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
-            service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             try
             {

--- a/ShopifySharp.Tests/ShopifyPayments_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyPayments_Tests.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp.Tests
 
         public ShopifyPayments_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact]

--- a/ShopifySharp.Tests/SmartCollection_Tests.cs
+++ b/ShopifySharp.Tests/SmartCollection_Tests.cs
@@ -210,7 +210,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one collection for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/StorefrontAccessToken_Tests.cs
+++ b/ShopifySharp.Tests/StorefrontAccessToken_Tests.cs
@@ -58,7 +58,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy();
+            var policy = new LeakyBucketExecutionPolicy();
             Service.SetExecutionPolicy(policy);
         }
 

--- a/ShopifySharp.Tests/Theme_Tests.cs
+++ b/ShopifySharp.Tests/Theme_Tests.cs
@@ -115,7 +115,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one collection for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp.Tests/Transaction_Tests.cs
+++ b/ShopifySharp.Tests/Transaction_Tests.cs
@@ -121,7 +121,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            var policy = new SmartRetryExecutionPolicy(false);
+            var policy = new LeakyBucketExecutionPolicy(false);
 
             Service.SetExecutionPolicy(policy);
             OrderService.SetExecutionPolicy(policy);

--- a/ShopifySharp.Tests/UsageCharge_Tests.cs
+++ b/ShopifySharp.Tests/UsageCharge_Tests.cs
@@ -9,7 +9,7 @@ namespace ShopifySharp.Tests
 
         UsageCharge_Tests()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
         }
 
         [Fact(Skip = "Usage charges cannot be tested with a private application.")]

--- a/ShopifySharp.Tests/User_Tests.cs
+++ b/ShopifySharp.Tests/User_Tests.cs
@@ -64,7 +64,7 @@ namespace ShopifySharp.Tests
 
         public Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             return Task.CompletedTask;
         }

--- a/ShopifySharp.Tests/Webhook_Tests.cs
+++ b/ShopifySharp.Tests/Webhook_Tests.cs
@@ -106,7 +106,7 @@ namespace ShopifySharp.Tests
 
         public async Task InitializeAsync()
         {
-            Service.SetExecutionPolicy(new SmartRetryExecutionPolicy());
+            Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
 
             // Create one collection for use with count, list, get, etc. tests.
             await Create();

--- a/ShopifySharp/Infrastructure/AssemblyInfo.cs
+++ b/ShopifySharp/Infrastructure/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ShopifySharp.Tests")]

--- a/ShopifySharp/Infrastructure/Policies/DefaultRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/DefaultRequestExecutionPolicy.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp
 {
     public class DefaultRequestExecutionPolicy : IRequestExecutionPolicy
     {
-        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage request, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken)
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage request, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
         {
             var fullResult = await executeRequestAsync(request);
 

--- a/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
@@ -16,6 +16,7 @@ namespace ShopifySharp
         /// <param name="baseRequest">The base request that was built by a service to execute.</param>
         /// <param name="executeRequestAsync">A delegate that executes the request you pass to it.</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        Task<RequestResult<T>> Run<T>(CloneableRequestMessage requestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken);
+        /// <param name="graphqlQueryCost">Optional expected QraphQL query cost (as seen in GraphQL response at extensions.cost.requestedQueryCost</param>
+        Task<RequestResult<T>> Run<T>(CloneableRequestMessage requestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null);
     }
 }

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucket.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucket.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    internal class LeakyBucket
+    {
+        private class Request
+        {
+            public int cost;
+            public SemaphoreSlim semaphore = new SemaphoreSlim(0, 1);
+            public CancellationToken cancelToken;
+
+            public Request(int cost, CancellationToken cancelToken)
+            {
+                this.cost = cost;
+                this.cancelToken = cancelToken;
+            }
+        }
+
+        internal int MaximumAvailable { get; private set; }
+
+        internal int RestoreRatePerSecond { get; private set; }
+
+        internal int LastCurrentlyAvailable { get; private set; }
+
+        internal DateTime LastUpdatedAt { get; private set; }
+
+        internal int ComputedCurrentlyAvailable => Math.Min(MaximumAvailable,
+                                                          LastCurrentlyAvailable + ((int)(_getTime() - LastUpdatedAt).TotalSeconds * RestoreRatePerSecond));
+
+        private Func<DateTime> _getTime;
+
+        private Queue<Request> _pendingRequests = new Queue<Request>();
+
+        private object _lock = new object();
+
+        private CancellationTokenSource _cancelNextSchedule;
+
+        public LeakyBucket(int maximumAvailable, int restoreRatePerSecond)
+            : this(maximumAvailable, restoreRatePerSecond, () => DateTime.UtcNow)
+        {
+        }
+
+        internal LeakyBucket(int maximumAvailable, int restoreRatePerSecond, Func<DateTime> getTime)
+        {
+            _getTime = getTime;
+            SetState(maximumAvailable, restoreRatePerSecond, maximumAvailable);
+        }
+
+        public void SetState(int maximumAvailable, int restoreRatePerSecond, int currentlyAvailable)
+        {
+            if (maximumAvailable <= 0 || currentlyAvailable < 0 || restoreRatePerSecond <= 0 || currentlyAvailable > maximumAvailable)
+                throw new ArgumentOutOfRangeException();
+
+            lock (_lock)
+            {
+                this.MaximumAvailable = maximumAvailable;
+                this.RestoreRatePerSecond = restoreRatePerSecond;
+                this.LastCurrentlyAvailable = currentlyAvailable;
+                this.LastUpdatedAt = _getTime();
+            }
+            this.TryGrantNextPendingRequest();
+        }
+
+        private void ConsumeAvailable(Request r)
+        {
+            lock (_lock)
+            {
+                this.LastCurrentlyAvailable = this.ComputedCurrentlyAvailable - r.cost;
+                this.LastUpdatedAt = _getTime();
+            }
+        }
+
+        public async Task WaitForAvailableAsync(int requestCost, CancellationToken cancellationToken = default)
+        {
+            if (requestCost > MaximumAvailable)
+                throw new ShopifyException($"Requested query cost of {requestCost} is larger than maximum available {MaximumAvailable}");
+
+            var r = new Request(requestCost, cancellationToken);
+
+            lock (_lock)
+            {
+                if (ComputedCurrentlyAvailable > requestCost && _pendingRequests.Count == 0)
+                {
+                    ConsumeAvailable(r);
+                    return;
+                }
+
+                _pendingRequests.Enqueue(r);
+
+                if (_pendingRequests.Count == 1)
+                    ScheduleTryGrantNextPendingRequest(r);
+            }
+            await r.semaphore.WaitAsync(cancellationToken);
+        }
+
+        private void ScheduleTryGrantNextPendingRequest(Request r)
+        {
+            _cancelNextSchedule?.Cancel();
+            _cancelNextSchedule = new CancellationTokenSource();
+            var waitFor = TimeSpan.FromSeconds(Math.Max(0, (r.cost - ComputedCurrentlyAvailable) / (float)RestoreRatePerSecond));
+            _ = Task.Delay(waitFor, _cancelNextSchedule.Token)
+                                  .ContinueWith(_ => TryGrantNextPendingRequest(), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        private void TryGrantNextPendingRequest()
+        {
+            lock (_lock)
+            {
+                while (_pendingRequests.Count > 0 &&
+                       (_pendingRequests.Peek().cancelToken.IsCancellationRequested || ComputedCurrentlyAvailable >= _pendingRequests.Peek().cost))
+                {
+                    var r = _pendingRequests.Dequeue();
+                    if (!r.cancelToken.IsCancellationRequested)
+                    {
+                        r.semaphore.Release();
+                        this.ConsumeAvailable(r);
+                    }
+                }
+
+                if (_pendingRequests.Count > 0)
+                    ScheduleTryGrantNextPendingRequest(_pendingRequests.Peek());
+            }
+        }
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
+using ShopifySharp.Infrastructure;
+using Newtonsoft.Json.Linq;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An execution policy that implements Shopify API rate limits via a leaky bucket algorithm
+    /// See https://shopify.dev/api/usage/rate-limits
+    /// Requests are granted execution in FIFO order.
+    /// The next pending request is granted execution as soon as the bucket has enough budget available
+    /// </summary>
+    public class LeakyBucketExecutionPolicy : IRequestExecutionPolicy
+    {
+        private const string REQUEST_HEADER_ACCESS_TOKEN = "X-Shopify-Access-Token";
+        public const string RESPONSE_HEADER_API_CALL_LIMIT = "X-Shopify-Shop-Api-Call-Limit";
+
+        private static ConcurrentDictionary<string, MultiShopifyAPIBucket> _shopAccessTokenToLeakyBucket = new ConcurrentDictionary<string, MultiShopifyAPIBucket>();
+
+        private readonly bool _retryRESTOnlyIfLeakyBucketFull;
+
+        public LeakyBucketExecutionPolicy(bool retryRESTOnlyIfLeakyBucketFull = true)
+        {
+            _retryRESTOnlyIfLeakyBucketFull = retryRESTOnlyIfLeakyBucketFull;
+        }
+
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
+        {
+            var accessToken = GetAccessToken(baseRequest);
+            var bucket = accessToken == null ? null : _shopAccessTokenToLeakyBucket.GetOrAdd(accessToken, _ => new MultiShopifyAPIBucket());
+            bool isGraphQL = baseRequest.RequestUri.AbsolutePath.EndsWith("graphql.json");
+
+            while (true)
+            {
+                var request = baseRequest.Clone();
+
+                if (isGraphQL)
+                {
+                    if (accessToken != null)
+                        await bucket.WaitForAvailableGraphQLAsync(graphqlQueryCost, cancellationToken);
+
+                    var res = await executeRequestAsync(request);
+                    var json = res.Result as JToken;
+
+                    if (bucket != null)
+                    {
+                        var cost = json.SelectToken("extensions.cost.throttleStatus");
+                        bucket.SetGraphQLBucketState((int)cost["maximumAvailable"], (int)cost["restoreRate"], (int)cost["currentlyAvailable"]);
+                    }
+
+                    if (json.SelectToken("errors")
+                            ?.Children()
+                            .Any(r => r.SelectToken("extensions.code")?.Value<string>() == "THROTTLED") 
+                            == true)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+                        continue;
+                    }
+
+                    return res;
+                }
+                else //REST
+                {
+                    try
+                    {
+                        if (accessToken != null)
+                            await bucket.WaitForAvailableRESTAsync(cancellationToken);
+
+                        var res = await executeRequestAsync(request);
+
+                        if (bucket != null)
+                        {
+                            var apiCallLimitHeaderValue = GetRestCallLimit(res.Response);
+                            if (apiCallLimitHeaderValue != null)
+                            {
+                                var split = apiCallLimitHeaderValue.Split('/');
+                                if (split.Length == 2 && int.TryParse(split[0], out int currentlyAvailable) &&
+                                                         int.TryParse(split[1], out int maxAvailable))
+                                {
+                                    bucket.SetRESTBucketState(maxAvailable, currentlyAvailable);
+                                }
+                            }
+                        }
+
+                        return res;
+                    }
+                    catch (ShopifyRateLimitException ex) when (ex.Reason == ShopifyRateLimitReason.BucketFull || !_retryRESTOnlyIfLeakyBucketFull)
+                    {
+                        //Only retry if breach caused by full bucket
+                        //Shopify sometimes return 429 for other limits (e.g if too many variants are created)
+                        await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+                    }
+                }
+            }
+        }
+
+        private string GetRestCallLimit(HttpResponseMessage response)
+        {
+            return response.Headers.FirstOrDefault(kvp => kvp.Key == RESPONSE_HEADER_API_CALL_LIMIT)
+                                       .Value
+                                       ?.FirstOrDefault();
+        }
+
+        private string GetAccessToken(HttpRequestMessage client)
+        {
+            return client.Headers.TryGetValues(REQUEST_HEADER_ACCESS_TOKEN, out var values) ?
+                values.FirstOrDefault() :
+                null;
+        }
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/MultiAPIBucket.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/MultiAPIBucket.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+    internal class MultiShopifyAPIBucket
+    {
+        private const int DEFAULT_REST_MAX_AVAILABLE = 40;
+        private const int DEFAULT_REST_RESTORE_RATE = 2;
+
+        private const int DEFAULT_GRAPHQL_MAX_AVAILABLE = 1_000;
+        private const int DEFAULT_GRAPHQL_RESTORE_RATE = 50;
+
+        private LeakyBucket RESTBucket { get; } = new LeakyBucket(DEFAULT_REST_MAX_AVAILABLE, DEFAULT_REST_RESTORE_RATE);
+
+        private LeakyBucket GraphQLBucket { get; } = new LeakyBucket(DEFAULT_GRAPHQL_MAX_AVAILABLE, DEFAULT_GRAPHQL_RESTORE_RATE);
+
+        public async Task WaitForAvailableRESTAsync(CancellationToken cancellationToken)
+        {
+            //REST calls all count for the same cost of 1
+            await RESTBucket.WaitForAvailableAsync(1, cancellationToken);
+        }
+
+        public async Task WaitForAvailableGraphQLAsync(int? queryCost, CancellationToken cancellationToken)
+        {
+            //if the user didn't pass a request query cost, we assume a cost of 1
+            await GraphQLBucket.WaitForAvailableAsync(queryCost ?? 1, cancellationToken);
+        }
+
+        public void SetRESTBucketState(int maximumAvailable, int currentlyAvailable)
+        {
+            //Shopify Plus customers have a bucket that is twice the size (80) so we resize the bucket capacity accordingly
+            //It is apparently possible to request the bucket size to be even larger
+            //https://ecommerce.shopify.com/c/shopify-apis-and-technology/t/what-is-the-default-api-call-limit-on-shopify-stores-407292
+            //Note that when the capacity doubles, the leak rate also doubles. So, not only can request bursts be larger, it is also possible to sustain a faster rate over the long term.
+            int restoreRatePerSecond = maximumAvailable / DEFAULT_REST_MAX_AVAILABLE * DEFAULT_REST_RESTORE_RATE;
+            RESTBucket.SetState(maximumAvailable, restoreRatePerSecond, currentlyAvailable);
+        }
+
+        public void SetGraphQLBucketState(int maximumAvailable, int restoreRatePerSecond, int currentlyAvailable)
+        {
+            GraphQLBucket.SetState(maximumAvailable, restoreRatePerSecond, currentlyAvailable);
+        }
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
             _retryOnlyIfLeakyBucketFull = retryOnlyIfLeakyBucketFull;
         }
 
-        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken)
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
         {
             while (true)
             {

--- a/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
             _retryOnlyIfLeakyBucketFull = retryOnlyIfLeakyBucketFull;
         }
 
-        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken)
+        public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
         {
             var accessToken = GetAccessToken(baseRequest);
             LeakyBucket bucket = null;

--- a/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
@@ -23,6 +23,7 @@ namespace ShopifySharp
     /// See https://help.shopify.com/api/guides/api-call-limit
     /// https://en.wikipedia.org/wiki/Leaky_bucket
     /// </remarks>
+    [Obsolete("LeakyBucketExecutionPolicy is recommended as it handles properly both REST and GraphQL calls")]
     public partial class SmartRetryExecutionPolicy : IRequestExecutionPolicy
     {
         private const string REQUEST_HEADER_ACCESS_TOKEN = "X-Shopify-Access-Token";

--- a/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/SmartRetryExecutionPolicy.cs
@@ -23,7 +23,6 @@ namespace ShopifySharp
     /// See https://help.shopify.com/api/guides/api-call-limit
     /// https://en.wikipedia.org/wiki/Leaky_bucket
     /// </remarks>
-    [Obsolete("LeakyBucketExecutionPolicy is recommended as it handles properly both REST and GraphQL calls")]
     public partial class SmartRetryExecutionPolicy : IRequestExecutionPolicy
     {
         private const string REQUEST_HEADER_ACCESS_TOKEN = "X-Shopify-Access-Token";

--- a/ShopifySharp/Infrastructure/ShopifyRateLimitException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyRateLimitException.cs
@@ -10,23 +10,19 @@ namespace ShopifySharp
     /// </summary>
     public class ShopifyRateLimitException : ShopifyException
     {
-        public LeakyBucketState LeakyBucket { get; }
-
         public int? RetryAfterSeconds { get; private set; }
 
         //When a 429 is returned because the bucket is full, Shopify doesn't include the X-Shopify-Shop-Api-Call-Limit header in the response
-        public ShopifyRateLimitReason Reason => LeakyBucket == null || LeakyBucket.IsFull ? ShopifyRateLimitReason.BucketFull : ShopifyRateLimitReason.Other;
+        public ShopifyRateLimitReason Reason => HttpResponse.Headers.Contains(LeakyBucketExecutionPolicy.RESPONSE_HEADER_API_CALL_LIMIT) ? ShopifyRateLimitReason.Other : ShopifyRateLimitReason.BucketFull;
 
         public ShopifyRateLimitException(HttpResponseMessage response, 
                                          HttpStatusCode httpStatusCode,
                                          IEnumerable<string> errors,
                                          string message,
                                          string jsonError,
-                                         string requestId,
-                                         LeakyBucketState leakyBucket) 
+                                         string requestId) 
             : base(response, httpStatusCode, errors, message, jsonError, requestId)
         {
-            LeakyBucket = leakyBucket;
             ExtractRetryAfterSeconds(response);
         }
 

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -21,12 +21,16 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
-        public GraphService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }        
+        public GraphService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
         /// <summary>
         /// Executes a Graph API Call.
         /// </summary>
         /// <param name="body">The query you would like to execute. Please see documentation for formatting.</param>
+        /// <param name="graphqlQueryCost">
+        /// The requestedQueryCost available at extensions.cost.requestedQueryCost.
+        /// While it is optional, it is recommended to provide it to avoid wasting resources to issue API calls that will be throttled
+        /// </param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A JToken containing the data from the request.</returns>
         public virtual async Task<JToken> PostAsync(string body, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
@@ -42,6 +46,10 @@ namespace ShopifySharp
         /// Executes a Graph API Call.
         /// </summary>
         /// <param name="body">The query you would like to execute, as a JToken. Please see documentation for formatting.</param>
+        /// <param name="graphqlQueryCost">
+        /// The requestedQueryCost available at extensions.cost.requestedQueryCost.
+        /// While it is optional, it is recommended to provide it to avoid wasting resources to issue API calls that will be throttled
+        /// </param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A JToken containing the data from the request.</returns>
         public virtual async Task<JToken> PostAsync(JToken body, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -59,9 +59,9 @@ namespace ShopifySharp
         /// <param name="req">The RequestUri.</param>
         /// <param name="content">The HttpContent, be it GraphQL or Json.</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        private async Task<JToken> SendAsync(RequestUri req, HttpContent content, CancellationToken cancellationToken = default)
+        private async Task<JToken> SendAsync(RequestUri req, HttpContent content, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
         {
-            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content);
+            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content, graphqlQueryCost: graphqlQueryCost);
 
             CheckForErrors(response);
 

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -29,13 +29,13 @@ namespace ShopifySharp
         /// <param name="body">The query you would like to execute. Please see documentation for formatting.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        public virtual async Task<JToken> PostAsync(string body, CancellationToken cancellationToken = default)
+        public virtual async Task<JToken> PostAsync(string body, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("graphql.json");
 
             var content = new StringContent(body, Encoding.UTF8, "application/graphql");
 
-            return await SendAsync(req, content, cancellationToken);
+            return await SendAsync(req, content, graphqlQueryCost, cancellationToken);
         }
 
         /// <summary>
@@ -44,13 +44,13 @@ namespace ShopifySharp
         /// <param name="body">The query you would like to execute, as a JToken. Please see documentation for formatting.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        public virtual async Task<JToken> PostAsync(JToken body, CancellationToken cancellationToken = default)
+        public virtual async Task<JToken> PostAsync(JToken body, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest("graphql.json");
 
             var content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
 
-            return await SendAsync(req, content);
+            return await SendAsync(req, content, graphqlQueryCost, cancellationToken);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <param name="req">The RequestUri.</param>
         /// <param name="content">The HttpContent, be it GraphQL or Json.</param>
         /// <returns>A JToken containing the data from the request.</returns>
-        private async Task<JToken> SendAsync(RequestUri req, HttpContent content, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
+        private async Task<JToken> SendAsync(RequestUri req, HttpContent content, int? graphqlQueryCost, CancellationToken cancellationToken = default)
         {
             var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content, graphqlQueryCost: graphqlQueryCost);
 

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -322,7 +322,7 @@ namespace ShopifySharp
                     errors = new List<string>{ baseMessage };
                 }
 
-                throw new ShopifyRateLimitException(response, code, errors, rateExceptionMessage, rawResponse, requestId, LeakyBucketState.Get(response));
+                throw new ShopifyRateLimitException(response, code, errors, rateExceptionMessage, rawResponse, requestId);
             }
 
             var contentType = response.Content.Headers.GetValues("Content-Type").FirstOrDefault();

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -152,7 +152,7 @@ namespace ShopifySharp
         /// This method will automatically dispose the <paramref name="baseClient"/> and <paramref name="content" /> when finished.
         /// </remarks>
         protected async Task<RequestResult<JToken>> ExecuteRequestAsync(RequestUri uri, HttpMethod method,
-            CancellationToken cancellationToken, HttpContent content = null, Dictionary<string, string> headers = null)
+            CancellationToken cancellationToken, HttpContent content = null, Dictionary<string, string> headers = null, int? graphqlQueryCost = null)
         {
             using (var baseRequestMessage = PrepareRequestMessage(uri, method, content, headers))
             {
@@ -181,7 +181,7 @@ namespace ShopifySharp
 
                         return new RequestResult<JToken>(response, jtoken, rawResult, ReadLinkHeader(response));
                     }
-                }, cancellationToken);
+                }, cancellationToken, graphqlQueryCost);
 
                 return policyResult;
             }


### PR DESCRIPTION
Here is the new execution policy that handles both REST and GraphQL limits.

- It's called `LeakyBucketExecutionPolicy` and implements logic described at https://shopify.dev/api/usage/rate-limits
- I've marked the `SmartRetryExecutionPolicy` as obsolete because I expect this one to be used instead.
- Most of the files changed are the test files, which I've updated to use this new policy
- I provided several tests for the leaky bucket algorithm
- Given it's a new policy, there should be no breaking changes
- Except that the GraphService now takes an extra (optional) parameter to indicate the query cost. Given that this policy tracks the current bucket level, it can tell whether a query will be throttled by looking at the expected query cost.

This is just a new policy for rate limits.
In the future I'd like to improve the GraphService to support variables and typed responses, but I don't want to change too much at a time.

@nozzlegear let me know if you have any questions.