### PR TITLE
Rename ShopifyRestApiCredentials to ShopifyApiCredentials

### DIFF
--- a/ShopifySharp.Extensions.DependencyInjection.Tests/FactoryServiceTests.cs
+++ b/ShopifySharp.Extensions.DependencyInjection.Tests/FactoryServiceTests.cs
@@ -2,7 +2,7 @@ namespace ShopifySharp.Extensions.DependencyInjection.Tests;
 
 public class FactoryServiceTests
 {
-    private readonly ShopifyRestApiCredentials _credentials = new("some-shopify-domain", "some-access-token");
+    private readonly ShopifyApiCredentials _credentials = new("some-shopify-domain", "some-access-token");
 
     [Fact]
     public void FactoryServices_WhenRequestExecutionPolicyIsNotInjected_ShouldCreateService()

--- a/ShopifySharp/Credentials/ShopifyApiCredentials.cs
+++ b/ShopifySharp/Credentials/ShopifyApiCredentials.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace ShopifySharp.Credentials
 {
-    public readonly struct ShopifyRestApiCredentials(string shopDomain, string accessToken)
+    public readonly struct ShopifyApiCredentials(string shopDomain, string accessToken)
     {
         public string ShopDomain { get; } = shopDomain;
         public string AccessToken { get; } = accessToken;
@@ -15,14 +15,14 @@ namespace ShopifySharp.Credentials
         #if NETSTANDARD2_0
         public override bool Equals(object obj)
         {
-            return obj is ShopifyRestApiCredentials other
+            return obj is ShopifyApiCredentials other
                 && ShopDomain == other.ShopDomain
                 && AccessToken == other.AccessToken;
         }
         #else
         public override bool Equals(object? obj)
         {
-            return obj is ShopifyRestApiCredentials other
+            return obj is ShopifyApiCredentials other
                 && ShopDomain == other.ShopDomain
                 && AccessToken == other.AccessToken;
         }
@@ -35,6 +35,16 @@ namespace ShopifySharp.Credentials
             #else
             return HashCode.Combine(ShopDomain, AccessToken);
             #endif
+        }
+
+        public static bool operator ==(ShopifyApiCredentials left, ShopifyApiCredentials right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ShopifyApiCredentials left, ShopifyApiCredentials right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/ShopifySharp/Credentials/ShopifyPartnerApiCredentials.cs
+++ b/ShopifySharp/Credentials/ShopifyPartnerApiCredentials.cs
@@ -36,5 +36,15 @@ namespace ShopifySharp.Credentials
             return HashCode.Combine(PartnerOrganizationId, AccessToken);
             #endif
         }
+
+        public static bool operator ==(ShopifyPartnerApiCredentials left, ShopifyPartnerApiCredentials right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ShopifyPartnerApiCredentials left, ShopifyPartnerApiCredentials right)
+        {
+            return !(left == right);
+        }
     }
 }

--- a/ShopifySharp/Factories/AccessScopeServiceFactory.cs
+++ b/ShopifySharp/Factories/AccessScopeServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IAccessScopeServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IAccessScopeService Create(ShopifyRestApiCredentials credentials);
+    IAccessScopeService Create(ShopifyApiCredentials credentials);
 }
 
 public class AccessScopeServiceFactory(
@@ -24,7 +24,7 @@ public class AccessScopeServiceFactory(
     #endif
 ) : IAccessScopeServiceFactory
 {
-    public virtual IAccessScopeService Create(ShopifyRestApiCredentials credentials)
+    public virtual IAccessScopeService Create(ShopifyApiCredentials credentials)
     {
         var service = new AccessScopeService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
+++ b/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IApplicationCreditServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IApplicationCreditService Create(ShopifyRestApiCredentials credentials);
+    IApplicationCreditService Create(ShopifyApiCredentials credentials);
 }
 
 public class ApplicationCreditServiceFactory(
@@ -24,7 +24,7 @@ public class ApplicationCreditServiceFactory(
     #endif
 ) : IApplicationCreditServiceFactory
 {
-    public virtual IApplicationCreditService Create(ShopifyRestApiCredentials credentials)
+    public virtual IApplicationCreditService Create(ShopifyApiCredentials credentials)
     {
         var service = new ApplicationCreditService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ArticleServiceFactory.cs
+++ b/ShopifySharp/Factories/ArticleServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IArticleServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IArticleService Create(ShopifyRestApiCredentials credentials);
+    IArticleService Create(ShopifyApiCredentials credentials);
 }
 
 public class ArticleServiceFactory(
@@ -24,7 +24,7 @@ public class ArticleServiceFactory(
     #endif
 ) : IArticleServiceFactory
 {
-    public virtual IArticleService Create(ShopifyRestApiCredentials credentials)
+    public virtual IArticleService Create(ShopifyApiCredentials credentials)
     {
         var service = new ArticleService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/AssetServiceFactory.cs
+++ b/ShopifySharp/Factories/AssetServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IAssetServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IAssetService Create(ShopifyRestApiCredentials credentials);
+    IAssetService Create(ShopifyApiCredentials credentials);
 }
 
 public class AssetServiceFactory(
@@ -24,7 +24,7 @@ public class AssetServiceFactory(
     #endif
 ) : IAssetServiceFactory
 {
-    public virtual IAssetService Create(ShopifyRestApiCredentials credentials)
+    public virtual IAssetService Create(ShopifyApiCredentials credentials)
     {
         var service = new AssetService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IAssignedFulfillmentOrderServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IAssignedFulfillmentOrderService Create(ShopifyRestApiCredentials credentials);
+    IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
 public class AssignedFulfillmentOrderServiceFactory(
@@ -24,7 +24,7 @@ public class AssignedFulfillmentOrderServiceFactory(
     #endif
 ) : IAssignedFulfillmentOrderServiceFactory
 {
-    public virtual IAssignedFulfillmentOrderService Create(ShopifyRestApiCredentials credentials)
+    public virtual IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials)
     {
         var service = new AssignedFulfillmentOrderService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/BlogServiceFactory.cs
+++ b/ShopifySharp/Factories/BlogServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IBlogServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IBlogService Create(ShopifyRestApiCredentials credentials);
+    IBlogService Create(ShopifyApiCredentials credentials);
 }
 
 public class BlogServiceFactory(
@@ -24,7 +24,7 @@ public class BlogServiceFactory(
     #endif
 ) : IBlogServiceFactory
 {
-    public virtual IBlogService Create(ShopifyRestApiCredentials credentials)
+    public virtual IBlogService Create(ShopifyApiCredentials credentials)
     {
         var service = new BlogService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICancellationRequestServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICancellationRequestService Create(ShopifyRestApiCredentials credentials);
+    ICancellationRequestService Create(ShopifyApiCredentials credentials);
 }
 
 public class CancellationRequestServiceFactory(
@@ -24,7 +24,7 @@ public class CancellationRequestServiceFactory(
     #endif
 ) : ICancellationRequestServiceFactory
 {
-    public virtual ICancellationRequestService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICancellationRequestService Create(ShopifyApiCredentials credentials)
     {
         var service = new CancellationRequestService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CarrierServiceFactory.cs
+++ b/ShopifySharp/Factories/CarrierServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICarrierServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICarrierService Create(ShopifyRestApiCredentials credentials);
+    ICarrierService Create(ShopifyApiCredentials credentials);
 }
 
 public class CarrierServiceFactory(
@@ -24,7 +24,7 @@ public class CarrierServiceFactory(
     #endif
 ) : ICarrierServiceFactory
 {
-    public virtual ICarrierService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICarrierService Create(ShopifyApiCredentials credentials)
     {
         var service = new CarrierService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/ChargeServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IChargeServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IChargeService Create(ShopifyRestApiCredentials credentials);
+    IChargeService Create(ShopifyApiCredentials credentials);
 }
 
 public class ChargeServiceFactory(
@@ -24,7 +24,7 @@ public class ChargeServiceFactory(
     #endif
 ) : IChargeServiceFactory
 {
-    public virtual IChargeService Create(ShopifyRestApiCredentials credentials)
+    public virtual IChargeService Create(ShopifyApiCredentials credentials)
     {
         var service = new ChargeService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICheckoutSalesChannelServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICheckoutSalesChannelService Create(ShopifyRestApiCredentials credentials);
+    ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials);
 }
 
 public class CheckoutSalesChannelServiceFactory(
@@ -24,7 +24,7 @@ public class CheckoutSalesChannelServiceFactory(
     #endif
 ) : ICheckoutSalesChannelServiceFactory
 {
-    public virtual ICheckoutSalesChannelService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials)
     {
         var service = new CheckoutSalesChannelService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CheckoutServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICheckoutServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICheckoutService Create(ShopifyRestApiCredentials credentials);
+    ICheckoutService Create(ShopifyApiCredentials credentials);
 }
 
 public class CheckoutServiceFactory(
@@ -24,7 +24,7 @@ public class CheckoutServiceFactory(
     #endif
 ) : ICheckoutServiceFactory
 {
-    public virtual ICheckoutService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICheckoutService Create(ShopifyApiCredentials credentials)
     {
         var service = new CheckoutService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CollectServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICollectServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICollectService Create(ShopifyRestApiCredentials credentials);
+    ICollectService Create(ShopifyApiCredentials credentials);
 }
 
 public class CollectServiceFactory(
@@ -24,7 +24,7 @@ public class CollectServiceFactory(
     #endif
 ) : ICollectServiceFactory
 {
-    public virtual ICollectService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICollectService Create(ShopifyApiCredentials credentials)
     {
         var service = new CollectService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CollectionListingServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionListingServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICollectionListingServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICollectionListingService Create(ShopifyRestApiCredentials credentials);
+    ICollectionListingService Create(ShopifyApiCredentials credentials);
 }
 
 public class CollectionListingServiceFactory(
@@ -24,7 +24,7 @@ public class CollectionListingServiceFactory(
     #endif
 ) : ICollectionListingServiceFactory
 {
-    public virtual ICollectionListingService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICollectionListingService Create(ShopifyApiCredentials credentials)
     {
         var service = new CollectionListingService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICollectionServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICollectionService Create(ShopifyRestApiCredentials credentials);
+    ICollectionService Create(ShopifyApiCredentials credentials);
 }
 
 public class CollectionServiceFactory(
@@ -24,7 +24,7 @@ public class CollectionServiceFactory(
     #endif
 ) : ICollectionServiceFactory
 {
-    public virtual ICollectionService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICollectionService Create(ShopifyApiCredentials credentials)
     {
         var service = new CollectionService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CountryServiceFactory.cs
+++ b/ShopifySharp/Factories/CountryServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICountryServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICountryService Create(ShopifyRestApiCredentials credentials);
+    ICountryService Create(ShopifyApiCredentials credentials);
 }
 
 public class CountryServiceFactory(
@@ -24,7 +24,7 @@ public class CountryServiceFactory(
     #endif
 ) : ICountryServiceFactory
 {
-    public virtual ICountryService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICountryService Create(ShopifyApiCredentials credentials)
     {
         var service = new CountryService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICustomCollectionServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICustomCollectionService Create(ShopifyRestApiCredentials credentials);
+    ICustomCollectionService Create(ShopifyApiCredentials credentials);
 }
 
 public class CustomCollectionServiceFactory(
@@ -24,7 +24,7 @@ public class CustomCollectionServiceFactory(
     #endif
 ) : ICustomCollectionServiceFactory
 {
-    public virtual ICustomCollectionService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICustomCollectionService Create(ShopifyApiCredentials credentials)
     {
         var service = new CustomCollectionService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICustomerAddressServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICustomerAddressService Create(ShopifyRestApiCredentials credentials);
+    ICustomerAddressService Create(ShopifyApiCredentials credentials);
 }
 
 public class CustomerAddressServiceFactory(
@@ -24,7 +24,7 @@ public class CustomerAddressServiceFactory(
     #endif
 ) : ICustomerAddressServiceFactory
 {
-    public virtual ICustomerAddressService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICustomerAddressService Create(ShopifyApiCredentials credentials)
     {
         var service = new CustomerAddressService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICustomerSavedSearchServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICustomerSavedSearchService Create(ShopifyRestApiCredentials credentials);
+    ICustomerSavedSearchService Create(ShopifyApiCredentials credentials);
 }
 
 public class CustomerSavedSearchServiceFactory(
@@ -24,7 +24,7 @@ public class CustomerSavedSearchServiceFactory(
     #endif
 ) : ICustomerSavedSearchServiceFactory
 {
-    public virtual ICustomerSavedSearchService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICustomerSavedSearchService Create(ShopifyApiCredentials credentials)
     {
         var service = new CustomerSavedSearchService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/CustomerServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ICustomerServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ICustomerService Create(ShopifyRestApiCredentials credentials);
+    ICustomerService Create(ShopifyApiCredentials credentials);
 }
 
 public class CustomerServiceFactory(
@@ -24,7 +24,7 @@ public class CustomerServiceFactory(
     #endif
 ) : ICustomerServiceFactory
 {
-    public virtual ICustomerService Create(ShopifyRestApiCredentials credentials)
+    public virtual ICustomerService Create(ShopifyApiCredentials credentials)
     {
         var service = new CustomerService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
+++ b/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IDiscountCodeServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IDiscountCodeService Create(ShopifyRestApiCredentials credentials);
+    IDiscountCodeService Create(ShopifyApiCredentials credentials);
 }
 
 public class DiscountCodeServiceFactory(
@@ -24,7 +24,7 @@ public class DiscountCodeServiceFactory(
     #endif
 ) : IDiscountCodeServiceFactory
 {
-    public virtual IDiscountCodeService Create(ShopifyRestApiCredentials credentials)
+    public virtual IDiscountCodeService Create(ShopifyApiCredentials credentials)
     {
         var service = new DiscountCodeService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/DraftOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/DraftOrderServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IDraftOrderServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IDraftOrderService Create(ShopifyRestApiCredentials credentials);
+    IDraftOrderService Create(ShopifyApiCredentials credentials);
 }
 
 public class DraftOrderServiceFactory(
@@ -24,7 +24,7 @@ public class DraftOrderServiceFactory(
     #endif
 ) : IDraftOrderServiceFactory
 {
-    public virtual IDraftOrderService Create(ShopifyRestApiCredentials credentials)
+    public virtual IDraftOrderService Create(ShopifyApiCredentials credentials)
     {
         var service = new DraftOrderService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/EventServiceFactory.cs
+++ b/ShopifySharp/Factories/EventServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IEventServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IEventService Create(ShopifyRestApiCredentials credentials);
+    IEventService Create(ShopifyApiCredentials credentials);
 }
 
 public class EventServiceFactory(
@@ -24,7 +24,7 @@ public class EventServiceFactory(
     #endif
 ) : IEventServiceFactory
 {
-    public virtual IEventService Create(ShopifyRestApiCredentials credentials)
+    public virtual IEventService Create(ShopifyApiCredentials credentials)
     {
         var service = new EventService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IFulfillmentEventServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IFulfillmentEventService Create(ShopifyRestApiCredentials credentials);
+    IFulfillmentEventService Create(ShopifyApiCredentials credentials);
 }
 
 public class FulfillmentEventServiceFactory(
@@ -24,7 +24,7 @@ public class FulfillmentEventServiceFactory(
     #endif
 ) : IFulfillmentEventServiceFactory
 {
-    public virtual IFulfillmentEventService Create(ShopifyRestApiCredentials credentials)
+    public virtual IFulfillmentEventService Create(ShopifyApiCredentials credentials)
     {
         var service = new FulfillmentEventService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IFulfillmentOrderServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IFulfillmentOrderService Create(ShopifyRestApiCredentials credentials);
+    IFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
 public class FulfillmentOrderServiceFactory(
@@ -24,7 +24,7 @@ public class FulfillmentOrderServiceFactory(
     #endif
 ) : IFulfillmentOrderServiceFactory
 {
-    public virtual IFulfillmentOrderService Create(ShopifyRestApiCredentials credentials)
+    public virtual IFulfillmentOrderService Create(ShopifyApiCredentials credentials)
     {
         var service = new FulfillmentOrderService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IFulfillmentRequestServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IFulfillmentRequestService Create(ShopifyRestApiCredentials credentials);
+    IFulfillmentRequestService Create(ShopifyApiCredentials credentials);
 }
 
 public class FulfillmentRequestServiceFactory(
@@ -24,7 +24,7 @@ public class FulfillmentRequestServiceFactory(
     #endif
 ) : IFulfillmentRequestServiceFactory
 {
-    public virtual IFulfillmentRequestService Create(ShopifyRestApiCredentials credentials)
+    public virtual IFulfillmentRequestService Create(ShopifyApiCredentials credentials)
     {
         var service = new FulfillmentRequestService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/FulfillmentServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IFulfillmentServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IFulfillmentService Create(ShopifyRestApiCredentials credentials);
+    IFulfillmentService Create(ShopifyApiCredentials credentials);
 }
 
 public class FulfillmentServiceFactory(
@@ -24,7 +24,7 @@ public class FulfillmentServiceFactory(
     #endif
 ) : IFulfillmentServiceFactory
 {
-    public virtual IFulfillmentService Create(ShopifyRestApiCredentials credentials)
+    public virtual IFulfillmentService Create(ShopifyApiCredentials credentials)
     {
         var service = new FulfillmentService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IFulfillmentServiceServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IFulfillmentServiceService Create(ShopifyRestApiCredentials credentials);
+    IFulfillmentServiceService Create(ShopifyApiCredentials credentials);
 }
 
 public class FulfillmentServiceServiceFactory(
@@ -24,7 +24,7 @@ public class FulfillmentServiceServiceFactory(
     #endif
 ) : IFulfillmentServiceServiceFactory
 {
-    public virtual IFulfillmentServiceService Create(ShopifyRestApiCredentials credentials)
+    public virtual IFulfillmentServiceService Create(ShopifyApiCredentials credentials)
     {
         var service = new FulfillmentServiceService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IGiftCardAdjustmentServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IGiftCardAdjustmentService Create(ShopifyRestApiCredentials credentials);
+    IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials);
 }
 
 public class GiftCardAdjustmentServiceFactory(
@@ -24,7 +24,7 @@ public class GiftCardAdjustmentServiceFactory(
     #endif
 ) : IGiftCardAdjustmentServiceFactory
 {
-    public virtual IGiftCardAdjustmentService Create(ShopifyRestApiCredentials credentials)
+    public virtual IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials)
     {
         var service = new GiftCardAdjustmentService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/GiftCardServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IGiftCardServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IGiftCardService Create(ShopifyRestApiCredentials credentials);
+    IGiftCardService Create(ShopifyApiCredentials credentials);
 }
 
 public class GiftCardServiceFactory(
@@ -24,7 +24,7 @@ public class GiftCardServiceFactory(
     #endif
 ) : IGiftCardServiceFactory
 {
-    public virtual IGiftCardService Create(ShopifyRestApiCredentials credentials)
+    public virtual IGiftCardService Create(ShopifyApiCredentials credentials)
     {
         var service = new GiftCardService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/GraphServiceFactory.cs
+++ b/ShopifySharp/Factories/GraphServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IGraphServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IGraphService Create(ShopifyRestApiCredentials credentials);
+    IGraphService Create(ShopifyApiCredentials credentials);
 }
 
 public class GraphServiceFactory(
@@ -24,7 +24,7 @@ public class GraphServiceFactory(
     #endif
 ) : IGraphServiceFactory
 {
-    public virtual IGraphService Create(ShopifyRestApiCredentials credentials)
+    public virtual IGraphService Create(ShopifyApiCredentials credentials)
     {
         var service = new GraphService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/InventoryItemServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryItemServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IInventoryItemServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IInventoryItemService Create(ShopifyRestApiCredentials credentials);
+    IInventoryItemService Create(ShopifyApiCredentials credentials);
 }
 
 public class InventoryItemServiceFactory(
@@ -24,7 +24,7 @@ public class InventoryItemServiceFactory(
     #endif
 ) : IInventoryItemServiceFactory
 {
-    public virtual IInventoryItemService Create(ShopifyRestApiCredentials credentials)
+    public virtual IInventoryItemService Create(ShopifyApiCredentials credentials)
     {
         var service = new InventoryItemService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IInventoryLevelServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IInventoryLevelService Create(ShopifyRestApiCredentials credentials);
+    IInventoryLevelService Create(ShopifyApiCredentials credentials);
 }
 
 public class InventoryLevelServiceFactory(
@@ -24,7 +24,7 @@ public class InventoryLevelServiceFactory(
     #endif
 ) : IInventoryLevelServiceFactory
 {
-    public virtual IInventoryLevelService Create(ShopifyRestApiCredentials credentials)
+    public virtual IInventoryLevelService Create(ShopifyApiCredentials credentials)
     {
         var service = new InventoryLevelService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/LocationServiceFactory.cs
+++ b/ShopifySharp/Factories/LocationServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ILocationServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ILocationService Create(ShopifyRestApiCredentials credentials);
+    ILocationService Create(ShopifyApiCredentials credentials);
 }
 
 public class LocationServiceFactory(
@@ -24,7 +24,7 @@ public class LocationServiceFactory(
     #endif
 ) : ILocationServiceFactory
 {
-    public virtual ILocationService Create(ShopifyRestApiCredentials credentials)
+    public virtual ILocationService Create(ShopifyApiCredentials credentials)
     {
         var service = new LocationService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/MetaFieldServiceFactory.cs
+++ b/ShopifySharp/Factories/MetaFieldServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IMetaFieldServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IMetaFieldService Create(ShopifyRestApiCredentials credentials);
+    IMetaFieldService Create(ShopifyApiCredentials credentials);
 }
 
 public class MetaFieldServiceFactory(
@@ -24,7 +24,7 @@ public class MetaFieldServiceFactory(
     #endif
 ) : IMetaFieldServiceFactory
 {
-    public virtual IMetaFieldService Create(ShopifyRestApiCredentials credentials)
+    public virtual IMetaFieldService Create(ShopifyApiCredentials credentials)
     {
         var service = new MetaFieldService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/OrderRiskServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderRiskServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IOrderRiskServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IOrderRiskService Create(ShopifyRestApiCredentials credentials);
+    IOrderRiskService Create(ShopifyApiCredentials credentials);
 }
 
 public class OrderRiskServiceFactory(
@@ -24,7 +24,7 @@ public class OrderRiskServiceFactory(
     #endif
 ) : IOrderRiskServiceFactory
 {
-    public virtual IOrderRiskService Create(ShopifyRestApiCredentials credentials)
+    public virtual IOrderRiskService Create(ShopifyApiCredentials credentials)
     {
         var service = new OrderRiskService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/OrderServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IOrderServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IOrderService Create(ShopifyRestApiCredentials credentials);
+    IOrderService Create(ShopifyApiCredentials credentials);
 }
 
 public class OrderServiceFactory(
@@ -24,7 +24,7 @@ public class OrderServiceFactory(
     #endif
 ) : IOrderServiceFactory
 {
-    public virtual IOrderService Create(ShopifyRestApiCredentials credentials)
+    public virtual IOrderService Create(ShopifyApiCredentials credentials)
     {
         var service = new OrderService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/PageServiceFactory.cs
+++ b/ShopifySharp/Factories/PageServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IPageServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IPageService Create(ShopifyRestApiCredentials credentials);
+    IPageService Create(ShopifyApiCredentials credentials);
 }
 
 public class PageServiceFactory(
@@ -24,7 +24,7 @@ public class PageServiceFactory(
     #endif
 ) : IPageServiceFactory
 {
-    public virtual IPageService Create(ShopifyRestApiCredentials credentials)
+    public virtual IPageService Create(ShopifyApiCredentials credentials)
     {
         var service = new PageService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/PolicyServiceFactory.cs
+++ b/ShopifySharp/Factories/PolicyServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IPolicyServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IPolicyService Create(ShopifyRestApiCredentials credentials);
+    IPolicyService Create(ShopifyApiCredentials credentials);
 }
 
 public class PolicyServiceFactory(
@@ -24,7 +24,7 @@ public class PolicyServiceFactory(
     #endif
 ) : IPolicyServiceFactory
 {
-    public virtual IPolicyService Create(ShopifyRestApiCredentials credentials)
+    public virtual IPolicyService Create(ShopifyApiCredentials credentials)
     {
         var service = new PolicyService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/PriceRuleServiceFactory.cs
+++ b/ShopifySharp/Factories/PriceRuleServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IPriceRuleServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IPriceRuleService Create(ShopifyRestApiCredentials credentials);
+    IPriceRuleService Create(ShopifyApiCredentials credentials);
 }
 
 public class PriceRuleServiceFactory(
@@ -24,7 +24,7 @@ public class PriceRuleServiceFactory(
     #endif
 ) : IPriceRuleServiceFactory
 {
-    public virtual IPriceRuleService Create(ShopifyRestApiCredentials credentials)
+    public virtual IPriceRuleService Create(ShopifyApiCredentials credentials)
     {
         var service = new PriceRuleService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ProductImageServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductImageServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IProductImageServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IProductImageService Create(ShopifyRestApiCredentials credentials);
+    IProductImageService Create(ShopifyApiCredentials credentials);
 }
 
 public class ProductImageServiceFactory(
@@ -24,7 +24,7 @@ public class ProductImageServiceFactory(
     #endif
 ) : IProductImageServiceFactory
 {
-    public virtual IProductImageService Create(ShopifyRestApiCredentials credentials)
+    public virtual IProductImageService Create(ShopifyApiCredentials credentials)
     {
         var service = new ProductImageService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ProductListingServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductListingServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IProductListingServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IProductListingService Create(ShopifyRestApiCredentials credentials);
+    IProductListingService Create(ShopifyApiCredentials credentials);
 }
 
 public class ProductListingServiceFactory(
@@ -24,7 +24,7 @@ public class ProductListingServiceFactory(
     #endif
 ) : IProductListingServiceFactory
 {
-    public virtual IProductListingService Create(ShopifyRestApiCredentials credentials)
+    public virtual IProductListingService Create(ShopifyApiCredentials credentials)
     {
         var service = new ProductListingService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ProductVariantServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductVariantServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IProductVariantServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IProductVariantService Create(ShopifyRestApiCredentials credentials);
+    IProductVariantService Create(ShopifyApiCredentials credentials);
 }
 
 public class ProductVariantServiceFactory(
@@ -24,7 +24,7 @@ public class ProductVariantServiceFactory(
     #endif
 ) : IProductVariantServiceFactory
 {
-    public virtual IProductVariantService Create(ShopifyRestApiCredentials credentials)
+    public virtual IProductVariantService Create(ShopifyApiCredentials credentials)
     {
         var service = new ProductVariantService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IRecurringChargeServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IRecurringChargeService Create(ShopifyRestApiCredentials credentials);
+    IRecurringChargeService Create(ShopifyApiCredentials credentials);
 }
 
 public class RecurringChargeServiceFactory(
@@ -24,7 +24,7 @@ public class RecurringChargeServiceFactory(
     #endif
 ) : IRecurringChargeServiceFactory
 {
-    public virtual IRecurringChargeService Create(ShopifyRestApiCredentials credentials)
+    public virtual IRecurringChargeService Create(ShopifyApiCredentials credentials)
     {
         var service = new RecurringChargeService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/RedirectServiceFactory.cs
+++ b/ShopifySharp/Factories/RedirectServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IRedirectServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IRedirectService Create(ShopifyRestApiCredentials credentials);
+    IRedirectService Create(ShopifyApiCredentials credentials);
 }
 
 public class RedirectServiceFactory(
@@ -24,7 +24,7 @@ public class RedirectServiceFactory(
     #endif
 ) : IRedirectServiceFactory
 {
-    public virtual IRedirectService Create(ShopifyRestApiCredentials credentials)
+    public virtual IRedirectService Create(ShopifyApiCredentials credentials)
     {
         var service = new RedirectService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/RefundServiceFactory.cs
+++ b/ShopifySharp/Factories/RefundServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IRefundServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IRefundService Create(ShopifyRestApiCredentials credentials);
+    IRefundService Create(ShopifyApiCredentials credentials);
 }
 
 public class RefundServiceFactory(
@@ -24,7 +24,7 @@ public class RefundServiceFactory(
     #endif
 ) : IRefundServiceFactory
 {
-    public virtual IRefundService Create(ShopifyRestApiCredentials credentials)
+    public virtual IRefundService Create(ShopifyApiCredentials credentials)
     {
         var service = new RefundService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ScriptTagServiceFactory.cs
+++ b/ShopifySharp/Factories/ScriptTagServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IScriptTagServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IScriptTagService Create(ShopifyRestApiCredentials credentials);
+    IScriptTagService Create(ShopifyApiCredentials credentials);
 }
 
 public class ScriptTagServiceFactory(
@@ -24,7 +24,7 @@ public class ScriptTagServiceFactory(
     #endif
 ) : IScriptTagServiceFactory
 {
-    public virtual IScriptTagService Create(ShopifyRestApiCredentials credentials)
+    public virtual IScriptTagService Create(ShopifyApiCredentials credentials)
     {
         var service = new ScriptTagService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
+++ b/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IShippingZoneServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IShippingZoneService Create(ShopifyRestApiCredentials credentials);
+    IShippingZoneService Create(ShopifyApiCredentials credentials);
 }
 
 public class ShippingZoneServiceFactory(
@@ -24,7 +24,7 @@ public class ShippingZoneServiceFactory(
     #endif
 ) : IShippingZoneServiceFactory
 {
-    public virtual IShippingZoneService Create(ShopifyRestApiCredentials credentials)
+    public virtual IShippingZoneService Create(ShopifyApiCredentials credentials)
     {
         var service = new ShippingZoneService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ShopServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IShopServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IShopService Create(ShopifyRestApiCredentials credentials);
+    IShopService Create(ShopifyApiCredentials credentials);
 }
 
 public class ShopServiceFactory(
@@ -24,7 +24,7 @@ public class ShopServiceFactory(
     #endif
 ) : IShopServiceFactory
 {
-    public virtual IShopService Create(ShopifyRestApiCredentials credentials)
+    public virtual IShopService Create(ShopifyApiCredentials credentials)
     {
         var service = new ShopService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IShopifyPaymentsServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IShopifyPaymentsService Create(ShopifyRestApiCredentials credentials);
+    IShopifyPaymentsService Create(ShopifyApiCredentials credentials);
 }
 
 public class ShopifyPaymentsServiceFactory(
@@ -24,7 +24,7 @@ public class ShopifyPaymentsServiceFactory(
     #endif
 ) : IShopifyPaymentsServiceFactory
 {
-    public virtual IShopifyPaymentsService Create(ShopifyRestApiCredentials credentials)
+    public virtual IShopifyPaymentsService Create(ShopifyApiCredentials credentials)
     {
         var service = new ShopifyPaymentsService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ISmartCollectionServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ISmartCollectionService Create(ShopifyRestApiCredentials credentials);
+    ISmartCollectionService Create(ShopifyApiCredentials credentials);
 }
 
 public class SmartCollectionServiceFactory(
@@ -24,7 +24,7 @@ public class SmartCollectionServiceFactory(
     #endif
 ) : ISmartCollectionServiceFactory
 {
-    public virtual ISmartCollectionService Create(ShopifyRestApiCredentials credentials)
+    public virtual ISmartCollectionService Create(ShopifyApiCredentials credentials)
     {
         var service = new SmartCollectionService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
+++ b/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IStorefrontAccessTokenServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IStorefrontAccessTokenService Create(ShopifyRestApiCredentials credentials);
+    IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials);
 }
 
 public class StorefrontAccessTokenServiceFactory(
@@ -24,7 +24,7 @@ public class StorefrontAccessTokenServiceFactory(
     #endif
 ) : IStorefrontAccessTokenServiceFactory
 {
-    public virtual IStorefrontAccessTokenService Create(ShopifyRestApiCredentials credentials)
+    public virtual IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials)
     {
         var service = new StorefrontAccessTokenService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ITenderTransactionServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ITenderTransactionService Create(ShopifyRestApiCredentials credentials);
+    ITenderTransactionService Create(ShopifyApiCredentials credentials);
 }
 
 public class TenderTransactionServiceFactory(
@@ -24,7 +24,7 @@ public class TenderTransactionServiceFactory(
     #endif
 ) : ITenderTransactionServiceFactory
 {
-    public virtual ITenderTransactionService Create(ShopifyRestApiCredentials credentials)
+    public virtual ITenderTransactionService Create(ShopifyApiCredentials credentials)
     {
         var service = new TenderTransactionService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/ThemeServiceFactory.cs
+++ b/ShopifySharp/Factories/ThemeServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IThemeServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IThemeService Create(ShopifyRestApiCredentials credentials);
+    IThemeService Create(ShopifyApiCredentials credentials);
 }
 
 public class ThemeServiceFactory(
@@ -24,7 +24,7 @@ public class ThemeServiceFactory(
     #endif
 ) : IThemeServiceFactory
 {
-    public virtual IThemeService Create(ShopifyRestApiCredentials credentials)
+    public virtual IThemeService Create(ShopifyApiCredentials credentials)
     {
         var service = new ThemeService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/TransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TransactionServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface ITransactionServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    ITransactionService Create(ShopifyRestApiCredentials credentials);
+    ITransactionService Create(ShopifyApiCredentials credentials);
 }
 
 public class TransactionServiceFactory(
@@ -24,7 +24,7 @@ public class TransactionServiceFactory(
     #endif
 ) : ITransactionServiceFactory
 {
-    public virtual ITransactionService Create(ShopifyRestApiCredentials credentials)
+    public virtual ITransactionService Create(ShopifyApiCredentials credentials)
     {
         var service = new TransactionService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/UsageChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/UsageChargeServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IUsageChargeServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IUsageChargeService Create(ShopifyRestApiCredentials credentials);
+    IUsageChargeService Create(ShopifyApiCredentials credentials);
 }
 
 public class UsageChargeServiceFactory(
@@ -24,7 +24,7 @@ public class UsageChargeServiceFactory(
     #endif
 ) : IUsageChargeServiceFactory
 {
-    public virtual IUsageChargeService Create(ShopifyRestApiCredentials credentials)
+    public virtual IUsageChargeService Create(ShopifyApiCredentials credentials)
     {
         var service = new UsageChargeService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/UserServiceFactory.cs
+++ b/ShopifySharp/Factories/UserServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IUserServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IUserService Create(ShopifyRestApiCredentials credentials);
+    IUserService Create(ShopifyApiCredentials credentials);
 }
 
 public class UserServiceFactory(
@@ -24,7 +24,7 @@ public class UserServiceFactory(
     #endif
 ) : IUserServiceFactory
 {
-    public virtual IUserService Create(ShopifyRestApiCredentials credentials)
+    public virtual IUserService Create(ShopifyApiCredentials credentials)
     {
         var service = new UserService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/WebhookServiceFactory.cs
+++ b/ShopifySharp/Factories/WebhookServiceFactory.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface IWebhookServiceFactory
 {
     // ReSharper disable once UnusedMember.Global
-    IWebhookService Create(ShopifyRestApiCredentials credentials);
+    IWebhookService Create(ShopifyApiCredentials credentials);
 }
 
 public class WebhookServiceFactory(
@@ -24,7 +24,7 @@ public class WebhookServiceFactory(
     #endif
 ) : IWebhookServiceFactory
 {
-    public virtual IWebhookService Create(ShopifyRestApiCredentials credentials)
+    public virtual IWebhookService Create(ShopifyApiCredentials credentials)
     {
         var service = new WebhookService(credentials.ShopDomain, credentials.AccessToken);
 

--- a/ShopifySharp/Factories/factory-service-template.txt
+++ b/ShopifySharp/Factories/factory-service-template.txt
@@ -13,7 +13,7 @@ namespace ShopifySharp.Factories;
 public interface I@@REPLACEME@@Factory
 {
     // ReSharper disable once UnusedMember.Global
-    I@@REPLACEME@@ Create(ShopifyRestApiCredentials credentials);
+    I@@REPLACEME@@ Create(ShopifyApiCredentials credentials);
 }
 
 public class @@REPLACEME@@Factory(
@@ -24,7 +24,7 @@ public class @@REPLACEME@@Factory(
     #endif
 ) : I@@REPLACEME@@Factory
 {
-    public virtual I@@REPLACEME@@ Create(ShopifyRestApiCredentials credentials)
+    public virtual I@@REPLACEME@@ Create(ShopifyApiCredentials credentials)
     {
         var service = new @@REPLACEME@@(credentials.ShopDomain, credentials.AccessToken);
 


### PR DESCRIPTION
This pull request renames the `ShopifyRestApiCredentials` struct to `ShopifyApiCredentials`. I thought I was going to need three to four different structs to hold different credential types, but it turns out we really only need two: one for the partner credentials (organization id + access token), and one for basically everything else (shop domain + access token).

That in mind, I'm going to quickly rename the struct to `ShopifyApiCredentials` while it's brand new so it can be used with the graph service without feeling awkward.