### PR TITLE
LeakyBucketExecutionPolicy support for requests context 

### DIFF
--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/ContextAwareQueue.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/ContextAwareQueue.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ShopifySharp
+{
+    internal class ContextAwareQueue<T>
+    {
+        private readonly Queue<T> _BackgroundQueue = new Queue<T>();
+
+        private readonly Queue<T> _ForegroundQueue = new Queue<T>();
+
+        private readonly Func<RequestContext> _getContext;
+
+        public int Count => _BackgroundQueue.Count + _ForegroundQueue.Count;
+
+        public ContextAwareQueue(Func<RequestContext> getContext)
+        {
+            _getContext = getContext;
+        }
+
+        public void Enqueue(T i)
+        {
+            (_getContext() == RequestContext.Background ? _BackgroundQueue : _ForegroundQueue).Enqueue(i);
+        }
+
+        public T Peek() => _ForegroundQueue.Count > 0 ? _ForegroundQueue.Peek() : _BackgroundQueue.Peek();
+
+        public T Dequeue() => _ForegroundQueue.Count > 0 ? _ForegroundQueue.Dequeue() : _BackgroundQueue.Dequeue();
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
@@ -23,16 +23,32 @@ namespace ShopifySharp
         private static ConcurrentDictionary<string, MultiShopifyAPIBucket> _shopAccessTokenToLeakyBucket = new ConcurrentDictionary<string, MultiShopifyAPIBucket>();
 
         private readonly bool _retryRESTOnlyIfLeakyBucketFull;
+        private readonly Func<RequestContext> _getRequestContext;
 
-        public LeakyBucketExecutionPolicy(bool retryRESTOnlyIfLeakyBucketFull = true)
+        /// <summary>
+        /// Creates a new LeakyBucketExecutionPolicy.
+        /// It is not recommended to create multiple instances for different access tokens because each instance maintain that leaky bucket state
+        /// and is not aware of other instances
+        /// </summary>
+        /// <param name="retryRESTOnlyIfLeakyBucketFull">Controls when the request should be retried when a Shopify returns an HTTP 429 to a REST request.
+        /// If true (default), then the policy only retries if the 429 is due to a empty bucket.
+        /// If false, then the policy also retries for other types of 429. For example, Shopify will return a 429 if one tries to create too many products too quickly on dev stores
+        /// </param>
+        /// <param name="getRequestContext">Indicates the current request context, either Foreground or Background.
+        /// Foreground requests will be priortized to execute before any background requests can run.
+        /// RequestContext.Foregroud can be used for requests where a user is waiting (e.g loading a web page to show results of query).
+        /// RequestContext.Background can be used for background requests triggered by job, where no user is waiting.
+        /// By default, all requests are served in FIFO order</param>
+        public LeakyBucketExecutionPolicy(bool retryRESTOnlyIfLeakyBucketFull = true, Func<RequestContext> getRequestContext = null)
         {
             _retryRESTOnlyIfLeakyBucketFull = retryRESTOnlyIfLeakyBucketFull;
+            _getRequestContext = getRequestContext ?? new Func<RequestContext>(() => RequestContext.Foreground);
         }
 
         public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequest, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
         {
             var accessToken = GetAccessToken(baseRequest);
-            var bucket = accessToken == null ? null : _shopAccessTokenToLeakyBucket.GetOrAdd(accessToken, _ => new MultiShopifyAPIBucket());
+            var bucket = accessToken == null ? null : _shopAccessTokenToLeakyBucket.GetOrAdd(accessToken, _ => new MultiShopifyAPIBucket(_getRequestContext));
             bool isGraphQL = baseRequest.RequestUri.AbsolutePath.EndsWith("graphql.json");
 
             while (true)

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/MultiAPIBucket.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/MultiAPIBucket.cs
@@ -12,9 +12,15 @@ namespace ShopifySharp
         private const int DEFAULT_GRAPHQL_MAX_AVAILABLE = 1_000;
         private const int DEFAULT_GRAPHQL_RESTORE_RATE = 50;
 
-        private LeakyBucket RESTBucket { get; } = new LeakyBucket(DEFAULT_REST_MAX_AVAILABLE, DEFAULT_REST_RESTORE_RATE);
+        private LeakyBucket RESTBucket { get; }
 
-        private LeakyBucket GraphQLBucket { get; } = new LeakyBucket(DEFAULT_GRAPHQL_MAX_AVAILABLE, DEFAULT_GRAPHQL_RESTORE_RATE);
+        private LeakyBucket GraphQLBucket { get; }
+
+        public MultiShopifyAPIBucket(Func<RequestContext> getRequestContext)
+        {
+            RESTBucket = new LeakyBucket(DEFAULT_REST_MAX_AVAILABLE, DEFAULT_REST_RESTORE_RATE, getRequestContext);
+            GraphQLBucket = new LeakyBucket(DEFAULT_GRAPHQL_MAX_AVAILABLE, DEFAULT_GRAPHQL_RESTORE_RATE, getRequestContext);
+        }
 
         public async Task WaitForAvailableRESTAsync(CancellationToken cancellationToken)
         {

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/RequestContext.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/RequestContext.cs
@@ -1,0 +1,8 @@
+﻿namespace ShopifySharp
+{
+    public enum RequestContext
+    {
+        Foreground,
+        Background
+    }
+}


### PR DESCRIPTION
This is a non breaking change. 
A new optional parameter `getRequestContext` can be supplied when constructing a `LeakyBucketExecutionPolicy`.

It serves to indicate whether the current context is `Foreground` or `Background`. The policy will prioritize foreground requests and run them first.

For example, if a user is waiting on the request (loading a page showing response results for example), you would want to prioritize this request over competing requests that might be running in the background (to run some jobs for example).
(In this scenario, you could for example inspect if there is an ambient HttpContext to determine whether the request is Foreground or Background)