### PR TITLE
Support for partners API

### DIFF
--- a/ShopifySharp.Tests/Partner_Tests.cs
+++ b/ShopifySharp.Tests/Partner_Tests.cs
@@ -1,0 +1,73 @@
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ShopifySharp.Tests
+{
+    [Trait("Category", "Partners")]
+    public class Partner_Tests
+    {
+        private async Task<JToken> Query(string query, IRequestExecutionPolicy policy = null)
+        {
+            var svc = new PartnerService(Utils.OrganizationId, Utils.OrganizationToken);
+
+            if (policy != null)
+                svc.SetExecutionPolicy(policy);
+
+            return await svc.PostAsync(query);
+        }
+
+        private async Task<JToken> QueryTransactions(IRequestExecutionPolicy policy = null)
+        {
+            string query = @"
+{
+  transactions
+  {
+    edges
+    {
+      node
+      {
+        id
+        createdAt
+      }
+    }
+  }
+}";
+            return await Query(query, policy);
+        }
+
+        [Fact]
+        public async Task Transactions()
+        {
+            var res = await QueryTransactions();
+            Assert.NotNull(res);
+        }
+
+        [Fact]
+        public async Task InvalidQueryMustThrowException()
+        {
+            await Assert.ThrowsAsync<ShopifyException>(() => Query("{{ query }"));
+        }
+
+        [Fact]
+        public async Task LeakyBucketPolicyShouldRetry()
+        {
+            var policy = new LeakyBucketExecutionPolicy();
+            bool caught = false;
+
+            try
+            {
+                //issue 10 parallel requests to trip the 4 req/sec limit
+                //they will be retried internally
+                await Task.WhenAll(Enumerable.Range(0, 10).Select(async _ => await QueryTransactions(policy)));
+            }
+            catch (ShopifyRateLimitException)
+            {
+                caught = true;
+            }
+
+            Assert.False(caught);
+        }
+    }
+}

--- a/ShopifySharp.Tests/Utils.cs
+++ b/ShopifySharp.Tests/Utils.cs
@@ -54,5 +54,9 @@ namespace ShopifySharp.Tests
         public static string MultipassSecret => Get("MULTIPASS_SECRET");
 
         public static string MyShopifyUrl => Get("MY_SHOPIFY_URL");
+
+        public static long OrganizationId => long.Parse(Get("ORG_ID"));
+
+        public static string OrganizationToken => Get("ORG_TOKEN");
     }
 }

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/APIType.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/APIType.cs
@@ -1,0 +1,11 @@
+﻿namespace ShopifySharp.Infrastructure
+{
+    internal enum APIType : byte
+    {
+        RESTAdmin,
+
+        GraphQLAdmin,
+
+        GraphQLPartner,
+    }
+}

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/MultiAPIBucket.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/MultiAPIBucket.cs
@@ -12,14 +12,22 @@ namespace ShopifySharp
         private const int DEFAULT_GRAPHQL_MAX_AVAILABLE = 1_000;
         private const int DEFAULT_GRAPHQL_RESTORE_RATE = 50;
 
+        //https://shopify.dev/api/partner#rate_limits
+        private const int DEFAULT_GRAPHQL_PARTNER_MAX_AVAILABLE = 4;
+        private const int DEFAULT_GRAPHQL_PARTNER_RESTORE_RATE = 4;
+
+
         private LeakyBucket RESTBucket { get; }
 
         private LeakyBucket GraphQLBucket { get; }
+
+        private LeakyBucket GraphQLPartnersBucket { get; }
 
         public MultiShopifyAPIBucket(Func<RequestContext> getRequestContext)
         {
             RESTBucket = new LeakyBucket(DEFAULT_REST_MAX_AVAILABLE, DEFAULT_REST_RESTORE_RATE, getRequestContext);
             GraphQLBucket = new LeakyBucket(DEFAULT_GRAPHQL_MAX_AVAILABLE, DEFAULT_GRAPHQL_RESTORE_RATE, getRequestContext);
+            GraphQLPartnersBucket = new LeakyBucket(DEFAULT_GRAPHQL_PARTNER_MAX_AVAILABLE, DEFAULT_GRAPHQL_PARTNER_RESTORE_RATE, getRequestContext);
         }
 
         public async Task WaitForAvailableRESTAsync(CancellationToken cancellationToken)
@@ -31,6 +39,11 @@ namespace ShopifySharp
         public async Task WaitForAvailableGraphQLAsync(int queryCost, CancellationToken cancellationToken)
         {
             await GraphQLBucket.WaitForAvailableAsync(queryCost, cancellationToken);
+        }
+
+        public async Task WaitForAvailableGraphQLPartnerAsync(CancellationToken cancellationToken)
+        {
+            await GraphQLPartnersBucket.WaitForAvailableAsync(1, cancellationToken);
         }
 
         public void SetRESTBucketState(int maximumAvailable, double currentlyAvailable)

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -1,0 +1,73 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Net.Http;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+using System.Net;
+using System.Threading;
+using System;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// A service to query the GraphQL Partner API
+    /// See https://shopify.dev/api/partner
+    /// </summary>
+    public class PartnerService : ShopifyService
+    {
+        private readonly long _organizationId;
+        private readonly string _apiVersion;
+
+        public override string APIVersion => _apiVersion ?? base.APIVersion;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="GraphService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public PartnerService(long organizationId, string accessToken, string apiVersion = null) : base("partners.shopify.com", accessToken) 
+        {
+            _organizationId = organizationId;
+            _apiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Executes a Graph API Call.
+        /// </summary>
+        /// <param name="body">The query you would like to execute. Please see documentation for formatting.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <returns>A JToken containing the data from the request.</returns>
+        public virtual async Task<JToken> PostAsync(string body, CancellationToken cancellationToken = default)
+        {
+            var req = new RequestUri(new Uri($"https://partners.shopify.com/{_organizationId}/api/{APIVersion}/graphql.json"));
+            var content = new StringContent(body, Encoding.UTF8, "application/graphql");
+            var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content);
+            CheckForErrors(response);
+            return response.Result["data"];
+        }
+
+        /// <summary>
+        /// Since Graph API Errors come back with error code 200, checking for them in a way similar to the REST API doesn't work well without potentially throwing unnecessary errors. This loses the requestId, but otherwise is capable of passing along the message.
+        /// </summary>
+        /// <param name="requestResult">The RequestResult<JToken> response from ExecuteRequestAsync.</param>
+        /// <returns>Task.</returns>
+        private void CheckForErrors(RequestResult<JToken> requestResult)
+        {
+            if (requestResult.Result["errors"] != null)
+            {
+                var errorList = new List<string>();
+                
+                foreach (var error in requestResult.Result["errors"])
+                {
+                    errorList.Add(error["message"].ToString());
+                }
+
+                var message = requestResult.Result["errors"].FirstOrDefault()["message"].ToString();
+
+                throw new ShopifyException(requestResult.Response, HttpStatusCode.OK, errorList, message, requestResult.RawResult, "");
+            }
+        }
+    }
+}


### PR DESCRIPTION
See https://shopify.dev/api/partner

This includes the PartnerService, some tests and enhancements to the leaky bucket policy because the Partners API has its own rate limits.

Running the tests requires 2 new environment variables:

1. SHOPIFYSHARP_ORG_ID => The Id of a partner organization. When logged in the partner dashboard, it shows in the url after https://partners.shopify.com/ 
![image](https://user-images.githubusercontent.com/3426504/216518586-5c6d800d-4147-4815-ad66-d684553102ee.png)

2. SHOPIFYSHARP_ORG_TOKEN => Within the partner dashboard, go to Settings then click 'Manage Partner API clients'. Then create a dummy client for testing. Ensure you grant the 'View financials', required to run run and copy the access token in the environment variable. 
![image](https://user-images.githubusercontent.com/3426504/216518951-41f4d2cd-52d0-4128-b83a-b9da1fa38486.png)
