### PR TITLE
Mapping the class to match the JSON and deserialize in a correct way

### DIFF
--- a/ShopifySharp/Entities/LineItemDuty.cs
+++ b/ShopifySharp/Entities/LineItemDuty.cs
@@ -13,11 +13,8 @@ namespace ShopifySharp
         [JsonProperty("country_code_of_origin")]
         public string CountryCodeOfOrigin { get; set; }
 
-        [JsonProperty("shop_money")]
-        public Price ShopMoney { get; set; }
-
-        [JsonProperty("presentment_money")]
-        public Price PresentmentMoney { get; set; }
+        [JsonProperty("price_set")]
+        public PriceSet PriceSet { get; set; }
 
         [JsonProperty("tax_lines")]
         public IEnumerable<TaxLine> TaxLines { get; set; }


### PR DESCRIPTION
![image](https://github.com/nozzlegear/ShopifySharp/assets/16907249/805328fb-a5ad-43e6-8671-20224558a16c)
 
As we can see in this JSON printscreen the price_set would be the correct way to implement this class. 

