### PR TITLE
Avoid using JObject.Parse because it doesn't preserve timezones

### DIFF
--- a/ShopifySharp/Infrastructure/Serializer.cs
+++ b/ShopifySharp/Infrastructure/Serializer.cs
@@ -32,7 +32,7 @@ namespace ShopifySharp.Infrastructure
 
         public static T Deserialize<T>(string json, string rootElementPath)
         {
-            var jToken = JObject.Parse(json).SelectToken(rootElementPath);
+            var jToken = Deserialize<JToken>(json).SelectToken(rootElementPath);
             return jToken.ToObject<T>(JsonSerializer.Create(CreateSettings()));
         }
     }


### PR DESCRIPTION
Avoid using JObject.Parse because it doesn't preserve timezone on datetimeoffset (it always converts to the local timezone) See https://stackoverflow.com/questions/46829888/how-parse-string-to-jobject-ignoring-time-zone