### PR TITLE
Add `factory.Create(string shopDomain, string accessToken)` overload to all service factories

### DIFF
--- a/ShopifySharp.Tests/Factories/OrderServiceFactoryTest.cs
+++ b/ShopifySharp.Tests/Factories/OrderServiceFactoryTest.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Credentials;
+using ShopifySharp.Factories;
+using Xunit;
+
+namespace ShopifySharp.Tests.Factories;
+
+[TestSubject(typeof(OrderServiceFactory))]
+[Trait("Category", "Factories")]
+public class OrderServiceFactoryTest
+{
+    private const string ShopDomain = "some-shop-domain";
+    private const string AccessToken = "some-access-token";
+
+    private readonly OrderServiceFactory _factory = new();
+
+    [Fact]
+    public void Create_ReturnsTheService()
+    {
+        // Act
+        var service = _factory.Create(ShopDomain, AccessToken);
+
+        // Assert
+        service.Should().NotBeNull();
+        service.Should().BeOfType<OrderService>().And.BeAssignableTo<IOrderService>();
+    }
+
+    [Fact]
+    public void Create_WhenGivenShopifyPartnerApiCredentials_ReturnsTheService()
+    {
+        // Setup
+        var credentials = new ShopifyApiCredentials(ShopDomain, AccessToken);
+
+        // Act
+        var service = _factory.Create(credentials);
+
+        // Assert
+        service.Should().NotBeNull();
+        service.Should().BeOfType<OrderService>().And.BeAssignableTo<IOrderService>();
+    }
+}

--- a/ShopifySharp.Tests/Factories/PartnerServiceFactoryTest.cs
+++ b/ShopifySharp.Tests/Factories/PartnerServiceFactoryTest.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Credentials;
+using ShopifySharp.Factories;
+using Xunit;
+
+namespace ShopifySharp.Tests.Factories;
+
+[TestSubject(typeof(PartnerServiceFactory))]
+[Trait("Category", "Factories")]
+public class PartnerServiceFactoryTest
+{
+    private const long OrganizationId = 123L;
+    private const string AccessToken = "some-access-token";
+
+    private readonly PartnerServiceFactory _factory = new();
+
+    [Fact]
+    public void Create_ReturnsTheService()
+    {
+        // Act
+        var service = _factory.Create(OrganizationId, AccessToken);
+
+        // Assert
+        service.Should().NotBeNull();
+        service.Should().BeOfType<PartnerService>().And.BeAssignableTo<IPartnerService>();
+    }
+
+    [Fact]
+    public void Create_WhenGivenShopifyPartnerApiCredentials_ReturnsTheService()
+    {
+        // Setup
+        var credentials = new ShopifyPartnerApiCredentials(OrganizationId, AccessToken);
+
+        // Act
+        var service = _factory.Create(credentials);
+
+        // Assert
+        service.Should().NotBeNull();
+        service.Should().BeOfType<PartnerService>().And.BeAssignableTo<IPartnerService>();
+    }
+}

--- a/ShopifySharp/Factories/AccessScopeServiceFactory.cs
+++ b/ShopifySharp/Factories/AccessScopeServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IAccessScopeServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IAccessScopeService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IAccessScopeService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IAccessScopeService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IAccessScopeService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class AccessScopeServiceFactory(
     #endif
 ) : IAccessScopeServiceFactory
 {
-    public virtual IAccessScopeService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IAccessScopeService Create(string shopDomain, string accessToken)
     {
-        var service = new AccessScopeService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new AccessScopeService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class AccessScopeServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IAccessScopeService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/AccessScopeServiceFactory.cs
+++ b/ShopifySharp/Factories/AccessScopeServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IAccessScopeServiceFactory
     IAccessScopeService Create(ShopifyApiCredentials credentials);
 }
 
-public class AccessScopeServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IAccessScopeServiceFactory
+public class AccessScopeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IAccessScopeServiceFactory
 {
     /// <inheritDoc />
     public virtual IAccessScopeService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
+++ b/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IApplicationCreditServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IApplicationCreditService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IApplicationCreditService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IApplicationCreditService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IApplicationCreditService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ApplicationCreditServiceFactory(
     #endif
 ) : IApplicationCreditServiceFactory
 {
-    public virtual IApplicationCreditService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IApplicationCreditService Create(string shopDomain, string accessToken)
     {
-        var service = new ApplicationCreditService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ApplicationCreditService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ApplicationCreditServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IApplicationCreditService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
+++ b/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IApplicationCreditServiceFactory
     IApplicationCreditService Create(ShopifyApiCredentials credentials);
 }
 
-public class ApplicationCreditServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IApplicationCreditServiceFactory
+public class ApplicationCreditServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IApplicationCreditServiceFactory
 {
     /// <inheritDoc />
     public virtual IApplicationCreditService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ArticleServiceFactory.cs
+++ b/ShopifySharp/Factories/ArticleServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IArticleServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IArticleService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IArticleService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IArticleService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IArticleService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ArticleServiceFactory(
     #endif
 ) : IArticleServiceFactory
 {
-    public virtual IArticleService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IArticleService Create(string shopDomain, string accessToken)
     {
-        var service = new ArticleService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ArticleService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ArticleServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IArticleService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ArticleServiceFactory.cs
+++ b/ShopifySharp/Factories/ArticleServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IArticleServiceFactory
     IArticleService Create(ShopifyApiCredentials credentials);
 }
 
-public class ArticleServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IArticleServiceFactory
+public class ArticleServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IArticleServiceFactory
 {
     /// <inheritDoc />
     public virtual IArticleService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/AssetServiceFactory.cs
+++ b/ShopifySharp/Factories/AssetServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IAssetServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IAssetService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IAssetService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IAssetService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IAssetService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class AssetServiceFactory(
     #endif
 ) : IAssetServiceFactory
 {
-    public virtual IAssetService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IAssetService Create(string shopDomain, string accessToken)
     {
-        var service = new AssetService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new AssetService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class AssetServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IAssetService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/AssetServiceFactory.cs
+++ b/ShopifySharp/Factories/AssetServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IAssetServiceFactory
     IAssetService Create(ShopifyApiCredentials credentials);
 }
 
-public class AssetServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IAssetServiceFactory
+public class AssetServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IAssetServiceFactory
 {
     /// <inheritDoc />
     public virtual IAssetService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IAssignedFulfillmentOrderServiceFactory
     IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class AssignedFulfillmentOrderServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IAssignedFulfillmentOrderServiceFactory
+public class AssignedFulfillmentOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IAssignedFulfillmentOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IAssignedFulfillmentOrderService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IAssignedFulfillmentOrderServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IAssignedFulfillmentOrderService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IAssignedFulfillmentOrderService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IAssignedFulfillmentOrderService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class AssignedFulfillmentOrderServiceFactory(
     #endif
 ) : IAssignedFulfillmentOrderServiceFactory
 {
-    public virtual IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IAssignedFulfillmentOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new AssignedFulfillmentOrderService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new AssignedFulfillmentOrderService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class AssignedFulfillmentOrderServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/BlogServiceFactory.cs
+++ b/ShopifySharp/Factories/BlogServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IBlogServiceFactory
     IBlogService Create(ShopifyApiCredentials credentials);
 }
 
-public class BlogServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IBlogServiceFactory
+public class BlogServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IBlogServiceFactory
 {
     /// <inheritDoc />
     public virtual IBlogService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/BlogServiceFactory.cs
+++ b/ShopifySharp/Factories/BlogServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IBlogServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IBlogService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IBlogService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IBlogService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IBlogService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class BlogServiceFactory(
     #endif
 ) : IBlogServiceFactory
 {
-    public virtual IBlogService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IBlogService Create(string shopDomain, string accessToken)
     {
-        var service = new BlogService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new BlogService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class BlogServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IBlogService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICancellationRequestServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICancellationRequestService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICancellationRequestService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICancellationRequestService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICancellationRequestService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CancellationRequestServiceFactory(
     #endif
 ) : ICancellationRequestServiceFactory
 {
-    public virtual ICancellationRequestService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICancellationRequestService Create(string shopDomain, string accessToken)
     {
-        var service = new CancellationRequestService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CancellationRequestService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CancellationRequestServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICancellationRequestService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICancellationRequestServiceFactory
     ICancellationRequestService Create(ShopifyApiCredentials credentials);
 }
 
-public class CancellationRequestServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICancellationRequestServiceFactory
+public class CancellationRequestServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICancellationRequestServiceFactory
 {
     /// <inheritDoc />
     public virtual ICancellationRequestService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CarrierServiceFactory.cs
+++ b/ShopifySharp/Factories/CarrierServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICarrierServiceFactory
     ICarrierService Create(ShopifyApiCredentials credentials);
 }
 
-public class CarrierServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICarrierServiceFactory
+public class CarrierServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICarrierServiceFactory
 {
     /// <inheritDoc />
     public virtual ICarrierService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CarrierServiceFactory.cs
+++ b/ShopifySharp/Factories/CarrierServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICarrierServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICarrierService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICarrierService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICarrierService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICarrierService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CarrierServiceFactory(
     #endif
 ) : ICarrierServiceFactory
 {
-    public virtual ICarrierService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICarrierService Create(string shopDomain, string accessToken)
     {
-        var service = new CarrierService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CarrierService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CarrierServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICarrierService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/ChargeServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IChargeServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IChargeService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IChargeService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IChargeService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IChargeService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ChargeServiceFactory(
     #endif
 ) : IChargeServiceFactory
 {
-    public virtual IChargeService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IChargeService Create(string shopDomain, string accessToken)
     {
-        var service = new ChargeService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ChargeService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ChargeServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IChargeService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/ChargeServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IChargeServiceFactory
     IChargeService Create(ShopifyApiCredentials credentials);
 }
 
-public class ChargeServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IChargeServiceFactory
+public class ChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IChargeServiceFactory
 {
     /// <inheritDoc />
     public virtual IChargeService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICheckoutSalesChannelServiceFactory
     ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials);
 }
 
-public class CheckoutSalesChannelServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICheckoutSalesChannelServiceFactory
+public class CheckoutSalesChannelServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICheckoutSalesChannelServiceFactory
 {
     /// <inheritDoc />
     public virtual ICheckoutSalesChannelService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICheckoutSalesChannelServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICheckoutSalesChannelService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICheckoutSalesChannelService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICheckoutSalesChannelService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CheckoutSalesChannelServiceFactory(
     #endif
 ) : ICheckoutSalesChannelServiceFactory
 {
-    public virtual ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICheckoutSalesChannelService Create(string shopDomain, string accessToken)
     {
-        var service = new CheckoutSalesChannelService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CheckoutSalesChannelService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CheckoutSalesChannelServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CheckoutServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICheckoutServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICheckoutService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICheckoutService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICheckoutService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICheckoutService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CheckoutServiceFactory(
     #endif
 ) : ICheckoutServiceFactory
 {
-    public virtual ICheckoutService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICheckoutService Create(string shopDomain, string accessToken)
     {
-        var service = new CheckoutService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CheckoutService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CheckoutServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICheckoutService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CheckoutServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICheckoutServiceFactory
     ICheckoutService Create(ShopifyApiCredentials credentials);
 }
 
-public class CheckoutServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICheckoutServiceFactory
+public class CheckoutServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICheckoutServiceFactory
 {
     /// <inheritDoc />
     public virtual ICheckoutService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CollectServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICollectServiceFactory
     ICollectService Create(ShopifyApiCredentials credentials);
 }
 
-public class CollectServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICollectServiceFactory
+public class CollectServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICollectServiceFactory
 {
     /// <inheritDoc />
     public virtual ICollectService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CollectServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICollectServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICollectService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICollectService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICollectService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICollectService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CollectServiceFactory(
     #endif
 ) : ICollectServiceFactory
 {
-    public virtual ICollectService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICollectService Create(string shopDomain, string accessToken)
     {
-        var service = new CollectService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CollectService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CollectServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICollectService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CollectionListingServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionListingServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICollectionListingServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICollectionListingService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICollectionListingService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICollectionListingService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICollectionListingService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CollectionListingServiceFactory(
     #endif
 ) : ICollectionListingServiceFactory
 {
-    public virtual ICollectionListingService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICollectionListingService Create(string shopDomain, string accessToken)
     {
-        var service = new CollectionListingService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CollectionListingService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CollectionListingServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICollectionListingService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CollectionListingServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionListingServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICollectionListingServiceFactory
     ICollectionListingService Create(ShopifyApiCredentials credentials);
 }
 
-public class CollectionListingServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICollectionListingServiceFactory
+public class CollectionListingServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICollectionListingServiceFactory
 {
     /// <inheritDoc />
     public virtual ICollectionListingService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICollectionServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICollectionService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICollectionService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICollectionService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICollectionService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CollectionServiceFactory(
     #endif
 ) : ICollectionServiceFactory
 {
-    public virtual ICollectionService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICollectionService Create(string shopDomain, string accessToken)
     {
-        var service = new CollectionService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CollectionService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CollectionServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICollectionService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICollectionServiceFactory
     ICollectionService Create(ShopifyApiCredentials credentials);
 }
 
-public class CollectionServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICollectionServiceFactory
+public class CollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICollectionServiceFactory
 {
     /// <inheritDoc />
     public virtual ICollectionService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CountryServiceFactory.cs
+++ b/ShopifySharp/Factories/CountryServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICountryServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICountryService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICountryService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICountryService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICountryService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CountryServiceFactory(
     #endif
 ) : ICountryServiceFactory
 {
-    public virtual ICountryService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICountryService Create(string shopDomain, string accessToken)
     {
-        var service = new CountryService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CountryService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CountryServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICountryService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CountryServiceFactory.cs
+++ b/ShopifySharp/Factories/CountryServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICountryServiceFactory
     ICountryService Create(ShopifyApiCredentials credentials);
 }
 
-public class CountryServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICountryServiceFactory
+public class CountryServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICountryServiceFactory
 {
     /// <inheritDoc />
     public virtual ICountryService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICustomCollectionServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICustomCollectionService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICustomCollectionService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICustomCollectionService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICustomCollectionService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CustomCollectionServiceFactory(
     #endif
 ) : ICustomCollectionServiceFactory
 {
-    public virtual ICustomCollectionService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICustomCollectionService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomCollectionService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CustomCollectionService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CustomCollectionServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICustomCollectionService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICustomCollectionServiceFactory
     ICustomCollectionService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomCollectionServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICustomCollectionServiceFactory
+public class CustomCollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomCollectionServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomCollectionService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICustomerAddressServiceFactory
     ICustomerAddressService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomerAddressServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICustomerAddressServiceFactory
+public class CustomerAddressServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomerAddressServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomerAddressService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICustomerAddressServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICustomerAddressService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICustomerAddressService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICustomerAddressService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICustomerAddressService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CustomerAddressServiceFactory(
     #endif
 ) : ICustomerAddressServiceFactory
 {
-    public virtual ICustomerAddressService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICustomerAddressService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomerAddressService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CustomerAddressService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CustomerAddressServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICustomerAddressService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICustomerSavedSearchServiceFactory
     ICustomerSavedSearchService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomerSavedSearchServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICustomerSavedSearchServiceFactory
+public class CustomerSavedSearchServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomerSavedSearchServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomerSavedSearchService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICustomerSavedSearchServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICustomerSavedSearchService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICustomerSavedSearchService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICustomerSavedSearchService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICustomerSavedSearchService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CustomerSavedSearchServiceFactory(
     #endif
 ) : ICustomerSavedSearchServiceFactory
 {
-    public virtual ICustomerSavedSearchService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICustomerSavedSearchService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomerSavedSearchService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CustomerSavedSearchService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CustomerSavedSearchServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICustomerSavedSearchService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CustomerServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ICustomerServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ICustomerService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ICustomerService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ICustomerService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ICustomerService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class CustomerServiceFactory(
     #endif
 ) : ICustomerServiceFactory
 {
-    public virtual ICustomerService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ICustomerService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomerService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new CustomerService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class CustomerServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ICustomerService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/CustomerServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ICustomerServiceFactory
     ICustomerService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomerServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ICustomerServiceFactory
+public class CustomerServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomerServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomerService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
+++ b/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IDiscountCodeServiceFactory
     IDiscountCodeService Create(ShopifyApiCredentials credentials);
 }
 
-public class DiscountCodeServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IDiscountCodeServiceFactory
+public class DiscountCodeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IDiscountCodeServiceFactory
 {
     /// <inheritDoc />
     public virtual IDiscountCodeService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
+++ b/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IDiscountCodeServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IDiscountCodeService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IDiscountCodeService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IDiscountCodeService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IDiscountCodeService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class DiscountCodeServiceFactory(
     #endif
 ) : IDiscountCodeServiceFactory
 {
-    public virtual IDiscountCodeService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IDiscountCodeService Create(string shopDomain, string accessToken)
     {
-        var service = new DiscountCodeService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new DiscountCodeService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class DiscountCodeServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IDiscountCodeService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/DraftOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/DraftOrderServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IDraftOrderServiceFactory
     IDraftOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class DraftOrderServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IDraftOrderServiceFactory
+public class DraftOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IDraftOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IDraftOrderService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/DraftOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/DraftOrderServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IDraftOrderServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IDraftOrderService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IDraftOrderService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IDraftOrderService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IDraftOrderService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class DraftOrderServiceFactory(
     #endif
 ) : IDraftOrderServiceFactory
 {
-    public virtual IDraftOrderService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IDraftOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new DraftOrderService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new DraftOrderService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class DraftOrderServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IDraftOrderService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/EventServiceFactory.cs
+++ b/ShopifySharp/Factories/EventServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IEventServiceFactory
     IEventService Create(ShopifyApiCredentials credentials);
 }
 
-public class EventServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IEventServiceFactory
+public class EventServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IEventServiceFactory
 {
     /// <inheritDoc />
     public virtual IEventService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/EventServiceFactory.cs
+++ b/ShopifySharp/Factories/EventServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IEventServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IEventService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IEventService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IEventService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IEventService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class EventServiceFactory(
     #endif
 ) : IEventServiceFactory
 {
-    public virtual IEventService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IEventService Create(string shopDomain, string accessToken)
     {
-        var service = new EventService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new EventService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class EventServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IEventService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IFulfillmentEventServiceFactory
     IFulfillmentEventService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentEventServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IFulfillmentEventServiceFactory
+public class FulfillmentEventServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentEventServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentEventService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IFulfillmentEventServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IFulfillmentEventService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IFulfillmentEventService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IFulfillmentEventService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IFulfillmentEventService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class FulfillmentEventServiceFactory(
     #endif
 ) : IFulfillmentEventServiceFactory
 {
-    public virtual IFulfillmentEventService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IFulfillmentEventService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentEventService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new FulfillmentEventService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class FulfillmentEventServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IFulfillmentEventService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IFulfillmentOrderServiceFactory
     IFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentOrderServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IFulfillmentOrderServiceFactory
+public class FulfillmentOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentOrderService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IFulfillmentOrderServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IFulfillmentOrderService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IFulfillmentOrderService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IFulfillmentOrderService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class FulfillmentOrderServiceFactory(
     #endif
 ) : IFulfillmentOrderServiceFactory
 {
-    public virtual IFulfillmentOrderService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IFulfillmentOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentOrderService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new FulfillmentOrderService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class FulfillmentOrderServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IFulfillmentOrderService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IFulfillmentRequestServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IFulfillmentRequestService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IFulfillmentRequestService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IFulfillmentRequestService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IFulfillmentRequestService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class FulfillmentRequestServiceFactory(
     #endif
 ) : IFulfillmentRequestServiceFactory
 {
-    public virtual IFulfillmentRequestService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IFulfillmentRequestService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentRequestService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new FulfillmentRequestService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class FulfillmentRequestServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IFulfillmentRequestService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IFulfillmentRequestServiceFactory
     IFulfillmentRequestService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentRequestServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IFulfillmentRequestServiceFactory
+public class FulfillmentRequestServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentRequestServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentRequestService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/FulfillmentServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IFulfillmentServiceFactory
     IFulfillmentService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IFulfillmentServiceFactory
+public class FulfillmentServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/FulfillmentServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IFulfillmentServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IFulfillmentService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IFulfillmentService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IFulfillmentService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IFulfillmentService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class FulfillmentServiceFactory(
     #endif
 ) : IFulfillmentServiceFactory
 {
-    public virtual IFulfillmentService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IFulfillmentService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new FulfillmentService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class FulfillmentServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IFulfillmentService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IFulfillmentServiceServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IFulfillmentServiceService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IFulfillmentServiceService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IFulfillmentServiceService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IFulfillmentServiceService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class FulfillmentServiceServiceFactory(
     #endif
 ) : IFulfillmentServiceServiceFactory
 {
-    public virtual IFulfillmentServiceService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IFulfillmentServiceService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentServiceService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new FulfillmentServiceService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class FulfillmentServiceServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IFulfillmentServiceService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IFulfillmentServiceServiceFactory
     IFulfillmentServiceService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentServiceServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IFulfillmentServiceServiceFactory
+public class FulfillmentServiceServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentServiceServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentServiceService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IGiftCardAdjustmentServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IGiftCardAdjustmentService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IGiftCardAdjustmentService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IGiftCardAdjustmentService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class GiftCardAdjustmentServiceFactory(
     #endif
 ) : IGiftCardAdjustmentServiceFactory
 {
-    public virtual IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IGiftCardAdjustmentService Create(string shopDomain, string accessToken)
     {
-        var service = new GiftCardAdjustmentService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new GiftCardAdjustmentService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class GiftCardAdjustmentServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IGiftCardAdjustmentServiceFactory
     IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials);
 }
 
-public class GiftCardAdjustmentServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IGiftCardAdjustmentServiceFactory
+public class GiftCardAdjustmentServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IGiftCardAdjustmentServiceFactory
 {
     /// <inheritDoc />
     public virtual IGiftCardAdjustmentService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/GiftCardServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IGiftCardServiceFactory
     IGiftCardService Create(ShopifyApiCredentials credentials);
 }
 
-public class GiftCardServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IGiftCardServiceFactory
+public class GiftCardServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IGiftCardServiceFactory
 {
     /// <inheritDoc />
     public virtual IGiftCardService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/GiftCardServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IGiftCardServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IGiftCardService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IGiftCardService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IGiftCardService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IGiftCardService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class GiftCardServiceFactory(
     #endif
 ) : IGiftCardServiceFactory
 {
-    public virtual IGiftCardService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IGiftCardService Create(string shopDomain, string accessToken)
     {
-        var service = new GiftCardService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new GiftCardService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class GiftCardServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IGiftCardService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/GraphServiceFactory.cs
+++ b/ShopifySharp/Factories/GraphServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IGraphServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IGraphService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IGraphService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IGraphService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IGraphService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class GraphServiceFactory(
     #endif
 ) : IGraphServiceFactory
 {
-    public virtual IGraphService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IGraphService Create(string shopDomain, string accessToken)
     {
-        var service = new GraphService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new GraphService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class GraphServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IGraphService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/GraphServiceFactory.cs
+++ b/ShopifySharp/Factories/GraphServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IGraphServiceFactory
     IGraphService Create(ShopifyApiCredentials credentials);
 }
 
-public class GraphServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IGraphServiceFactory
+public class GraphServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IGraphServiceFactory
 {
     /// <inheritDoc />
     public virtual IGraphService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/InventoryItemServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryItemServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IInventoryItemServiceFactory
     IInventoryItemService Create(ShopifyApiCredentials credentials);
 }
 
-public class InventoryItemServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IInventoryItemServiceFactory
+public class InventoryItemServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IInventoryItemServiceFactory
 {
     /// <inheritDoc />
     public virtual IInventoryItemService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/InventoryItemServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryItemServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IInventoryItemServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IInventoryItemService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IInventoryItemService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IInventoryItemService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IInventoryItemService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class InventoryItemServiceFactory(
     #endif
 ) : IInventoryItemServiceFactory
 {
-    public virtual IInventoryItemService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IInventoryItemService Create(string shopDomain, string accessToken)
     {
-        var service = new InventoryItemService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new InventoryItemService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class InventoryItemServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IInventoryItemService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IInventoryLevelServiceFactory
     IInventoryLevelService Create(ShopifyApiCredentials credentials);
 }
 
-public class InventoryLevelServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IInventoryLevelServiceFactory
+public class InventoryLevelServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IInventoryLevelServiceFactory
 {
     /// <inheritDoc />
     public virtual IInventoryLevelService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IInventoryLevelServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IInventoryLevelService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IInventoryLevelService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IInventoryLevelService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IInventoryLevelService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class InventoryLevelServiceFactory(
     #endif
 ) : IInventoryLevelServiceFactory
 {
-    public virtual IInventoryLevelService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IInventoryLevelService Create(string shopDomain, string accessToken)
     {
-        var service = new InventoryLevelService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new InventoryLevelService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class InventoryLevelServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IInventoryLevelService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/LocationServiceFactory.cs
+++ b/ShopifySharp/Factories/LocationServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ILocationServiceFactory
     ILocationService Create(ShopifyApiCredentials credentials);
 }
 
-public class LocationServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ILocationServiceFactory
+public class LocationServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ILocationServiceFactory
 {
     /// <inheritDoc />
     public virtual ILocationService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/LocationServiceFactory.cs
+++ b/ShopifySharp/Factories/LocationServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ILocationServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ILocationService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ILocationService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ILocationService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ILocationService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class LocationServiceFactory(
     #endif
 ) : ILocationServiceFactory
 {
-    public virtual ILocationService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ILocationService Create(string shopDomain, string accessToken)
     {
-        var service = new LocationService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new LocationService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class LocationServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ILocationService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/MetaFieldServiceFactory.cs
+++ b/ShopifySharp/Factories/MetaFieldServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IMetaFieldServiceFactory
     IMetaFieldService Create(ShopifyApiCredentials credentials);
 }
 
-public class MetaFieldServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IMetaFieldServiceFactory
+public class MetaFieldServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IMetaFieldServiceFactory
 {
     /// <inheritDoc />
     public virtual IMetaFieldService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/MetaFieldServiceFactory.cs
+++ b/ShopifySharp/Factories/MetaFieldServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IMetaFieldServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IMetaFieldService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IMetaFieldService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IMetaFieldService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IMetaFieldService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class MetaFieldServiceFactory(
     #endif
 ) : IMetaFieldServiceFactory
 {
-    public virtual IMetaFieldService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IMetaFieldService Create(string shopDomain, string accessToken)
     {
-        var service = new MetaFieldService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new MetaFieldService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class MetaFieldServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IMetaFieldService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/OrderRiskServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderRiskServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IOrderRiskServiceFactory
     IOrderRiskService Create(ShopifyApiCredentials credentials);
 }
 
-public class OrderRiskServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IOrderRiskServiceFactory
+public class OrderRiskServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IOrderRiskServiceFactory
 {
     /// <inheritDoc />
     public virtual IOrderRiskService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/OrderRiskServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderRiskServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IOrderRiskServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IOrderRiskService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IOrderRiskService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IOrderRiskService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IOrderRiskService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class OrderRiskServiceFactory(
     #endif
 ) : IOrderRiskServiceFactory
 {
-    public virtual IOrderRiskService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IOrderRiskService Create(string shopDomain, string accessToken)
     {
-        var service = new OrderRiskService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new OrderRiskService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class OrderRiskServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IOrderRiskService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/OrderServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IOrderServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IOrderService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IOrderService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IOrderService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IOrderService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class OrderServiceFactory(
     #endif
 ) : IOrderServiceFactory
 {
-    public virtual IOrderService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new OrderService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new OrderService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class OrderServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IOrderService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/OrderServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IOrderServiceFactory
     IOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class OrderServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IOrderServiceFactory
+public class OrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IOrderService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/PageServiceFactory.cs
+++ b/ShopifySharp/Factories/PageServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IPageServiceFactory
     IPageService Create(ShopifyApiCredentials credentials);
 }
 
-public class PageServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IPageServiceFactory
+public class PageServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPageServiceFactory
 {
     /// <inheritDoc />
     public virtual IPageService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/PageServiceFactory.cs
+++ b/ShopifySharp/Factories/PageServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IPageServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IPageService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IPageService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IPageService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IPageService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class PageServiceFactory(
     #endif
 ) : IPageServiceFactory
 {
-    public virtual IPageService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IPageService Create(string shopDomain, string accessToken)
     {
-        var service = new PageService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new PageService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class PageServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IPageService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/PartnerServiceFactory.cs
+++ b/ShopifySharp/Factories/PartnerServiceFactory.cs
@@ -1,15 +1,24 @@
+// Notice:
+// This class is auto-generated from a template. Please do not edit it or change it directly.
 #if NETSTANDARD2_0
 #nullable disable
 #else
 #nullable enable
 #endif
+
 using ShopifySharp.Credentials;
 
 namespace ShopifySharp.Factories;
 
 public interface IPartnerServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IPartnerService" /> with the given credentials.
+    /// <param name="partnerOrganizationId">Your Shopify Partner organization ID. This can be found on your Shopify Partner account settings page.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IPartnerService Create(long partnerOrganizationId, string accessToken);
+
+    /// Creates a new instance of the <see cref="IPartnerService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IPartnerService Create(ShopifyPartnerApiCredentials credentials);
 }
 
@@ -21,9 +30,10 @@ public class PartnerServiceFactory(
     #endif
 ) : IPartnerServiceFactory
 {
-    public virtual IPartnerService Create(ShopifyPartnerApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IPartnerService Create(long partnerOrganizationId, string accessToken)
     {
-        var service = new PartnerService(credentials.PartnerOrganizationId, credentials.AccessToken);
+        var service = new PartnerService(partnerOrganizationId, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -32,4 +42,8 @@ public class PartnerServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IPartnerService Create(ShopifyPartnerApiCredentials credentials) =>
+        Create(credentials.PartnerOrganizationId, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/PartnerServiceFactory.cs
+++ b/ShopifySharp/Factories/PartnerServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IPartnerServiceFactory
     IPartnerService Create(ShopifyPartnerApiCredentials credentials);
 }
 
-public class PartnerServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IPartnerServiceFactory
+public class PartnerServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPartnerServiceFactory
 {
     /// <inheritDoc />
     public virtual IPartnerService Create(long partnerOrganizationId, string accessToken)

--- a/ShopifySharp/Factories/PolicyServiceFactory.cs
+++ b/ShopifySharp/Factories/PolicyServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IPolicyServiceFactory
     IPolicyService Create(ShopifyApiCredentials credentials);
 }
 
-public class PolicyServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IPolicyServiceFactory
+public class PolicyServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPolicyServiceFactory
 {
     /// <inheritDoc />
     public virtual IPolicyService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/PolicyServiceFactory.cs
+++ b/ShopifySharp/Factories/PolicyServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IPolicyServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IPolicyService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IPolicyService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IPolicyService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IPolicyService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class PolicyServiceFactory(
     #endif
 ) : IPolicyServiceFactory
 {
-    public virtual IPolicyService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IPolicyService Create(string shopDomain, string accessToken)
     {
-        var service = new PolicyService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new PolicyService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class PolicyServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IPolicyService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/PriceRuleServiceFactory.cs
+++ b/ShopifySharp/Factories/PriceRuleServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IPriceRuleServiceFactory
     IPriceRuleService Create(ShopifyApiCredentials credentials);
 }
 
-public class PriceRuleServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IPriceRuleServiceFactory
+public class PriceRuleServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPriceRuleServiceFactory
 {
     /// <inheritDoc />
     public virtual IPriceRuleService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/PriceRuleServiceFactory.cs
+++ b/ShopifySharp/Factories/PriceRuleServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IPriceRuleServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IPriceRuleService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IPriceRuleService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IPriceRuleService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IPriceRuleService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class PriceRuleServiceFactory(
     #endif
 ) : IPriceRuleServiceFactory
 {
-    public virtual IPriceRuleService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IPriceRuleService Create(string shopDomain, string accessToken)
     {
-        var service = new PriceRuleService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new PriceRuleService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class PriceRuleServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IPriceRuleService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ProductImageServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductImageServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IProductImageServiceFactory
     IProductImageService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductImageServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IProductImageServiceFactory
+public class ProductImageServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductImageServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductImageService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ProductImageServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductImageServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IProductImageServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IProductImageService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IProductImageService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IProductImageService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IProductImageService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ProductImageServiceFactory(
     #endif
 ) : IProductImageServiceFactory
 {
-    public virtual IProductImageService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IProductImageService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductImageService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ProductImageService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ProductImageServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IProductImageService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ProductListingServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductListingServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IProductListingServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IProductListingService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IProductListingService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IProductListingService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IProductListingService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ProductListingServiceFactory(
     #endif
 ) : IProductListingServiceFactory
 {
-    public virtual IProductListingService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IProductListingService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductListingService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ProductListingService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ProductListingServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IProductListingService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ProductListingServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductListingServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IProductListingServiceFactory
     IProductListingService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductListingServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IProductListingServiceFactory
+public class ProductListingServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductListingServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductListingService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ProductVariantServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductVariantServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IProductVariantServiceFactory
     IProductVariantService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductVariantServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IProductVariantServiceFactory
+public class ProductVariantServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductVariantServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductVariantService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ProductVariantServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductVariantServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IProductVariantServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IProductVariantService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IProductVariantService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IProductVariantService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IProductVariantService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ProductVariantServiceFactory(
     #endif
 ) : IProductVariantServiceFactory
 {
-    public virtual IProductVariantService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IProductVariantService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductVariantService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ProductVariantService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ProductVariantServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IProductVariantService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IRecurringChargeServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IRecurringChargeService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IRecurringChargeService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IRecurringChargeService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IRecurringChargeService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class RecurringChargeServiceFactory(
     #endif
 ) : IRecurringChargeServiceFactory
 {
-    public virtual IRecurringChargeService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IRecurringChargeService Create(string shopDomain, string accessToken)
     {
-        var service = new RecurringChargeService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new RecurringChargeService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class RecurringChargeServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IRecurringChargeService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IRecurringChargeServiceFactory
     IRecurringChargeService Create(ShopifyApiCredentials credentials);
 }
 
-public class RecurringChargeServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IRecurringChargeServiceFactory
+public class RecurringChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IRecurringChargeServiceFactory
 {
     /// <inheritDoc />
     public virtual IRecurringChargeService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/RedirectServiceFactory.cs
+++ b/ShopifySharp/Factories/RedirectServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IRedirectServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IRedirectService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IRedirectService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IRedirectService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IRedirectService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class RedirectServiceFactory(
     #endif
 ) : IRedirectServiceFactory
 {
-    public virtual IRedirectService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IRedirectService Create(string shopDomain, string accessToken)
     {
-        var service = new RedirectService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new RedirectService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class RedirectServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IRedirectService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/RedirectServiceFactory.cs
+++ b/ShopifySharp/Factories/RedirectServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IRedirectServiceFactory
     IRedirectService Create(ShopifyApiCredentials credentials);
 }
 
-public class RedirectServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IRedirectServiceFactory
+public class RedirectServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IRedirectServiceFactory
 {
     /// <inheritDoc />
     public virtual IRedirectService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/RefundServiceFactory.cs
+++ b/ShopifySharp/Factories/RefundServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IRefundServiceFactory
     IRefundService Create(ShopifyApiCredentials credentials);
 }
 
-public class RefundServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IRefundServiceFactory
+public class RefundServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IRefundServiceFactory
 {
     /// <inheritDoc />
     public virtual IRefundService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/RefundServiceFactory.cs
+++ b/ShopifySharp/Factories/RefundServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IRefundServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IRefundService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IRefundService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IRefundService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IRefundService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class RefundServiceFactory(
     #endif
 ) : IRefundServiceFactory
 {
-    public virtual IRefundService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IRefundService Create(string shopDomain, string accessToken)
     {
-        var service = new RefundService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new RefundService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class RefundServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IRefundService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ScriptTagServiceFactory.cs
+++ b/ShopifySharp/Factories/ScriptTagServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IScriptTagServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IScriptTagService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IScriptTagService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IScriptTagService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IScriptTagService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ScriptTagServiceFactory(
     #endif
 ) : IScriptTagServiceFactory
 {
-    public virtual IScriptTagService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IScriptTagService Create(string shopDomain, string accessToken)
     {
-        var service = new ScriptTagService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ScriptTagService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ScriptTagServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IScriptTagService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ScriptTagServiceFactory.cs
+++ b/ShopifySharp/Factories/ScriptTagServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IScriptTagServiceFactory
     IScriptTagService Create(ShopifyApiCredentials credentials);
 }
 
-public class ScriptTagServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IScriptTagServiceFactory
+public class ScriptTagServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IScriptTagServiceFactory
 {
     /// <inheritDoc />
     public virtual IScriptTagService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
+++ b/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IShippingZoneServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IShippingZoneService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IShippingZoneService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IShippingZoneService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IShippingZoneService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ShippingZoneServiceFactory(
     #endif
 ) : IShippingZoneServiceFactory
 {
-    public virtual IShippingZoneService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IShippingZoneService Create(string shopDomain, string accessToken)
     {
-        var service = new ShippingZoneService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ShippingZoneService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ShippingZoneServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IShippingZoneService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
+++ b/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IShippingZoneServiceFactory
     IShippingZoneService Create(ShopifyApiCredentials credentials);
 }
 
-public class ShippingZoneServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IShippingZoneServiceFactory
+public class ShippingZoneServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IShippingZoneServiceFactory
 {
     /// <inheritDoc />
     public virtual IShippingZoneService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ShopServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IShopServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IShopService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IShopService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IShopService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IShopService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ShopServiceFactory(
     #endif
 ) : IShopServiceFactory
 {
-    public virtual IShopService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IShopService Create(string shopDomain, string accessToken)
     {
-        var service = new ShopService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ShopService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ShopServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IShopService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ShopServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IShopServiceFactory
     IShopService Create(ShopifyApiCredentials credentials);
 }
 
-public class ShopServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IShopServiceFactory
+public class ShopServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IShopServiceFactory
 {
     /// <inheritDoc />
     public virtual IShopService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IShopifyPaymentsServiceFactory
     IShopifyPaymentsService Create(ShopifyApiCredentials credentials);
 }
 
-public class ShopifyPaymentsServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IShopifyPaymentsServiceFactory
+public class ShopifyPaymentsServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IShopifyPaymentsServiceFactory
 {
     /// <inheritDoc />
     public virtual IShopifyPaymentsService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IShopifyPaymentsServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IShopifyPaymentsService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IShopifyPaymentsService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IShopifyPaymentsService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IShopifyPaymentsService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ShopifyPaymentsServiceFactory(
     #endif
 ) : IShopifyPaymentsServiceFactory
 {
-    public virtual IShopifyPaymentsService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IShopifyPaymentsService Create(string shopDomain, string accessToken)
     {
-        var service = new ShopifyPaymentsService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ShopifyPaymentsService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ShopifyPaymentsServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IShopifyPaymentsService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ISmartCollectionServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ISmartCollectionService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ISmartCollectionService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ISmartCollectionService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ISmartCollectionService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class SmartCollectionServiceFactory(
     #endif
 ) : ISmartCollectionServiceFactory
 {
-    public virtual ISmartCollectionService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ISmartCollectionService Create(string shopDomain, string accessToken)
     {
-        var service = new SmartCollectionService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new SmartCollectionService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class SmartCollectionServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ISmartCollectionService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ISmartCollectionServiceFactory
     ISmartCollectionService Create(ShopifyApiCredentials credentials);
 }
 
-public class SmartCollectionServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ISmartCollectionServiceFactory
+public class SmartCollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ISmartCollectionServiceFactory
 {
     /// <inheritDoc />
     public virtual ISmartCollectionService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
+++ b/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IStorefrontAccessTokenServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IStorefrontAccessTokenService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IStorefrontAccessTokenService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IStorefrontAccessTokenService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class StorefrontAccessTokenServiceFactory(
     #endif
 ) : IStorefrontAccessTokenServiceFactory
 {
-    public virtual IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IStorefrontAccessTokenService Create(string shopDomain, string accessToken)
     {
-        var service = new StorefrontAccessTokenService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new StorefrontAccessTokenService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class StorefrontAccessTokenServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
+++ b/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IStorefrontAccessTokenServiceFactory
     IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials);
 }
 
-public class StorefrontAccessTokenServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IStorefrontAccessTokenServiceFactory
+public class StorefrontAccessTokenServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IStorefrontAccessTokenServiceFactory
 {
     /// <inheritDoc />
     public virtual IStorefrontAccessTokenService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ITenderTransactionServiceFactory
     ITenderTransactionService Create(ShopifyApiCredentials credentials);
 }
 
-public class TenderTransactionServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ITenderTransactionServiceFactory
+public class TenderTransactionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ITenderTransactionServiceFactory
 {
     /// <inheritDoc />
     public virtual ITenderTransactionService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ITenderTransactionServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ITenderTransactionService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ITenderTransactionService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ITenderTransactionService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ITenderTransactionService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class TenderTransactionServiceFactory(
     #endif
 ) : ITenderTransactionServiceFactory
 {
-    public virtual ITenderTransactionService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ITenderTransactionService Create(string shopDomain, string accessToken)
     {
-        var service = new TenderTransactionService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new TenderTransactionService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class TenderTransactionServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ITenderTransactionService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/ThemeServiceFactory.cs
+++ b/ShopifySharp/Factories/ThemeServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IThemeServiceFactory
     IThemeService Create(ShopifyApiCredentials credentials);
 }
 
-public class ThemeServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IThemeServiceFactory
+public class ThemeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IThemeServiceFactory
 {
     /// <inheritDoc />
     public virtual IThemeService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/ThemeServiceFactory.cs
+++ b/ShopifySharp/Factories/ThemeServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IThemeServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IThemeService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IThemeService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IThemeService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IThemeService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class ThemeServiceFactory(
     #endif
 ) : IThemeServiceFactory
 {
-    public virtual IThemeService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IThemeService Create(string shopDomain, string accessToken)
     {
-        var service = new ThemeService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new ThemeService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class ThemeServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IThemeService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/TransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TransactionServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface ITransactionServiceFactory
     ITransactionService Create(ShopifyApiCredentials credentials);
 }
 
-public class TransactionServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : ITransactionServiceFactory
+public class TransactionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ITransactionServiceFactory
 {
     /// <inheritDoc />
     public virtual ITransactionService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/TransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TransactionServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface ITransactionServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="ITransactionService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    ITransactionService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="ITransactionService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     ITransactionService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class TransactionServiceFactory(
     #endif
 ) : ITransactionServiceFactory
 {
-    public virtual ITransactionService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual ITransactionService Create(string shopDomain, string accessToken)
     {
-        var service = new TransactionService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new TransactionService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class TransactionServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual ITransactionService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/UsageChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/UsageChargeServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IUsageChargeServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IUsageChargeService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IUsageChargeService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IUsageChargeService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IUsageChargeService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class UsageChargeServiceFactory(
     #endif
 ) : IUsageChargeServiceFactory
 {
-    public virtual IUsageChargeService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IUsageChargeService Create(string shopDomain, string accessToken)
     {
-        var service = new UsageChargeService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new UsageChargeService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class UsageChargeServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IUsageChargeService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/UsageChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/UsageChargeServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IUsageChargeServiceFactory
     IUsageChargeService Create(ShopifyApiCredentials credentials);
 }
 
-public class UsageChargeServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IUsageChargeServiceFactory
+public class UsageChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IUsageChargeServiceFactory
 {
     /// <inheritDoc />
     public virtual IUsageChargeService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/UserServiceFactory.cs
+++ b/ShopifySharp/Factories/UserServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IUserServiceFactory
     IUserService Create(ShopifyApiCredentials credentials);
 }
 
-public class UserServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IUserServiceFactory
+public class UserServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IUserServiceFactory
 {
     /// <inheritDoc />
     public virtual IUserService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/UserServiceFactory.cs
+++ b/ShopifySharp/Factories/UserServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IUserServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IUserService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IUserService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IUserService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IUserService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class UserServiceFactory(
     #endif
 ) : IUserServiceFactory
 {
-    public virtual IUserService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IUserService Create(string shopDomain, string accessToken)
     {
-        var service = new UserService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new UserService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class UserServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IUserService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/WebhookServiceFactory.cs
+++ b/ShopifySharp/Factories/WebhookServiceFactory.cs
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface IWebhookServiceFactory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="IWebhookService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IWebhookService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IWebhookService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     IWebhookService Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class WebhookServiceFactory(
     #endif
 ) : IWebhookServiceFactory
 {
-    public virtual IWebhookService Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual IWebhookService Create(string shopDomain, string accessToken)
     {
-        var service = new WebhookService(credentials.ShopDomain, credentials.AccessToken);
+        var service = new WebhookService(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class WebhookServiceFactory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual IWebhookService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Factories/WebhookServiceFactory.cs
+++ b/ShopifySharp/Factories/WebhookServiceFactory.cs
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface IWebhookServiceFactory
     IWebhookService Create(ShopifyApiCredentials credentials);
 }
 
-public class WebhookServiceFactory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : IWebhookServiceFactory
+public class WebhookServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IWebhookServiceFactory
 {
     /// <inheritDoc />
     public virtual IWebhookService Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/factory-service-template.txt
+++ b/ShopifySharp/Factories/factory-service-template.txt
@@ -1,10 +1,6 @@
+#nullable enable
 // Notice:
 // This class is auto-generated from a template. Please do not edit it or change it directly.
-#if NETSTANDARD2_0
-#nullable disable
-#else
-#nullable enable
-#endif
 
 using ShopifySharp.Credentials;
 
@@ -22,13 +18,7 @@ public interface I@@REPLACEME@@Factory
     I@@REPLACEME@@ Create(ShopifyApiCredentials credentials);
 }
 
-public class @@REPLACEME@@Factory(
-    #if NETSTANDARD2_0
-    IRequestExecutionPolicy requestExecutionPolicy = null
-    #else
-    IRequestExecutionPolicy? requestExecutionPolicy = null
-    #endif
-) : I@@REPLACEME@@Factory
+public class @@REPLACEME@@Factory(IRequestExecutionPolicy? requestExecutionPolicy = null) : I@@REPLACEME@@Factory
 {
     /// <inheritDoc />
     public virtual I@@REPLACEME@@ Create(string shopDomain, string accessToken)

--- a/ShopifySharp/Factories/factory-service-template.txt
+++ b/ShopifySharp/Factories/factory-service-template.txt
@@ -12,7 +12,13 @@ namespace ShopifySharp.Factories;
 
 public interface I@@REPLACEME@@Factory
 {
-    // ReSharper disable once UnusedMember.Global
+    /// Creates a new instance of the <see cref="I@@REPLACEME@@" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    I@@REPLACEME@@ Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="I@@REPLACEME@@" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
     I@@REPLACEME@@ Create(ShopifyApiCredentials credentials);
 }
 
@@ -24,9 +30,10 @@ public class @@REPLACEME@@Factory(
     #endif
 ) : I@@REPLACEME@@Factory
 {
-    public virtual I@@REPLACEME@@ Create(ShopifyApiCredentials credentials)
+    /// <inheritDoc />
+    public virtual I@@REPLACEME@@ Create(string shopDomain, string accessToken)
     {
-        var service = new @@REPLACEME@@(credentials.ShopDomain, credentials.AccessToken);
+        var service = new @@REPLACEME@@(shopDomain, accessToken);
 
         if (requestExecutionPolicy is not null)
         {
@@ -35,4 +42,8 @@ public class @@REPLACEME@@Factory(
 
         return service;
     }
+
+    /// <inheritDoc />
+    public virtual I@@REPLACEME@@ Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
 }

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -45,21 +45,28 @@ namespace ShopifySharp
         /// </summary>
         /// <param name="requestResult">The RequestResult{JToken} response from ExecuteRequestAsync.</param>
         /// <exception cref="ShopifyException">Thrown if <paramref name="requestResult"/> contains an error.</exception>
-        private void CheckForErrors(RequestResult<JToken> requestResult)
+        private static void CheckForErrors(RequestResult<JToken> requestResult)
         {
-            if (requestResult.Result["errors"] != null)
+            if (requestResult.Result["errors"] is null)
             {
-                var errorList = new List<string>();
-                
-                foreach (var error in requestResult.Result["errors"])
-                {
-                    errorList.Add(error["message"].ToString());
-                }
-
-                var message = requestResult.Result["errors"].FirstOrDefault()["message"].ToString();
-
-                throw new ShopifyException(requestResult.Response, HttpStatusCode.OK, errorList, message, requestResult.RawResult, "");
+                return;
             }
+
+            var errorList = new List<string>();
+
+            foreach (var error in requestResult.Result["errors"])
+            {
+                var errorMessage = error["message"];
+
+                if (errorMessage is not null)
+                {
+                    errorList.Add(errorMessage.ToString());
+                }
+            }
+
+            var message = requestResult.Result["errors"].FirstOrDefault()?["message"]?.ToString();
+
+            throw new ShopifyException(requestResult.Response, HttpStatusCode.OK, errorList, message, requestResult.RawResult, "");
         }
     }
 }


### PR DESCRIPTION
This pull request adds a `factory.Create(string shopDomain, string accessToken)` overload to all service factory interfaces. It also adds `factory.Create(long organizationId, string accessToken)` to the IPartnerServiceFactory interface.