### PR TITLE
Fulfillment orders

### DIFF
--- a/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
@@ -46,8 +46,14 @@ namespace ShopifySharp.Tests
             var fulfillmentOrders = await Fixture.Service.ListAsync(order.Id.Value);
             Assert.NotEmpty(fulfillmentOrders);
             var fulfillmentOrder = fulfillmentOrders.First();
+            fulfillmentOrder = await Fixture.FulfillmentRequestService.CreateAsync(fulfillmentOrder.Id.Value, new FulfillmentRequest() 
+            {
+                Message = "Testing Fulfillment Order",
+            });
+            fulfillmentOrder = await Fixture.FulfillmentRequestService.AcceptAsync(fulfillmentOrder.Id.Value, "Testing");
             var result = await Fixture.Service.CloseAsync(fulfillmentOrder.Id.Value, "Testing Done");
             Assert.NotNull(result);
+            Assert.Equal("incomplete", result.Status);
         }
 
     }
@@ -65,7 +71,7 @@ namespace ShopifySharp.Tests
 
 
         public long? LocationId => FulfillmentServiceEntity?.LocationId;
-        public string FulfillmentServiceName { get; } = "ShopifySharpTesting";
+        public string FulfillmentServiceName { get; } = "ShopifySharpTesting4";
 
 
         /// <summary>
@@ -232,11 +238,12 @@ namespace ShopifySharp.Tests
                 fulfillmentServiceEntity = await FulfillmentServiceService.CreateAsync(new FulfillmentServiceEntity()
                 {
                     Name = FulfillmentServiceName,
-                    //CallbackUrl = "https://example.com/fulfillmentService",
-                    InventoryManagement = false,
-                    TrackingSupport = false,
+                    CallbackUrl = "https://test.test/fulfillmentService",
+                    InventoryManagement = true,
+                    TrackingSupport = true,
                     RequiresShippingMethod = false,
                     Format = "json",
+                    FulfillmentOrdersOptIn = true,
                 });
             }
 

--- a/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
@@ -38,6 +38,18 @@ namespace ShopifySharp.Tests
             Assert.Equal(fulfillmentOrder.Id.Value, result.Id.Value);
         }
 
+        [Fact]
+        public async Task Cancel_FulfillmentOrders()
+        {
+            var order = Fixture.CreatedOrders.First();
+            var fulfillmentOrders = await Fixture.Service.ListAsync(order.Id.Value);
+            Assert.NotEmpty(fulfillmentOrders);
+            var fulfillmentOrder = fulfillmentOrders.First();
+            //for canceling, RequestStatus must be unsubmitted
+            var result = await Fixture.Service.CancelAsync(fulfillmentOrder.Id.Value);
+            Assert.NotNull(result);
+            Assert.Equal("closed", result.Status);
+        }
 
         [Fact]
         public async Task Close_FulfillmentOrders()

--- a/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
@@ -170,7 +170,7 @@ namespace ShopifySharp.Tests
         public FulfillmentRequestService FulfillmentRequestService { get; } = new FulfillmentRequestService(Utils.MyShopifyUrl, Utils.AccessToken);
 
         public long? LocationId => FulfillmentServiceEntities[0]?.LocationId;
-        public long OtherLocationId => 62885986369;//6226758;
+        public long OtherLocationId => 6226758;
 
         public string FulfillmentServiceName { get; } = "ShopifySharpTesting4";
 

--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -276,7 +276,7 @@ namespace ShopifySharp.Tests
 
         public OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
 
-        public long LocationId => 6226758;
+        public long LocationId => 62885986369;
 
         /// <summary>
         /// Fulfillments must be part of an order and cannot be deleted.

--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -276,7 +276,7 @@ namespace ShopifySharp.Tests
 
         public OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
 
-        public long LocationId => 62885986369;
+        public long LocationId => 6226758;
 
         /// <summary>
         /// Fulfillments must be part of an order and cannot be deleted.

--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -207,6 +207,38 @@ namespace ShopifySharp.Tests
             Assert.Equal(company, updated.TrackingCompany);
         }
 
+        [Fact]
+        public async Task Updates_Tracking_Fulfillments()
+        {
+            string company = "Auntie Dot's Shipping Company";
+            string trackingNum = "123456789";
+            string trackingUrl = "https://example.com/123456789";
+            var order = await Fixture.CreateOrder();
+            var created = await Fixture.Create(order.Id.Value, false);
+            long id = created.Id.Value;
+
+            var update = new FulfillmentShipping()
+            {
+                NotifyCustomer = true,
+                TrackingInfo = new TrackingInfo()
+                {
+                    Company = company,
+                    Number = trackingNum,
+                    Url = trackingUrl,
+                }
+            };
+
+            var updated = await Fixture.Service.UpdateTrackingAsync(id, update);
+
+            Assert.Equal(company, updated.TrackingCompany);
+            Assert.Equal(trackingNum, updated.TrackingNumber);
+            Assert.Equal(trackingUrl, updated.TrackingUrl);
+            Assert.Single(updated.TrackingNumbers);
+            Assert.Single(updated.TrackingUrls);
+            Assert.Equal(trackingNum, updated.TrackingNumbers.First());
+            Assert.Equal(trackingUrl, updated.TrackingUrls.First());
+        }
+
         [Fact(Skip = "Can't complete/cancel/open a fulfillment whose status is not 'pending'. It's not clear how to create a fulfillment that's pending.")]
         public async Task Opens_Fulfillments()
         {

--- a/ShopifySharp/Entities/FulfillmentHold.cs
+++ b/ShopifySharp/Entities/FulfillmentHold.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ShopifySharp
+{
+    public class FulfillmentHold
+    {
+        /// <summary>
+        /// A mandatory reason for the fulfillment hold.
+        ///     awaiting_payment: The fulfillment hold is applied because payment is pending.
+        ///     high_risk_of_fraud: The fulfillment hold is applied because of a high risk of fraud.
+        ///     incorrect_address: The fulfillment hold is applied because of an incorrect address.
+        ///     inventory_out_of_stock: The fulfillment hold is applied because inventory is out of stock.
+        ///     other: The fulfillment hold is applied for any other reason.
+        /// </summary>
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        [JsonProperty("reason_notes")]
+        public string ReasonNotes { get; set; }
+    }
+}

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -68,6 +68,7 @@ namespace ShopifySharp
             return await ExecuteGetAsync<Fulfillment>($"orders/{orderId}/fulfillments/{fulfillmentId}.json", "fulfillment", fields, cancellationToken);
         }
 
+        [Obsolete]
         /// <summary>
         /// Creates a new <see cref="Fulfillment"/> on the order.
         /// <see href="https://shopify.dev/api/admin/rest/reference/shipping-and-fulfillment/fulfillment#createV2-2021-07">API Reference</see>
@@ -110,6 +111,7 @@ namespace ShopifySharp
             return response.Result;
         }
 
+        [Obsolete]
         /// <summary>
         /// Updates the given <see cref="Fulfillment"/>.
         /// </summary>
@@ -132,6 +134,27 @@ namespace ShopifySharp
         }
 
         /// <summary>
+        /// Updates tracking for the given <see cref="Fulfillment"/>.
+        /// </summary>
+        /// <param name="fulfillmentId">Id of the object being updated.</param>
+        /// <param name="fulfillment">The <see cref="Fulfillment"/> to update.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <returns>The updated <see cref="Fulfillment"/>.</returns>
+        public virtual async Task<Fulfillment> UpdateTrackingAsync(long fulfillmentId, FulfillmentShipping fulfillment, CancellationToken cancellationToken = default)
+        {
+            var req = PrepareRequest($"fulfillments/{fulfillmentId}/update_tracking.json");
+            var body = fulfillment.ToDictionary();
+            var content = new JsonContent(new
+            {
+                fulfillment = body
+            });
+
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, content, "fulfillment");
+            return response.Result;
+        }
+
+        [Obsolete]
+        /// <summary>
         /// Completes a pending fulfillment with the given id.
         /// </summary>
         /// <param name="orderId">The order id to which the fulfillments belong.</param>
@@ -145,6 +168,7 @@ namespace ShopifySharp
             return response.Result;
         }
 
+        [Obsolete]
         /// <summary>
         /// Cancels a pending fulfillment with the given id.
         /// </summary>
@@ -159,6 +183,7 @@ namespace ShopifySharp
             return response.Result;
         }
 
+        [Obsolete]
         /// <summary>
         /// Opens a pending fulfillment with the given id.
         /// </summary>

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -51,7 +51,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/close.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -71,7 +71,7 @@ namespace ShopifySharp
                 fulfillment_hold = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/close.json");
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -22,14 +22,144 @@ namespace ShopifySharp
         public FulfillmentOrderService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
         /// <summary>
+        /// Cancel a fulfillment order with the given id.
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order to which the fulfillment orders belong.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> CancelAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
+        {
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/cancel.json");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
+        /// Marks an in progress fulfillment order as incomplete, indicating the fulfillment service is unable to ship any remaining items and intends to close the fulfillment order.
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order id.</param>
+        /// <param name="message">Close reason.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> CloseAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
+        {
+            var body = new
+            {
+                message = message,
+            }.ToDictionary();
+            var content = new JsonContent(new
+            {
+                fulfillment_order = body,
+            });
+
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
+        /// Halts all fulfillment work on a fulfillment order with status OPEN and changes the status of the fulfillment order to ON_HOLD.
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order id.</param>
+        /// <param name="fulfillmentHold">The fulfillment hold.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> HoldAsync(long fulfillmentOrderId, FulfillmentHold fulfillmentHold, string message, CancellationToken cancellationToken = default)
+        {
+            var body = fulfillmentHold.ToDictionary();
+            var content = new JsonContent(new
+            {
+                fulfillment_hold = body,
+            });
+
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/close.json");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
+        /// Moves a fulfillment order from one merchant managed location to another merchant managed location.
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order id.</param>
+        /// <param name="newLocationId">The new fulfillment order location.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> MoveAsync(long fulfillmentOrderId, long newLocationId, CancellationToken cancellationToken = default)
+        {
+            var body = new
+            {
+                new_location_id = newLocationId,
+            }.ToDictionary();
+            var content = new JsonContent(new
+            {
+                fulfillment_order = body,
+            });
+
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/move.json");
+
+            //needs to be original_fulfillment_order
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
+        /// Marks a scheduled fulfillment order as ready for fulfillment.
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order to which the fulfillment orders belong.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> OpenAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
+        {
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/open.json");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
+        /// Release the fulfillment hold on a fulfillment order and changes the status of the fulfillment order to OPEN or SCHEDULED
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order to which the fulfillment orders belong.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> ReleaseHoldAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
+        {
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/release_hold.json");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
+        /// Updates the fulfill_at time of a scheduled fulfillment order. This endpoint is used to manage the time a scheduled fulfillment order will be marked as ready for fulfillment.
+        /// </summary>
+        /// <param name="fulfillmentOrderId">The fulfillment order id.</param>
+        /// <param name="newFulfillAt">The new fulfill date.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<FulfillmentOrder> RescheduleAsync(long fulfillmentOrderId, DateTimeOffset newFulfillAt, CancellationToken cancellationToken = default)
+        {
+            var body  = new
+            {
+                new_fulfill_at = newFulfillAt,
+            }.ToDictionary();
+            var content = new JsonContent(new
+            {
+                fulfillment_order = body,
+            });
+
+            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/reschedule.json");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
+
+            return response.Result;
+        }
+
+        /// <summary>
         /// Gets a fulfillment order with the given id.
         /// </summary>
         /// <param name="fulfillmentOrderId">The fulfillment order to which the fulfillment orders belong.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        public virtual async Task<IEnumerable<FulfillmentOrder>> GetAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
+        public virtual async Task<FulfillmentOrder> GetAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
             var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}.json");
-            var response = await ExecuteRequestAsync<IEnumerable<FulfillmentOrder>>(req, HttpMethod.Get, cancellationToken, rootElement: "fulfillment_order");
+            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Get, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
         }

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -63,7 +63,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentOrderId">The fulfillment order id.</param>
         /// <param name="fulfillmentHold">The fulfillment hold.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        public virtual async Task<FulfillmentOrder> HoldAsync(long fulfillmentOrderId, FulfillmentHold fulfillmentHold, string message, CancellationToken cancellationToken = default)
+        public virtual async Task<FulfillmentOrder> HoldAsync(long fulfillmentOrderId, FulfillmentHold fulfillmentHold, CancellationToken cancellationToken = default)
         {
             var body = fulfillmentHold.ToDictionary();
             var content = new JsonContent(new

--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ ShopifySharp currently supports the following Shopify APIs:
     -   Carrier Service (docs not yet written)
     -   [Fulfillments](#fulfillments)
     -   [Fulfillment Events](#fulfillment-events)
-    -   [Fulfillment Orders](#fulfillment-orders) (List/Get only. Create/Delete not implemented yet)
+    -   [Fulfillment Orders](#fulfillment-orders) (List/Get/Close only. Scheduling not implemented yet)
     -   [Fulfillment Requests](#fulfillment-requests)
     -   [Fulfillment Services](#fulfillment-services)
     -   Locations For Move (not implimented yet)
@@ -1451,7 +1451,7 @@ be fulfilled from the same location. There can be more than one fulfillment orde
 > - [X] Cancel a fulfillment order
 > - [X] Mark a fulfillment order as incomplete
 > - [ ] Move a fulfillment order to a new location
-> - [X] Mark the fulfillment order as open
+> - [ ] Mark the fulfillment order as open
 > - [ ] Reschedule the fulfill_at time of a scheduled fulfillment order
 > - [X] Retrieve a specific fulfillment order
 

--- a/readme.md
+++ b/readme.md
@@ -1448,12 +1448,12 @@ The FulfillmentOrder resource represents either an item or a group of items in a
 be fulfilled from the same location. There can be more than one fulfillment order for an order at a given location.
 
 > **TODO**
-> - [ ] Cancel a fulfillment order
-> - [ ] Mark a fulfillment order as incomplete
+> - [X] Cancel a fulfillment order
+> - [X] Mark a fulfillment order as incomplete
 > - [ ] Move a fulfillment order to a new location
-> - [ ] Mark the fulfillment order as open
+> - [X] Mark the fulfillment order as open
 > - [ ] Reschedule the fulfill_at time of a scheduled fulfillment order
-> - [ ] Retrieve a specific fulfillment order
+> - [X] Retrieve a specific fulfillment order
 
 ### List Fulfillment Orders
 


### PR DESCRIPTION
Referencing #600, Shopify is making Fulfillment Orders mandatory for the fulfillment process and deprecating Fulfillment endpoints in [2022-07](https://shopify.dev/api/release-notes/2022-07#rest-admin-api-changes).

This PR implements the endpoints still on 2022-04 and marked the appropriate fulfillment endpoints as Obsolete in preparation for the next API version.

Most now have tests, although I could not figure out how to test scheduled Fulfillment Orders due to it requiring subscription orders. Move cannot be tested on 2022-04 due to a missing value in the api `requires_sku_sharing` for `FulfillmentService`.
![image](https://user-images.githubusercontent.com/7527244/184979415-ad117274-3639-41d4-8606-247787cef5bc.png)

Thanks!