### PR TITLE
Fix for serialization bug

### DIFF
--- a/ShopifySharp/Entities/Customer.cs
+++ b/ShopifySharp/Entities/Customer.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using ShopifySharp.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +20,7 @@ namespace ShopifySharp
         /// The date and time when the customer consented or objected to receiving marketing material by email. Set this value whenever the customer consents or objects to marketing materials.
         /// </summary>
         [JsonProperty("accepts_marketing_updated_at")]
+        [JsonConverter(typeof(InvalidDateToNullConverter))]
         public DateTimeOffset? AcceptsMarketingUpdatedAt { get; set; }
         
         /// <summary>


### PR DESCRIPTION
I started seeing errors in the logs as soon as I deployed the latest version.

```Newtonsoft.Json.JsonReaderException: Could not convert string to DateTimeOffset: 0000-12-31T18:09:24-05:50. Path 'accepts_marketing_updated_at'```

It turns out Shopify can populate an invalid date such as 0000-12-31T18:09:24-05:50, which cannot be parsed to a DateTimeOffset.

Luckily we already had a converter to handle this case so the fix was pretty simple.