### PR TITLE
Add IProductServiceFactory to DI container

### DIFF
--- a/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -92,6 +92,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IPriceRuleServiceFactory, PriceRuleServiceFactory>();
         services.TryAddSingleton<IProductImageServiceFactory, ProductImageServiceFactory>();
         services.TryAddSingleton<IProductListingServiceFactory, ProductListingServiceFactory>();
+        services.TryAddSingleton<IProductServiceFactory, ProductServiceFactory>();
         services.TryAddSingleton<IProductVariantServiceFactory, ProductVariantServiceFactory>();
         services.TryAddSingleton<IRecurringChargeServiceFactory, RecurringChargeServiceFactory>();
         services.TryAddSingleton<IRedirectServiceFactory, RedirectServiceFactory>();


### PR DESCRIPTION
This PR just adds the IProductServiceFactory + implementation to the DI container in the ShopifySharp.Extensions.DependencyInjection package, as the factory itself was previously missing due to a bug.