### PR TITLE
Invalid dates - Fix 2

### DIFF
--- a/ShopifySharp/Infrastructure/Serializer.cs
+++ b/ShopifySharp/Infrastructure/Serializer.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using ShopifySharp.Converters;
 using System;
 using System.Collections.Generic;
@@ -25,8 +26,14 @@ namespace ShopifySharp.Infrastructure
 
         public static string Serialize(object data) => JsonConvert.SerializeObject(data, CreateSettings());
 
+        public static object Deserialize(string json, Type objectType) => JsonConvert.DeserializeObject(json, objectType, CreateSettings());
+
         public static T Deserialize<T>(string json) => JsonConvert.DeserializeObject<T>(json, CreateSettings());
 
-        public static object Deserialize(string json, Type objectType) => JsonConvert.DeserializeObject(json, objectType, CreateSettings());
+        public static T Deserialize<T>(string json, string rootElementPath)
+        {
+            var jToken = JObject.Parse(json).SelectToken(rootElementPath);
+            return jToken.ToObject<T>(JsonSerializer.Create(CreateSettings()));
+        }
     }
 }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -235,8 +235,7 @@ namespace ShopifySharp
                             // This method may fail when the method was Delete, which is intendend.
                             // Delete methods should not be parsing the response JSON and should instead
                             // be using the non-generic ExecuteRequestAsync.
-                            var data = Serializer.Deserialize<JObject>(rawResult).SelectToken(rootElement);
-                            result = data.ToObject<T>();
+                            result = Serializer.Deserialize<T>(rawResult, rootElement);
                         }
 
                         return new RequestResult<T>(response, result, rawResult, ReadLinkHeader(response));


### PR DESCRIPTION
This ensure that if an invalid date is present in the API, it is converted to NULL.
It expands on the previous fix, which was only handling invalid dates when deserializing from a webhook json.