### PR TITLE
Added OrderEditWebhook entity

### DIFF
--- a/ShopifySharp/Entities/OrderEdit.cs
+++ b/ShopifySharp/Entities/OrderEdit.cs
@@ -1,0 +1,54 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify order edit.
+    /// </summary>
+    public class OrderEdit : ShopifyObject
+    {
+        /// <summary>
+        /// Unique identifier of the app who created the order edit.
+        /// </summary>
+        [JsonProperty("app_id")]
+        public long? AppId { get; set; }
+
+        /// <summary>
+        /// The date and time when the order was edited in Shopify.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        /// <summary>
+        /// A flag indicating whether the customer should be notified.
+        /// </summary>
+        [JsonProperty("notify_customer")]
+        public bool? NotifyCustomer { get; set; }
+
+        /// <summary>
+        /// The unique numeric identifier for the order associated to this edit
+        /// </summary>
+        [JsonProperty("order_id")]
+        public long? OrderId { get; set; }
+
+        /// <summary>
+        /// The text of an optional note that a shop owner can attach to the order.
+        /// </summary>
+        [JsonProperty("staff_note")]
+        public string StaffNote { get; set; }
+
+        /// <summary>
+        /// The unique numerical identifier of the user that made this edit
+        /// </summary>
+        [JsonProperty("user_id")]
+        public long? UserId { get; set; }
+
+        /// <summary>
+        /// Changes to line items
+        /// </summary>
+        [JsonProperty("line_items")]
+        public OrderEditLineItems LineItems { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/OrderEditLineItemDelta.cs
+++ b/ShopifySharp/Entities/OrderEditLineItemDelta.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify line item addition or removal.
+    /// The Id of this object is the Id of the line item being edited
+    /// </summary>
+    public class OrderEditLineItemDelta : ShopifyObject
+    {
+        /// <summary>
+        /// The quantiy added or removed
+        /// </summary>
+        [JsonProperty("delta")]
+        public int? Delta { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/OrderEditLineItems.cs
+++ b/ShopifySharp/Entities/OrderEditLineItems.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify line item edit.
+    /// The Id of this object is the Id of the line item being edited
+    /// </summary>
+    public class OrderEditLineItems
+    {
+        /// <summary>
+        /// The additions to the line item
+        /// </summary>
+        [JsonProperty("additions")]
+        public IEnumerable<OrderEditLineItemDelta> Additions { get; set; }
+
+        /// <summary>
+        /// The removals to the line item
+        /// </summary>
+        [JsonProperty("removals")]
+        public IEnumerable<OrderEditLineItemDelta> Removals { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/OrderEditWebhook.cs
+++ b/ShopifySharp/Entities/OrderEditWebhook.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify order edit webhook (orders/edited topic)
+    /// </summary>
+    public class OrderEditWebhook
+    {
+        /// <summary>
+        /// The OrderEdit object
+        /// </summary>
+        [JsonProperty("order_edit")]
+        public OrderEdit OrderEdit { get; set; }
+    }
+}


### PR DESCRIPTION
Added OrderEditWebhook entity.
Unlike other orders/* topics, the orders/edited webhook doesn't contain a normal order payload.
Instead it contains info about the edit and what was changed. This entity is useful to deserialize the payload into an object.