### PR TITLE
Add missing property Customer.EmailMarketingConsent; mark AcceptsMarketing, AcceptsMarketingUpdatedAt and MarketingOptInLevel as deprecated

### DIFF
--- a/ShopifySharp/Entities/Customer.cs
+++ b/ShopifySharp/Entities/Customer.cs
@@ -2,9 +2,6 @@ using Newtonsoft.Json;
 using ShopifySharp.Converters;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
@@ -14,6 +11,7 @@ namespace ShopifySharp
         /// Indicates whether the customer has consented to be sent marketing material via email.
         /// </summary>
         [JsonProperty("accepts_marketing")]
+        [Obsolete("As of API version 2022-04, this property is deprecated. Use email_marketing_consent instead.")]
         public bool? AcceptsMarketing { get; set; }
         
         /// <summary>
@@ -21,12 +19,14 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("accepts_marketing_updated_at")]
         [JsonConverter(typeof(InvalidDateToNullConverter))]
+        [Obsolete("As of API version 2022-04, this property is deprecated. Use email_marketing_consent instead.")]
         public DateTimeOffset? AcceptsMarketingUpdatedAt { get; set; }
         
         /// <summary>
         /// The marketing subscription opt-in level (as described by the M3AAWG best practices guideline) that the customer gave when they consented to receive marketing material by email. If the customer does not accept email marketing, then this property will be set to null. Valid values: single_opt_in, confirmed_opt_in, unknown.
         /// </summary>
         [JsonProperty("marketing_opt_in_level")]
+        [Obsolete("As of API version 2022-04, this property is deprecated. Use email_marketing_consent instead.")]
         public string MarketingOptInLevel { get; set; }
         
         /// <summary>
@@ -178,5 +178,11 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("metafields")]
         public IEnumerable<MetaField> Metafields { get; set; }
+
+        /// <summary>
+        /// The marketing consent information when the customer consented to receiving marketing material by email. The email property is required to create a customer with email consent information and to update a customer for email consent that doesn't have an email recorded.
+        /// </summary>
+        [JsonProperty("email_marketing_consent")]
+        public CustomerEmailMarketingConsent EmailMarketingConsent { get; set; }
     }
 }

--- a/ShopifySharp/Entities/CustomerEmailMarketingConsent.cs
+++ b/ShopifySharp/Entities/CustomerEmailMarketingConsent.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace ShopifySharp
+{
+    public class CustomerEmailMarketingConsent
+    {
+        /// <summary>
+        /// The current email marketing state for the customer.
+        /// </summary>
+        [JsonProperty("state")]
+        public string State { get; set; }
+
+        /// <summary>
+        /// The marketing subscription opt-in level, as described in the M3AAWG Sender Best Common Practices, that the customer gave when they consented to receive marketing material by email.
+        /// </summary>
+        [JsonProperty("opt_in_level")]
+        public string OptInLevel { get; set; }
+
+        /// <summary>
+        /// The date and time when the customer consented to receive marketing material by email. If no date is provided, then the date and time when the consent information was sent is used.
+        /// </summary>
+        [JsonProperty("consent_updated_at")]
+        public DateTimeOffset? ConsentUpdatedAt { get; set; }
+    }
+}


### PR DESCRIPTION
With Version 2022-04 the property EmailMarktingConsent was added to the customer entity and the following properties got marked as deprecated: AcceptsMarketing, AcceptsMarketingUpdatedAt and MarketingOptInLevel 

Reference: https://shopify.dev/changelog/new-email-marketing-consent-for-customers-and-deprecated-fields