### PR TITLE
Change to netstandard2.0

### DIFF
--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotenvfile" Version="2.1.0" />
@@ -12,6 +12,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="env.yml">

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>ShopifySharp</AssemblyName>
     <RootNamespace>ShopifySharp</RootNamespace>
     <VersionPrefix>5.15.0</VersionPrefix>
@@ -18,9 +18,8 @@
     <PackageTags>shopify,ecommerce</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="microsoft.extensions.primitives" Version="6.0.0" />
     <PackageReference Include="newtonsoft.json" Version="13.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Changed to `netstandard2.0` to support more frameworks.
- Downgraded `Microsoft.Extensions.Http` to lowest version. Higher frameworks can override this with a newer version.
- Cross target test project (I added netcoreapp2.1 since we haven't updated yet, but it could be removed)

Note:
dotnet frameworks require `System.Net.Http` from nuget. The `<ItemGroup>` conditional and net472 target could be moved to Main csproj instead.

Tests:
![image](https://user-images.githubusercontent.com/67749749/155133974-8ea4e80e-ac2a-44c8-b60e-17905ef369fe.png)
- `Authorization_Tests`: Hardcoded data
- `Collect_Tests`: http://placehold.it/250x250 not found
- `Collection_Tests`: http://placehold.it/250x250 not found
- `CustomerSavedSearchavedSearch_Tests`: `The following constructor parameters did not have matching fixture data: CustomerSavedSearchavedSearch_Tests_Fixture fixture`. Happened when I ran on master branch as well
- `Fulfillment_Tests`: Hardcoded location
- `FulfillmentEvents_Tests`: Hardcoded location
- `FulfillmentOrder_Tests`: Hardcoded location
- `RetryExecutionPolicies_Tests`: Our test store is shopify plus
- `ShopifyException_Tests` (Rate exceptions): Our test store is shopify plus