### PR TITLE
Added SmartCollectionRules.ConditionObjectId

### DIFF
--- a/ShopifySharp/Entities/SmartCollectionRules.cs
+++ b/ShopifySharp/Entities/SmartCollectionRules.cs
@@ -24,5 +24,11 @@ namespace ShopifySharp
         /// </summary>
         [JsonProperty("column")]
         public string Column { get; set; }
+
+        /// <summary>
+        /// The id of the object that points to additional attributes for the collection rule. This is only required when using metafield definition rules.
+        /// </summary>
+        [JsonProperty("condition_object_id")]
+        public long? ConditionObjectId { get; set; }
     }
 }


### PR DESCRIPTION
https://github.com/nozzlegear/ShopifySharp/issues/933

This change allows reading/writing of `SmartCollectionRules` which use metafields in `SmartCollections`.

Shopify Docs: https://shopify.dev/docs/api/admin-rest/2023-07/resources/smartcollection

It can be used to create a metafield rule in a smart collection as follows (example shows for a product metafield):

```
var rule = new SmartCollectionRule
{
    Column = "product_metafield_definition",
    Relation = "equals",
    Condition = value
    ConditionObjectId = conditionObjectId
};
```

I found the most straightforward way to find the `ConditionObjectId` for a given product metafield was to inspect the HTML of the Settings / Custom Data page in my store and find the ids there:

`<li id="gid://shopify/MetafieldDefinition/123456789" class="Polaris-IndexTable__TableRow_1a85o">`

where `123456789` is to be used as `conditionObjectId`.