### PR TITLE
Adding missing authorization scopes as defined in https://shopify.dev…

### DIFF
--- a/ShopifySharp/Enums/AuthorizationScope.cs
+++ b/ShopifySharp/Enums/AuthorizationScope.cs
@@ -109,6 +109,12 @@ namespace ShopifySharp.Enums
         [EnumMember(Value = "read_merchant_managed_fulfillment_orders")]
         ReadMerchantManagedFulfillmentOrders,
 
+        [EnumMember(Value = "read_assigned_fulfillment_orders")]
+        ReadAssignedFulfillmentOrders,
+        
+        [EnumMember(Value = "write_assigned_fulfillment_orders")]
+        WriteAssignedFulfillmentOrders,
+
         [EnumMember(Value = "read_marketing_events")]
         ReadMarketingEvents,
 


### PR DESCRIPTION
Just a small change to add 2 scopes that were missing in the enum, and are defined at https://shopify.dev/api/usage/access-scopes