### PR TITLE
int to long for api_client_id in GiftCardAdjustment

### DIFF
--- a/ShopifySharp/Entities/GiftCardAdjustment.cs
+++ b/ShopifySharp/Entities/GiftCardAdjustment.cs
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// A unique numeric identifier of the application that issued the adjustment (if it was issued by an application).
         /// </summary>
         [JsonProperty("api_client_id")]
-        public int? ApiClientId { get; set; }
+        public long? ApiClientId { get; set; }
 
         /// <summary>
         /// A unique numeric identifier of the user that issued the adjustment (if it was issued by a user).


### PR DESCRIPTION
Api Client Id can be a long.