### PR TITLE
Fulfillment order move object

### DIFF
--- a/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
@@ -99,7 +99,8 @@ namespace ShopifySharp.Tests
             Assert.Equal(Fixture.LocationId.Value, fulfillmentOrder.AssignedLocationId.Value);
             var result = await Fixture.Service.MoveAsync(fulfillmentOrder.Id.Value,  Fixture.OtherLocationId);
             Assert.NotNull(result);
-            Assert.Equal(Fixture.OtherLocationId, result.AssignedLocationId.Value);
+            Assert.NotNull(result.MovedFulfillmentOrder);
+            Assert.Equal(Fixture.OtherLocationId, result.MovedFulfillmentOrder.AssignedLocationId.Value);
         }
 
         [Fact(Skip = "Requires Subscription setup.")]

--- a/ShopifySharp/Entities/FulfillmentOrderMove.cs
+++ b/ShopifySharp/Entities/FulfillmentOrderMove.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// Fulfillment Order Move object
+    /// </summary>
+    public class FulfillmentOrderMove
+    {
+        /// <summary>
+        /// Original fulfillment order
+        /// </summary>
+        [JsonProperty("original_fulfillment_order")]
+        public FulfillmentOrder OriginalFulfillmentOrder { get; set; }
+
+        /// <summary>
+        /// Moved fulfillment order
+        /// </summary>
+        [JsonProperty("moved_fulfillment_order")]
+        public FulfillmentOrder MovedFulfillmentOrder { get; set; }
+
+        /// <summary>
+        /// Remaining fulfillment order if anything remains.
+        /// </summary>
+        [JsonProperty("remaining_fulfillment_order")]
+        public FulfillmentOrder RemainingFulfillmentOrder { get; set; }
+
+    }
+}

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 using ShopifySharp.Filters;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -83,7 +83,7 @@ namespace ShopifySharp
         /// <param name="fulfillmentOrderId">The fulfillment order id.</param>
         /// <param name="newLocationId">The new fulfillment order location.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        public virtual async Task<FulfillmentOrder> MoveAsync(long fulfillmentOrderId, long newLocationId, CancellationToken cancellationToken = default)
+        public virtual async Task<FulfillmentOrderMove> MoveAsync(long fulfillmentOrderId, long newLocationId, CancellationToken cancellationToken = default)
         {
             var body = new
             {
@@ -97,7 +97,7 @@ namespace ShopifySharp
             var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/move.json");
 
             //needs to be original_fulfillment_order
-            var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
+            var response = await ExecuteRequestAsync<FulfillmentOrderMove>(req, HttpMethod.Post, cancellationToken, content);
 
             return response.Result;
         }


### PR DESCRIPTION
I was attempting to use the Fulfillment Order Move endpoint but was getting a null reference exception. I referenced the [docs here](https://shopify.dev/api/admin-rest/2022-04/resources/fulfillmentorder#post-fulfillment-orders-fulfillment-order-id-move) and realized we need a different return object. Here's the improvement.