### PR TITLE
2023-01 upgrade

### DIFF
--- a/ShopifySharp.Tests/FulfillmentRequest_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentRequest_Tests.cs
@@ -74,7 +74,7 @@ namespace ShopifySharp.Tests
 
             // Get a location id to use in these tests
             var locations = await LocationService.ListAsync();
-            LocationId = locations.First().Id.Value;
+            LocationId = locations.Items.First().Id.Value;
         }
 
         public async Task DisposeAsync()

--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -159,8 +159,6 @@ namespace ShopifySharp.Tests
         private OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
         private FulfillmentOrderService FulfillmentOrderService { get; } = new FulfillmentOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
 
-        public FulfillmentOrderService FulfillmentOrderService { get; } = new FulfillmentOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
-
         public long LocationId => 6226758;
 
         /// <summary>

--- a/ShopifySharp.Tests/Location_Tests.cs
+++ b/ShopifySharp.Tests/Location_Tests.cs
@@ -1,3 +1,4 @@
+using ShopifySharp.Filters;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -28,9 +29,9 @@ namespace ShopifySharp.Tests
             var list = await Service.ListAsync();
 
             // Not all shops have a location.
-            if (list.Count() > 0)
+            if (list.Items.Count() > 0)
             {
-                long id = list.First().Id.Value;
+                long id = list.Items.First().Id.Value;
                 var location = await Service.GetAsync(id);
 
                 Assert.NotNull(location.Address1);

--- a/ShopifySharp.Tests/User_Tests.cs
+++ b/ShopifySharp.Tests/User_Tests.cs
@@ -50,7 +50,7 @@ namespace ShopifySharp.Tests
             var cancellationToken = new CancellationTokenSource().Token;
             
             var result = await Fixture.Service.ListAsync();
-            result = await Fixture.Service.ListAsync(cancellationToken);
+            result = await Fixture.Service.ListAsync(cancellationToken: cancellationToken);
             result = await Fixture.Service.ListAsync(userFilter);
             result = await Fixture.Service.ListAsync(userFilter, cancellationToken);
             result = await Fixture.Service.ListAsync(listFilter);

--- a/ShopifySharp/Entities/LineItem.cs
+++ b/ShopifySharp/Entities/LineItem.cs
@@ -208,6 +208,7 @@ namespace ShopifySharp
         /// The location of the line item's fulfillment origin.
         /// </summary>
         [JsonProperty("origin_location")]
+        [Obsolete("This field is deprecated in the API and will be removed in an upcoming release")]
         public LineItemOriginLocation OriginLocation { get; set; }
 
         /// <summary>

--- a/ShopifySharp/Entities/PaymentDetails.cs
+++ b/ShopifySharp/Entities/PaymentDetails.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
@@ -23,5 +18,17 @@ namespace ShopifySharp
 
         [JsonProperty("credit_card_company")]
         public string CreditCardCompany { get; set; }
+
+        [JsonProperty("credit_card_name")]
+        public string CreditCardName { get; set; }
+
+        [JsonProperty("credit_card_wallet")]
+        public string CreditCardWallet { get; set; }
+
+        [JsonProperty("credit_card_expiration_month")]
+        public int? CreditCardExpirationMonth { get; set; }
+
+        [JsonProperty("credit_card_expiration_year")]
+        public int? CreditCardExpirationYear { get; set; }
     }
 }

--- a/ShopifySharp/Entities/Shop.cs
+++ b/ShopifySharp/Entities/Shop.cs
@@ -323,5 +323,17 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("primary_location_id")]
         public long? PrimaryLocationId { get; set; }
+
+        /// <summary>
+        /// Whether transactional SMS sent by Shopify are disabled on the shop's online store
+        /// </summary>
+        [JsonProperty("transactional_sms_disabled")]
+        public bool? TransactionalSmsDisabled { get; set; }
+
+        /// <summary>
+        /// Whether SMS marketing has been enabled on the shop's checkout configuration settings
+        /// </summary>
+        [JsonProperty("marketing_sms_consent_enabled_at_checkout")]
+        public bool? MarketingSmsConsentEnabledAtCheckout { get; set; }
     }
 }

--- a/ShopifySharp/Entities/Transaction.cs
+++ b/ShopifySharp/Entities/Transaction.cs
@@ -152,5 +152,13 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("currency_exchange_adjustment")]
         public CurrencyExchangeAdjustment CurrencyExchangeAdjustment { get; set; }
+
+        /// <summary>
+        /// Unique ID is now sent to payment providers when a customer pays at checkout. 
+        /// This ID can be used to match order information between Shopify and payment providers. An Order can have more than one Payment ID. 
+        /// It only includes successful or pending payments. It does not include captures and refunds.
+        /// </summary>
+        [JsonProperty("payment_id")]
+        public string PaymentId { get; set; }
     }
 }

--- a/ShopifySharp/Filters/LocationListFilter.cs
+++ b/ShopifySharp/Filters/LocationListFilter.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Filters
+{
+    public class LocationListFilter : ListFilter<Location>
+    {
+    }
+}

--- a/ShopifySharp/Services/Location/LocationService.cs
+++ b/ShopifySharp/Services/Location/LocationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Filters;
+using ShopifySharp.Lists;
 
 namespace ShopifySharp
 {
@@ -32,12 +33,19 @@ namespace ShopifySharp
         }
 
         /// <summary>
-        /// Retrieves a list of all <see cref="Location"/> objects.
+        /// Gets a list of up to 250 of the locations.
         /// </summary>
-        /// <returns>The list of <see cref="Location"/> objects.</returns>
-        public virtual async Task<IEnumerable<Location>> ListAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<ListResult<Location>> ListAsync(ListFilter<Location> filter = null, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<IEnumerable<Location>>($"locations.json", "locations", cancellationToken: cancellationToken);
+            return await ExecuteGetListAsync("locations.json", "locations", filter, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets a list of up to 250 of the locations.
+        /// </summary>
+        public virtual async Task<ListResult<Location>> ListAsync(LocationListFilter filter, CancellationToken cancellationToken = default)
+        {
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp
 {
     public abstract class ShopifyService
     {
-        public virtual string APIVersion => "2022-07";
+        public virtual string APIVersion => "2023-01";
 
         private static IRequestExecutionPolicy _GlobalExecutionPolicy = new DefaultRequestExecutionPolicy();
 

--- a/ShopifySharp/Services/User/UserService.cs
+++ b/ShopifySharp/Services/User/UserService.cs
@@ -25,17 +25,6 @@ namespace ShopifySharp
         /// <summary>
         /// Gets a list of up to 250 of the users.
         /// </summary>
-        /// <remarks>
-        /// To be removed in 6.0, only exists for backwards compatibility.
-        /// </remarks>
-        public virtual async Task<ListResult<User>> ListAsync(CancellationToken cancellationToken)
-        {
-            return await ListAsync(null, cancellationToken);
-        }
-
-        /// <summary>
-        /// Gets a list of up to 250 of the users.
-        /// </summary>
         public virtual async Task<ListResult<User>> ListAsync(ListFilter<User> filter = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteGetListAsync("users.json", "users", filter, cancellationToken);


### PR DESCRIPTION
This upgrades ShopifySharp to use 2023-01 version.

I went through changes described at:
- https://shopify.dev/docs/api/release-notes/2022-10
- https://shopify.dev/docs/api/release-notes/2023-01

Changes:
- Marked LineItem.origin_location as obsolete
- Added new Shop properties transactional_sms_disabled and marketing_sms_consent_enabled_at_checkout
- Location listing is now paged
 - New fields on Transaction