### PR TITLE
Add method to validate Shopify webhooks using `ReadOnlyMemory<byte>`

### DIFF
--- a/ShopifySharp.Tests/Authorization_Tests.cs
+++ b/ShopifySharp.Tests/Authorization_Tests.cs
@@ -132,7 +132,7 @@ namespace ShopifySharp.Tests
         {
             var qs = "hmac=134298b94779fc1be04851ed8f972c827d9a3b4fdf6725fe97369ef422cc5746&shop=stages-test-shop-2.myshopify.com&signature=f477a85f3ed6027735589159f9da74da&timestamp=1459779785";
 
-            bool isValid = AuthorizationService.IsAuthenticRequest(qs, Utils.SecretKey);
+            Assert.True(AuthorizationService.IsAuthenticRequest(qs, Utils.SecretKey));
         }
 
         [Fact]

--- a/ShopifySharp.Tests/Authorization_Tests.cs
+++ b/ShopifySharp.Tests/Authorization_Tests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -218,8 +216,8 @@ namespace ShopifySharp.Tests
             Assert.True(actual);
         }
 
-#if NET6_0_OR_GREATER
-
+#if NET472
+#else
         [Fact]
         public void IsAuthenticWebhook_UsingBytes_WhenHeaderIsMissing_ReturnFalse()
         {

--- a/ShopifySharp.Tests/GenerateGraphQLSchema_Test.cs
+++ b/ShopifySharp.Tests/GenerateGraphQLSchema_Test.cs
@@ -1,4 +1,4 @@
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotenvfile" Version="2.1.0" />
@@ -25,9 +25,7 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Wish.GraphQLSchemaGenerator">
-      <Version>1.5.2</Version>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Wish.GraphQLSchemaGenerator" Version="1.5.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Merging method contributed by @Socolin, at their request.

- Remove unnecessary allocation
- Remove conversion from string to bytes

Benchmark:

|   Method |     Mean |     Error |    StdDev |   Median |   Gen0 |   Gen1 | Allocated |
|--------- |---------:|----------:|----------:|---------:|-------:|-------:|----------:|
|      Old | 2.308 μs | 0.0694 μs | 0.2045 μs | 2.392 μs | 0.0057 | 0.0038 |     624 B |
|      New | 1.115 μs | 0.0016 μs | 0.0013 μs | 1.115 μs |      - |      - |      64 B |
| OldLarge | 2.383 μs | 0.0469 μs | 0.0482 μs | 2.384 μs | 0.0114 | 0.0076 |    1088 B |
| NewLarge | 1.245 μs | 0.0022 μs | 0.0018 μs | 1.245 μs |      - |      - |      64 B |