### PR TITLE
Fixes https://github.com/nozzlegear/ShopifySharp/issues/957

### DIFF
--- a/ShopifySharp/Entities/ShippingLine.cs
+++ b/ShopifySharp/Entities/ShippingLine.cs
@@ -1,13 +1,9 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-    public class ShippingLine
+    public class ShippingLine : ShopifyObject
     {
         /// <summary>
         /// The carrier provided identifier.

--- a/ShopifySharp/Entities/ShopifyObject.cs
+++ b/ShopifySharp/Entities/ShopifyObject.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ShopifySharp
 {


### PR DESCRIPTION
ShippingLine inherits ShopifyObject's Id property