### PR TITLE
Added ability to override the API version used when instantiating a GraphService

### DIFF
--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -16,12 +16,19 @@ namespace ShopifySharp
     /// </summary>
     public class GraphService : ShopifyService
     {
+        private readonly string _apiVersion;
+
+        public override string APIVersion => _apiVersion ?? base.APIVersion;
+
         /// <summary>
         /// Creates a new instance of <see cref="GraphService" />.
         /// </summary>
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
-        public GraphService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
+        public GraphService(string myShopifyUrl, string shopAccessToken, string apiVersion = null) : base(myShopifyUrl, shopAccessToken) 
+        {
+            _apiVersion = apiVersion;
+        }
 
         /// <summary>
         /// Executes a Graph API Call.


### PR DESCRIPTION
ShopifySharp is pinned to an API version, which makes sense when using the REST API because the requets and responses objects are defined in the library itself.

However, for GraphService, it makes sense to be able to override the desired API version since the response is dictated by the shape of the request.
For example, right now I'd like to create a grapqhQL request with the latest stable version but I can't because ShopifySharp is pinned to an earlier version. (I know that I can override the GraphService and override the api version but I think that being able to override it in the constructor makes it a lot easier).