### PR TITLE
Add missing properties to order cancel options

### DIFF
--- a/ShopifySharp/Services/Order/OrderCancelOptions.cs
+++ b/ShopifySharp/Services/Order/OrderCancelOptions.cs
@@ -12,6 +12,14 @@ namespace ShopifySharp
         public decimal? RefundAmount { get; set; }
 
         /// <summary>
+        /// The three letter code (ISO 4217) for the currency used for the refund.
+        /// The currency of the refund that's issued when the order is canceled. 
+        /// Required for multi-currency orders whenever the `amount` property is provided.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string RefundCurrency { get; set; }
+
+        /// <summary>
         /// Restock the items for this order back to your store.
         /// </summary>
         [JsonProperty("restock")]

--- a/ShopifySharp/Services/Order/OrderCancelOptions.cs
+++ b/ShopifySharp/Services/Order/OrderCancelOptions.cs
@@ -17,7 +17,7 @@ namespace ShopifySharp
         /// Required for multi-currency orders whenever the `amount` property is provided.
         /// </summary>
         [JsonProperty("currency")]
-        public string RefundCurrency { get; set; }
+        public string Currency { get; set; }
 
         /// <summary>
         /// Restock the items for this order back to your store.


### PR DESCRIPTION
Add RefundCurrency property to the OrderCancelOptions
https://shopify.dev/docs/api/admin-rest/2023-04/resources/order#post-orders-order-id-cancel