### PR TITLE
Add info about API version 2022-07 to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,8 @@ Shopify has begun versioning their API, meaning new features are locked behind n
 | 5.8.0 - 5.10.0       | 2020-10             |
 | 5.11.0 - 5.13.1      | 2021-07             |
 | 5.14.0 - 5.15.0      | 2021-10             |
-| 5.16.0 and above     | 2022-04             |
+| 5.16.0 - 5.18.11     | 2022-04             |
+| 5.19.0 and above     | 2022-07             |
 
 **Note:** ShopifySharp dropped support for .NET Framework 4.5 in version 5.14.0. [More details in #438.](https://github.com/nozzlegear/ShopifySharp/issues/438)
 


### PR DESCRIPTION
This adds the newly merged 5.19.0 release to the API version table.