### PR TITLE
Automatically downcase Metafield resource type strings

### DIFF
--- a/ShopifySharp.Tests/MetaField_Tests.cs
+++ b/ShopifySharp.Tests/MetaField_Tests.cs
@@ -38,6 +38,14 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
+        public async Task Counting_Metafields_On_Resources_Downcases_ResourceType()
+        {
+            var exn = await Record.ExceptionAsync(async () => await Fixture.Service.CountAsync(Fixture.ResourceId, Fixture.ResourceType.ToUpper()));
+
+            Assert.Null(exn);
+        }
+
+        [Fact]
         public async Task Counts_Metafields_On_Resources_And_Parent()
         {
             var count = await Fixture.Service.CountAsync(Fixture.ChildResourceId, Fixture.ChildResourceType, Fixture.ResourceId, Fixture.ResourceType);
@@ -46,10 +54,18 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
+        public async Task Counting_Metafields_On_Resources_And_Parent_Downcases_ResourceTypes()
+        {
+            var exn = await Record.ExceptionAsync(async () => await Fixture.Service.CountAsync(Fixture.ChildResourceId, Fixture.ChildResourceType.ToUpper(), Fixture.ResourceId, Fixture.ResourceType.ToUpper()));
+
+            Assert.Null(exn);
+        }
+
+        [Fact]
         public async Task Lists_Metafields()
         {
             var list = await Fixture.Service.ListAsync();
-            
+
             Assert.Contains(list.Items, i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description);
         }
 
@@ -57,16 +73,32 @@ namespace ShopifySharp.Tests
         public async Task Lists_Metafields_On_Resources()
         {
             var list = await Fixture.Service.ListAsync(Fixture.ResourceId, Fixture.ResourceType);
-            
+
             Assert.Contains(list.Items, i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description);
+        }
+
+        [Fact]
+        public async Task Listing_Metafields_On_Resources_Downcases_ResourceType()
+        {
+            var exn = await Record.ExceptionAsync(async () => await Fixture.Service.ListAsync(Fixture.ResourceId, Fixture.ResourceType.ToUpper()));
+
+            Assert.Null(exn);
         }
 
         [Fact]
         public async Task Lists_Metafields_On_Resources_And_Parent()
         {
             var list = await Fixture.Service.ListAsync(Fixture.ChildResourceId, Fixture.ChildResourceType, Fixture.ResourceId, Fixture.ResourceType);
-            
+
             Assert.Contains(list.Items, i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description);
+        }
+
+        [Fact]
+        public async Task Listing_Metafields_On_Resources_And_Parent_Downcases_ResourceTypes()
+        {
+            var exn = await Record.ExceptionAsync(async () => await Fixture.Service.ListAsync(Fixture.ChildResourceId, Fixture.ChildResourceType.ToUpper(), Fixture.ResourceId, Fixture.ResourceType.ToUpper()));
+
+            Assert.Null(exn);
         }
 
         [Fact]
@@ -116,6 +148,14 @@ namespace ShopifySharp.Tests
         }
 
         [Fact]
+        public async Task Creating_Metafields_On_Resources_Downcases_ResourceType()
+        {
+            var exn = await Record.ExceptionAsync(async () => await Fixture.Create(Fixture.ResourceId, Fixture.ResourceType.ToUpper()));
+
+            Assert.Null(exn);
+        }
+
+        [Fact]
         public async Task Creates_Metafields_On_Resources_And_Parent()
         {
             var created = await Fixture.Create(Fixture.ChildResourceId, Fixture.ChildResourceType, Fixture.ResourceId, Fixture.ResourceType);
@@ -127,6 +167,14 @@ namespace ShopifySharp.Tests
             Assert.NotNull(created.Value);
             Assert.Contains(created.OwnerResource, new [] { Fixture.ChildResourceType, Fixture.ChildResourceType.Substring(0, Fixture.ChildResourceType.Length - 1) });
             Assert.Equal(Fixture.ChildResourceId, created.OwnerId);
+        }
+
+        [Fact]
+        public async Task Creating_Metafields_On_Resources_And_Parent_Downcases_ResourceTypes()
+        {
+            var exn = await Record.ExceptionAsync(async () => await Fixture.Create(Fixture.ChildResourceId, Fixture.ChildResourceType.ToUpper(), Fixture.ResourceId, Fixture.ResourceType.ToUpper()));
+
+            Assert.Null(exn);
         }
 
         [Fact]

--- a/ShopifySharp.Tests/MetaField_Tests.cs
+++ b/ShopifySharp.Tests/MetaField_Tests.cs
@@ -49,28 +49,31 @@ namespace ShopifySharp.Tests
         public async Task Lists_Metafields()
         {
             var list = await Fixture.Service.ListAsync();
-            Assert.True(list.Items.Any(i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description));
+            
+            Assert.Contains(list.Items, i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description);
         }
 
         [Fact]
         public async Task Lists_Metafields_On_Resources()
         {
             var list = await Fixture.Service.ListAsync(Fixture.ResourceId, Fixture.ResourceType);
-            Assert.True(list.Items.Any(i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description));
+            
+            Assert.Contains(list.Items, i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description);
         }
 
         [Fact]
         public async Task Lists_Metafields_On_Resources_And_Parent()
         {
             var list = await Fixture.Service.ListAsync(Fixture.ChildResourceId, Fixture.ChildResourceType, Fixture.ResourceId, Fixture.ResourceType);
-            Assert.True(list.Items.Any(i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description));
+            
+            Assert.Contains(list.Items, i => i.Namespace == Fixture.Namespace && i.Description == Fixture.Description);
         }
 
         [Fact]
         public async Task Deletes_Metafields()
         {
             var created = await Fixture.Create(true);
-            bool threw = false;
+            var threw = false;
 
             try
             {
@@ -108,7 +111,7 @@ namespace ShopifySharp.Tests
             Assert.Equal(Fixture.Description, created.Description);
             EmptyAssert.NotNullOrEmpty(created.Key);
             Assert.NotNull(created.Value);
-            Assert.True(new string[] { Fixture.ResourceType, Fixture.ResourceType.Substring(0, Fixture.ResourceType.Length - 1) }.Contains(created.OwnerResource));
+            Assert.Contains(created.OwnerResource, new [] { Fixture.ResourceType, Fixture.ResourceType.Substring(0, Fixture.ResourceType.Length - 1) });
             Assert.Equal(Fixture.ResourceId, created.OwnerId);
         }
 
@@ -122,16 +125,16 @@ namespace ShopifySharp.Tests
             Assert.Equal(Fixture.Description, created.Description);
             EmptyAssert.NotNullOrEmpty(created.Key);
             Assert.NotNull(created.Value);
-            Assert.True(new string[] { Fixture.ChildResourceType, Fixture.ChildResourceType.Substring(0, Fixture.ChildResourceType.Length - 1) }.Contains(created.OwnerResource));
+            Assert.Contains(created.OwnerResource, new [] { Fixture.ChildResourceType, Fixture.ChildResourceType.Substring(0, Fixture.ChildResourceType.Length - 1) });
             Assert.Equal(Fixture.ChildResourceId, created.OwnerId);
         }
 
         [Fact]
         public async Task Updates_Metafields()
         {
-            string value = "10";
+            var value = "10";
             var created = await Fixture.Create();
-            long id = created.Id.Value;
+            var id = created.Id.Value;
 
             created.Value = value;
             created.Id = null;
@@ -147,9 +150,9 @@ namespace ShopifySharp.Tests
         [Fact]
         public async Task Updates_Metafields_On_Resources()
         {
-            string value = "10";
+            var value = "10";
             var created = await Fixture.Create(Fixture.ResourceId, Fixture.ResourceType);
-            long id = created.Id.Value;
+            var id = created.Id.Value;
 
             created.Value = value;
             created.Id = null;
@@ -165,9 +168,9 @@ namespace ShopifySharp.Tests
         [Fact]
         public async Task Updates_Metafields_On_Child_Resources()
         {
-            string value = "10";
+            var value = "10";
             var created = await Fixture.Create(Fixture.ChildResourceId, Fixture.ChildResourceType);
-            long id = created.Id.Value;
+            var id = created.Id.Value;
 
             created.Value = value;
             created.Id = null;
@@ -183,9 +186,9 @@ namespace ShopifySharp.Tests
         [Fact]
         public async Task Updates_Metafields_On_Resources_And_Parent()
         {
-            string value = "10";
+            var value = "10";
             var created = await Fixture.Create(Fixture.ChildResourceId, Fixture.ChildResourceType, Fixture.ResourceId, Fixture.ResourceType);
-            long id = created.Id.Value;
+            var id = created.Id.Value;
 
             created.Value = value;
             created.Id = null;
@@ -205,15 +208,12 @@ namespace ShopifySharp.Tests
 
         public ProductService ProductService { get; } = new ProductService(Utils.MyShopifyUrl, Utils.AccessToken);
 
-        public List<ShopifySharp.MetaField> Created { get; } = new List<ShopifySharp.MetaField>();
+        public List<MetaField> Created { get; } = new List<MetaField>();
 
         public string Namespace => "testing";
-
         public string Description => "This is a test meta field. It is an integer value.";
-
         public string ResourceType => "products";
         public string ChildResourceType => "variants";
-
         public long ResourceId { get; set; }
         public long ChildResourceId { get; set; }
 

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
-            return await _CountAsync($"{resourceType}/{resourceId}/metafields/count.json", cancellationToken);
+            return await _CountAsync($"{resourceType.ToLower()}/{resourceId}/metafields/count.json", cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace ShopifySharp
         /// </remarks>
         public virtual async Task<int> CountAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
-            return await _CountAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields/count.json", cancellationToken);
+            return await _CountAsync($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields/count.json", cancellationToken);
         }
 
         private async Task<ListResult<MetaField>> _ListAsync(string path, ListFilter<MetaField> filter,
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
+            return await _ListAsync($"{resourceType.ToLower()}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, ListFilter<MetaField> filter, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
+            return await _ListAsync($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
 
@@ -131,7 +131,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
+            return await _ListAsync($"{resourceType.ToLower()}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<ListResult<MetaField>> ListAsync(long resourceId, string resourceType, long parentResourceId, string parentResourceType, MetaFieldFilter filter = null, CancellationToken cancellationToken = default)
         {
-            return await _ListAsync($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json", filter, cancellationToken);
+            return await _ListAsync($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json", filter, cancellationToken);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{parentResourceType}/{parentResourceId}/{resourceType}/{resourceId}/metafields.json");
+            var req = PrepareRequest($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -206,7 +206,7 @@ namespace ShopifySharp
         /// <param name="cancellationToken">Cancellation Token</param>
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{resourceType}/{resourceId}/metafields.json");
+            var req = PrepareRequest($"{resourceType.ToLower()}/{resourceId}/metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield


### PR DESCRIPTION
This pull request will automatically downcase the resource type strings used by the `MetafieldService` class. These strings are case sensitive and must be downcased. If they're not downcased, Shopify will return a 404, causing ShopifySharp to throw an exception.

"orders" => would work 
"Orders" => 404
"ORDERS" => 404

After this change, all resource strings will be automatically downcased. See #789 and #788.