### PR TITLE
Fix for Charge.test serialization

### DIFF
--- a/ShopifySharp.Tests/FalseToNullConverter_Tests.cs
+++ b/ShopifySharp.Tests/FalseToNullConverter_Tests.cs
@@ -1,5 +1,7 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using ShopifySharp.Converters;
+using ShopifySharp.Infrastructure;
 using Xunit;
 
 namespace ShopifySharp.Tests
@@ -10,6 +12,25 @@ namespace ShopifySharp.Tests
         public FalseToNullConverter_Tests()
         {
 
+        }
+
+        [Fact]
+        public void SerializeChargeTest()
+        {
+            var charge = Serializer.Deserialize<RecurringCharge>("{ \"test\" : true }");
+            Assert.True(charge.Test);
+
+            charge = Serializer.Deserialize<RecurringCharge>("{ \"test\" : null }");
+            Assert.False(charge.Test);
+            
+            charge = Serializer.Deserialize<RecurringCharge>("{ \"test\" : false }");
+            Assert.False(charge.Test);
+
+            Assert.True(JObject.Parse(Serializer.Serialize(new RecurringCharge { Test = true })).Value<bool?>("test"));
+
+            Assert.Null(JObject.Parse(Serializer.Serialize(new RecurringCharge { Test = false })).Value<bool?>("test"));
+
+            Assert.Null(JObject.Parse(Serializer.Serialize(new RecurringCharge { Test = null })).Value<bool?>("test"));
         }
 
         [Fact]

--- a/ShopifySharp/Entities/Charge.cs
+++ b/ShopifySharp/Entities/Charge.cs
@@ -55,7 +55,7 @@ namespace ShopifySharp
         /// States whether or not the application charge is a test transaction.
         /// </summary>
         /// <remarks>Valid values are 'true' or null. Needs a special converter to convert null to false and vice-versa.</remarks>
-        [JsonProperty("test"), JsonConverter(typeof(FalseToNullConverter))]
+        [JsonProperty("test", NullValueHandling = NullValueHandling.Include), JsonConverter(typeof(FalseToNullConverter))]
         public bool? Test { get; set; }
 
         /// <summary>

--- a/ShopifySharp/Entities/RecurringCharge.cs
+++ b/ShopifySharp/Entities/RecurringCharge.cs
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// States whether or not the application charge is a test transaction.
         /// </summary>
         /// <remarks>Valid values are 'true' or null. Needs a special converter to convert null to false and vice-versa.</remarks>
-        [JsonProperty("test"), JsonConverter(typeof(FalseToNullConverter))]
+        [JsonProperty("test", NullValueHandling = NullValueHandling.Include), JsonConverter(typeof(FalseToNullConverter))]
         public bool? Test { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Ensure that `Charge.Test` and `RecurringCharge.Test` property is always serialized so that the `FalseToNullConverter` can kick in.

The `FalseToNullConverter` wasn't kicking in because the serializer uses `NullValueHandling.Ignore`
This is fixed by applying `NullValueHandling.Include` at the property level.

I personally think this converter should be removed altogether, but some people might rely on the fact that this the `Test` property should always return either false or true and never null. The API seems to accept false values.

Maybe we can remove `FalseToNullConverter.cs` altogether in the major/breaking release.