### PR TITLE
Added the missing Shopify Return object to the Shopify Refund object

### DIFF
--- a/ShopifySharp/Entities/Refund.cs
+++ b/ShopifySharp/Entities/Refund.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using ShopifySharp.Entities;
 using System;
 using System.Collections.Generic;
 
@@ -94,7 +95,12 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("refund_duties")]
         public IEnumerable<RefundDutyType> RefundDuties { get; set; }
-        
+
+        /// <summary>
+        /// Unique identifiers for the return.
+        /// </summary>
+        [JsonProperty("return")]
+        public Return Return { get; set; }
     }
 
     public class Shipping

--- a/ShopifySharp/Entities/Return.cs
+++ b/ShopifySharp/Entities/Return.cs
@@ -1,0 +1,9 @@
+﻿namespace ShopifySharp.Entities
+{
+    /// <summary>
+    /// An object representing the Shopify Return
+    /// </summary>
+    public class Return : ShopifyObject
+    {
+    }
+}


### PR DESCRIPTION
As part of the the issue #878 where the Refund object is missing from the Return object.
The refund object only contains the standard Shopify id / graphql id as far as I am aware.