### PR TITLE
Added Multipass properties

### DIFF
--- a/ShopifySharp.Tests/Multipass_Tests.cs
+++ b/ShopifySharp.Tests/Multipass_Tests.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp.Tests
             string url = MultipassService.GetMultipassUrl(
                 Fixture.Create(),
                 Utils.MyShopifyUrl,
-                Utils.AccessToken
+                Utils.MultipassSecret
             );
 
             Assert.True(!string.IsNullOrEmpty(url));
@@ -33,7 +33,7 @@ namespace ShopifySharp.Tests
     {
         public Guid Guid = Guid.NewGuid();
 
-        public Customer Create() => new Customer()
+        public MultipassRequest Create() => new MultipassRequest()
         {
             Email = Guid.NewGuid().ToString() + "@example.com",
             CreatedAt = DateTimeOffset.Now,
@@ -41,6 +41,7 @@ namespace ShopifySharp.Tests
             LastName = "Doe",
             VerifiedEmail = true,
             MultipassIdentifier = Guid.ToString(),
+            ReturnTo = $"{Utils.MyShopifyUrl}",
             Addresses = new List<Address>()
             {
                 new Address()

--- a/ShopifySharp/Entities/MultipassRequest.cs
+++ b/ShopifySharp/Entities/MultipassRequest.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShopifySharp
+{
+    public class MultipassRequest : Customer
+    {
+        [JsonProperty("tag_string")]
+        public string TagString { get; set; }
+        [JsonProperty("identifier")]
+        public string Identifier { get; set; }
+        [JsonProperty("remote_ip")]
+        public string RemoteIP { get; set; }
+        [JsonProperty("return_to")]
+        public string ReturnTo { get; set; }
+    }
+}

--- a/ShopifySharp/Services/Multipass/MultipassService.cs
+++ b/ShopifySharp/Services/Multipass/MultipassService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Newtonsoft.Json;
+using ShopifySharp.Entities;
 
 namespace ShopifySharp
 {
@@ -12,8 +13,8 @@ namespace ShopifySharp
         private const int FixedKeySize = 16;
 
         public static string GetMultipassUrl(
-            Customer userData,
-            string shopifyUrl, 
+            MultipassRequest userData,
+            string shopifyUrl,
             string multipassSecret
             )
         {


### PR DESCRIPTION
Hi,

I have additional properties to multipass request. New properties are:

tag_string
identifier,
remote_ip,
return_to

I have also fixed the test to utilize the MultipassSecret instead of ShopifyToken.

Please merge.