### PR TITLE
Added pre_tax_price and pre_tax_price_set properties

### DIFF
--- a/ShopifySharp/Entities/LineItem.cs
+++ b/ShopifySharp/Entities/LineItem.cs
@@ -187,6 +187,18 @@ namespace ShopifySharp
         public PriceSet PriceSet { get; set; }
 
         /// <summary>
+        /// The price per item, excluding taxes and excluding discounts.
+        /// </summary>
+        [JsonProperty("pre_tax_price")]
+        public decimal? PreTaxPrice { get; set; }
+
+        /// <summary>
+        /// The price per item, excluding taxes and excluding discounts in shop and presentment currencies.
+        /// </summary>
+        [JsonProperty("pre_tax_price_set")]
+        public PriceSet PreTaxPriceSet { get; set; }
+        
+        /// <summary>
         /// A list of duty objects, each containing information about a duty on the line item
         /// </summary>
         [JsonProperty("duties")]


### PR DESCRIPTION
Both the pre_tax_price and pre_tax_price_set properties are available on most Shopify Plus shops, but this is not (publicly) documented. By adding this it becomes possible to test and use the value without the need to calculate pre_tax_price values for products. Very useful in customs applications...