### PR TITLE
Check env.yml for prefixed variables

### DIFF
--- a/ShopifySharp.Tests/Utils.cs
+++ b/ShopifySharp.Tests/Utils.cs
@@ -29,12 +29,21 @@ namespace ShopifySharp.Tests
                 _dotEnvFile = DotEnvFile.LoadFile("./env.yml", true);
             }
 
-            if (_dotEnvFile != null && _dotEnvFile.ContainsKey(key))
+            var prefix = "SHOPIFYSHARP_";
+
+            if (_dotEnvFile != null)
             {
-                return _dotEnvFile[key];
+                if (_dotEnvFile.ContainsKey(key))
+                {
+                    return _dotEnvFile[key];
+                }
+
+                if (_dotEnvFile.ContainsKey(prefix + key))
+                {
+                    return _dotEnvFile[prefix + key];
+                }
             }
 
-            var prefix = "SHOPIFYSHARP_";
             var value = Environment.GetEnvironmentVariable(key) ?? Environment.GetEnvironmentVariable(prefix + key);
 
             if (string.IsNullOrEmpty(value))


### PR DESCRIPTION
Update Utils.Get() so that when checking for environment variables in the env.yml file that variables prefixed with 'SHOPIFYSHARP_' can be found.