### PR TITLE
Adds two overloads to GraphService.SendAsync to allow passing mediaType for application/json formatted queries.

### DIFF
--- a/ShopifySharp.Tests/GenerateGraphQLSchema_Test.cs
+++ b/ShopifySharp.Tests/GenerateGraphQLSchema_Test.cs
@@ -92,6 +92,35 @@ namespace ShopifySharp.Tests
                 Assert.Null(commentEventEmbed.AsCustomer());
             }
         }
+
+        [Fact]
+        public async Task GetProductsAsParameterizedJsonQuery()
+        {
+            var svc = new GraphService(Utils.MyShopifyUrl, Utils.AccessToken);
+            svc.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
+
+            var parameterizedQuery = new
+            {
+                query = @"
+                        query ($limit: Int!) { 
+                            products(first:$limit) { 
+                                nodes { 
+                                    id 
+                                } 
+                             } 
+                        }",
+                variables = new
+                {
+                    limit = 10,
+                }
+            };
+
+            var queryAsJson = Serializer.Serialize(parameterizedQuery);
+            var res = await svc.SendAsync<ProductConnection>(queryAsJson, "application/json");
+            var orders = res.nodes;
+            Assert.NotNull(orders);
+            Assert.NotEmpty(orders);
+        }
     }
 }
 #endif

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -44,17 +44,25 @@ namespace ShopifySharp
             return res["data"];
         }
 
-        public virtual async Task<JsonElement> SendAsync(string graphqlQuery, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
+        public virtual Task<JsonElement> SendAsync(string graphqlQuery, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
+            => SendAsync(graphqlQuery, "application/graphql", graphqlQueryCost, cancellationToken);
+
+        public virtual async Task<JsonElement> SendAsync(string graphqlQuery, string mediaType, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
         {
-            var res = await PostAsync<JsonDocument>(graphqlQuery, "application/graphql", graphqlQueryCost, cancellationToken);
+            var res = await PostAsync<JsonDocument>(graphqlQuery, mediaType, graphqlQueryCost, cancellationToken);
             return res.RootElement.GetProperty("data");
         }
 
 #if NET6_0_OR_GREATER
-        public virtual async Task<TResult> SendAsync<TResult>(string graphqlQuery, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
+
+        public virtual Task<TResult> SendAsync<TResult>(string graphqlQuery, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
+            where TResult : class
+            => SendAsync<TResult>(graphqlQuery, "application/graphql", graphqlQueryCost, cancellationToken);
+
+        public virtual async Task<TResult> SendAsync<TResult>(string graphqlQuery, string mediaType, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)
             where TResult : class
         {
-            var elt = await this.SendAsync(graphqlQuery, graphqlQueryCost, cancellationToken);
+            var elt = await SendAsync(graphqlQuery, mediaType, graphqlQueryCost, cancellationToken);
             var ptyElt = elt.EnumerateObject().Single().Value;
             return GraphQL.Serializer.Deserialize<TResult>(ptyElt.GetRawText());
         }


### PR DESCRIPTION
> I'm absurdly new to GraphQL and may not fully understand what it is at play in passing the application/graphql vs application/json media types but as I was hoping to create a parameterized query and it worked with Json.Net I was hoping to make the same possible for the System.Text.Json variants. Please feel free to burn this, salt the ground where it was and move on if it serves no purpose.

1. Added overloads of the `GraphService.SendAsync` methods to allow passing `mediaType` parameter so "application/json" can be used when passing a json query and variables.

2. Forwarding existing  `GraphService.SendAsync` to the overloads passing the "application/graphql" media type to preserve their behavior.

3. Added test method `GetProductsAsParameterizedJsonQuery`  to validate the new SendAsync overloads.