### PR TITLE
Reimplement fulfilment cancel endpoint

### DIFF
--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -151,6 +151,16 @@ namespace ShopifySharp.Tests
             Assert.Equal(trackingNum, updated.TrackingNumbers.First());
             Assert.Equal(trackingUrl, updated.TrackingUrls.First());
         }
+
+        [Fact]
+        public async Task Cancels_Fulfillments()
+        {
+            var order = await Fixture.CreateOrder();
+            var created = await Fixture.Create(order.Id.Value);
+            var cancelled = await Fixture.Service.CancelAsync(created.Id.Value);
+
+            Assert.Equal("cancelled", cancelled.Status);
+        }
     }
 
     public class Fulfillment_Tests_Fixture : IAsyncLifetime

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -67,5 +67,18 @@ namespace ShopifySharp
             var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, content, "fulfillment");
             return response.Result;
         }
+
+        /// <summary>
+        /// Cancels a pending fulfillment with the given id.
+        /// </summary>
+        /// <param name="fulfillmentId">The fulfillment's id.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        public virtual async Task<Fulfillment> CancelAsync(long fulfillmentId, CancellationToken cancellationToken = default)
+        {
+            var req = PrepareRequest($"fulfillments/{fulfillmentId}/cancel.json");
+
+            var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment");
+            return response.Result;
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -1346,7 +1346,7 @@ Fulfillments can only be cancelled if their `Status` is `pending`.
 
 ```cs
 var service = new FulfillmentService(myShopifyUrl, shopAccessToken);
-await service.CancelAsync(orderId, fulfillmentId);
+await service.CancelAsync(fulfillmentId)
 ```
 
 ---


### PR DESCRIPTION
Implements the fulfilment cancellation endpoint described in #833.

There was still a leftover code snippet in the README for the old method that has since been removed, so I just clipped out the order ID parameter to make it match this implementation.