### PR TITLE
Deprecate ShopifyService.PrepareRequest and replace with an overridable `ShopifyService.BuildRequestUri`

### DIFF
--- a/ShopifySharp.Experimental/ApplicationCredit.fs
+++ b/ShopifySharp.Experimental/ApplicationCredit.fs
@@ -60,11 +60,11 @@ module ApplicationCredits =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (data : ApplicationCreditProperties) =
-            let req = base.PrepareRequest "application_credits.json"
+            let req = base.BuildRequestUri("application_credits.json")
             let data = dict [ "application_credit" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, CancellationToken.None, content, "usage_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/Charges.fs
+++ b/ShopifySharp.Experimental/Charges.fs
@@ -61,11 +61,11 @@ module Charges =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (data : ChargeProperties) =
-            let req = base.PrepareRequest "application_charges.json"
+            let req = base.BuildRequestUri("application_charges.json")
             let data = dict [ "application_charge" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Charge>(req, HttpMethod.Post, CancellationToken.None, content, "application_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/Orders.fs
+++ b/ShopifySharp.Experimental/Orders.fs
@@ -3,8 +3,6 @@
 open System.Collections.Generic
 open System.Net.Http
 open System.Threading
-open System.Threading
-open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -274,25 +272,25 @@ module Orders =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (order: OrderProperties) =
-            let req = base.PrepareRequest "orders.json"
+            let req = base.BuildRequestUri("orders.json")
             let data = dict [ "order" => order ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, CancellationToken.None, content, "order")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.CreateAsync(order: OrderProperties, options: CreationOptions.CreationOptionProperties) =
-            let req = base.PrepareRequest "orders.json"
+            let req = base.BuildRequestUri("orders.json")
             let data = dict [ "order", mergeOrderAndCreationOptions order options |> JsonValue.MapPropertyValuesToObjects ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, CancellationToken.None, content, "order")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.UpdateAsync (id: int64, order: OrderProperties) =
-            let req = base.PrepareRequest (sprintf "orders/%i.json" id)
+            let req = base.BuildRequestUri($"orders/{id}.json")
             let data = dict [ "order" => order ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Order>(req, HttpMethod.Put, CancellationToken.None, content, "order")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/RecurringCharges.fs
+++ b/ShopifySharp.Experimental/RecurringCharges.fs
@@ -73,11 +73,11 @@ module RecurringCharges =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (data : RecurringChargeProperties) =
-            let req = base.PrepareRequest "recurring_application_charges.json"
+            let req = base.BuildRequestUri("recurring_application_charges.json")
             let data = dict [ "recurring_application_charge" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<RecurringCharge>(req, HttpMethod.Post, CancellationToken.None, content, "recurring_application_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/ScriptTags.fs
+++ b/ShopifySharp.Experimental/ScriptTags.fs
@@ -2,7 +2,6 @@
 
 open System.Net.Http
 open System.Threading
-open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -79,18 +78,18 @@ module ScriptTags =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (tag : ScriptTagProperties) =
-            let req = base.PrepareRequest "script_tags.json"
+            let req = base.BuildRequestUri("script_tags.json")
             let data = dict [ "script_tag" => tag ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, CancellationToken.None, content, "script_tag")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.UpdateAsync (id : int64, tag : ScriptTagProperties) =
-            let req = base.PrepareRequest (sprintf "script_tags/%i.json" id)
+            let req = base.BuildRequestUri($"script_tags/{id}.json")
             let data = dict [ "script_tag" => tag ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, CancellationToken.None, content, "script_tag")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/UsageCharges.fs
+++ b/ShopifySharp.Experimental/UsageCharges.fs
@@ -53,11 +53,11 @@ module UsageCharges =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (recurringChargeId : int64, data : UsageChargeProperties) =
-            let req = base.PrepareRequest (sprintf "recurring_application_charges/%i/usage_charges.json" recurringChargeId)
+            let req = base.BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges.json")
             let data = dict [ "usage_charge" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, CancellationToken.None, content, "usage_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/Webhooks.fs
+++ b/ShopifySharp.Experimental/Webhooks.fs
@@ -2,8 +2,6 @@ namespace ShopifySharp.Experimental
 
 open System.Net.Http
 open System.Threading
-open System.Threading
-open System.Threading.Tasks
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -80,20 +78,20 @@ module Webhooks =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
              
         member x.CreateAsync (webhook: WebhookProperties) =
-            let req = base.PrepareRequest "webhooks.json"
+            let req = base.BuildRequestUri("webhooks.json")
             let data = dict [ "webhook" => webhook ]
             let content = new JsonContent(data)
             
             base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Post, CancellationToken.None, content, "webhook")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.UpdateAsync (id: int64, webhook: WebhookProperties) =
-            let req = base.PrepareRequest (sprintf "webhooks/%i.json" id)
+            let req = base.BuildRequestUri($"webhooks/{id}.json")
             let data = dict [ "webhook" => webhook ]
             let content = new JsonContent(data)
             
             base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Put, CancellationToken.None, content, "webhook")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Tests/Services/ShopifyServiceTests.cs
+++ b/ShopifySharp.Tests/Services/ShopifyServiceTests.cs
@@ -1,0 +1,30 @@
+using System;
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Tests.TestClasses;
+using Xunit;
+
+namespace ShopifySharp.Tests.Services;
+
+[Trait("Category", "ShopifyService")]
+[TestSubject(typeof(ShopifyService))]
+public class ShopifyServiceTests
+{
+    #region PrepareRequest(string path) and BuildRequestUri
+
+    [Fact]
+    public void BuildRequestUri_ShouldReturnOverridenUri()
+    {
+        // Setup
+        var expectedUri = new Uri("https://some-expected-uri.com", UriKind.Absolute);
+        var service = new TestBuildRequestUriShopifyService(expectedUri);
+
+        // Act
+        var result = service.BuildRequestUriProxy();
+
+        // Assert
+        result.ToUri().Should().Be(expectedUri);
+    }
+
+    #endregion
+}

--- a/ShopifySharp.Tests/ShopifyService_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyService_Tests.cs
@@ -5,12 +5,16 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using ShopifySharp.Filters;
 using Xunit;
+
+// TODO: move the tests in this file to the ShopifySharp.Tests.Services.ShopifyServiceTests file
 
 namespace ShopifySharp.Tests
 {
     [Trait("Category", "ShopifyService"), Trait("Category", "DotNetFramework"), Collection("DotNetFramework tests")]
+    [TestSubject(typeof(ShopifyService))]
     public class ShopifyService_Tests
     {
         string ReasonPhrase(HttpStatusCode code)

--- a/ShopifySharp.Tests/TestClasses/TestBuildRequestUriShopifyService.cs
+++ b/ShopifySharp.Tests/TestClasses/TestBuildRequestUriShopifyService.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+
+namespace ShopifySharp.Tests.TestClasses;
+
+/// <summary>
+/// A test ShopifyService that overrides the <see cref="ShopifyService.BuildRequestUri(string)"/> method for testing.
+/// </summary>
+/// <param name="requestUri">The uri you want the overriden <see cref="ShopifyService.BuildRequestUri(string)"/> to return for testing.</param>
+public class TestBuildRequestUriShopifyService(Uri requestUri) : ShopifyService("some-shop-domain", "some-access-token")
+{
+    protected override RequestUri BuildRequestUri(string _)
+    {
+        return new RequestUri(requestUri);
+    }
+
+    public RequestUri BuildRequestUriProxy() => BuildRequestUri("some-path");
+}

--- a/ShopifySharp/Services/AccessScope/AccessScopeService.cs
+++ b/ShopifySharp/Services/AccessScope/AccessScopeService.cs
@@ -12,7 +12,7 @@ namespace ShopifySharp
     public class AccessScopeService : ShopifyService, IAccessScopeService
     {
         //oauth endpoints don't support versioning
-        protected override bool SupportsAPIVersioning => false;
+        public override bool SupportsAPIVersioning => false;
 
         /// <summary>
         /// Creates a new instance of the service.

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ApplicationCredit> CreateAsync(ApplicationCredit credit, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"application_credits.json");
+            var req = BuildRequestUri($"application_credits.json");
             var body = new JsonContent(new
             {
                 application_credit = credit,

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Article> GetAsync(long blogId, long articleId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/{articleId}.json");
 
             if (fields != null)
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Article> CreateAsync(long blogId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles.json");
             var body = article.ToDictionary();
 
             if (metafields != null)
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Article> UpdateAsync(long blogId, long articleId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/{articleId}.json");
             var body = article.ToDictionary();
 
             if (metafields != null)
@@ -89,7 +89,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long blogId, long articleId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/{articleId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -97,7 +97,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<string>> ListAuthorsAsync(CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"articles/authors.json");
+            var req = BuildRequestUri($"articles/authors.json");
 
             var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, cancellationToken, rootElement: "authors");
             return response.Result;
@@ -106,7 +106,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"articles/tags.json");
+            var req = BuildRequestUri($"articles/tags.json");
 
             if (popular.HasValue)
             {
@@ -125,7 +125,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/tags.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/tags.json");
 
             if (popular.HasValue)
             {

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Asset> GetAsync(long themeId, string key, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}/assets.json");
+            var req = BuildRequestUri($"themes/{themeId}/assets.json");
             // Add the proper asset querystring
             req = SetAssetQuerystring(req, key, themeId);
 
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Asset> CreateOrUpdateAsync(long themeId, Asset asset, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}/assets.json");
+            var req = BuildRequestUri($"themes/{themeId}/assets.json");
             var content = new JsonContent(new
             {
                 asset = asset
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long themeId, string key, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}/assets.json");
+            var req = BuildRequestUri($"themes/{themeId}/assets.json");
 
             req = SetAssetQuerystring(req, key, themeId);
 

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Blog> CreateAsync(Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest("blogs.json");
+            var request = BuildRequestUri("blogs.json");
             var body = blog.ToDictionary();
 
             if (metafields != null && metafields.Any())
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Blog> UpdateAsync(long blogId, Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest($"blogs/{blogId}.json");
+            var request = BuildRequestUri($"blogs/{blogId}.json");
             var body = blog.ToDictionary();
 
             if (metafields != null && metafields.Count() >= 1)
@@ -76,7 +76,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Blog> GetAsync(long id, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest($"blogs/{id}.json");
+            var request = BuildRequestUri($"blogs/{id}.json");
 
             var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Get, cancellationToken, rootElement: "blog");
             return response.Result;
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest($"blogs/{id}.json");
+            var request = BuildRequestUri($"blogs/{id}.json");
 
             await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/CancellationRequest/CancellationRequestService.cs
+++ b/ShopifySharp/Services/CancellationRequest/CancellationRequestService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CreateAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request.json");
             var cancellationRequest = new CancellationRequest { Message = message };
             var body = cancellationRequest.ToDictionary();
 
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> AcceptAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/accept.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/accept.json");
             var cancellationRequest = new CancellationRequest { Message = message };
             var body = cancellationRequest.ToDictionary();
 
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> RejectAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/reject.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/reject.json");
             var cancellationRequest = new CancellationRequest { Message = message };
             var body = cancellationRequest.ToDictionary();
 

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Carrier> CreateAsync(Carrier carrier, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("carrier_services.json");
+            var req = BuildRequestUri("carrier_services.json");
             var content = new JsonContent(new
             {
                 carrier_service = carrier
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Carrier> GetAsync(long carrierId, CancellationToken cancellationToken = default)
         {            
-            var req = PrepareRequest($"carrier_services/{carrierId}.json");
+            var req = BuildRequestUri($"carrier_services/{carrierId}.json");
 
             var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Get, cancellationToken, rootElement: "carrier_service");
             return response.Result;
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long carrierId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"carrier_services/{carrierId}.json");
+            var req = BuildRequestUri($"carrier_services/{carrierId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -55,7 +55,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Carrier> UpdateAsync(long carrierId, Carrier carrier, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"carrier_services/{carrierId}.json");
+            var req = BuildRequestUri($"carrier_services/{carrierId}.json");
             var content = new JsonContent(new
             {
                 carrier_service = carrier

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Charge> CreateAsync(Charge charge, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("application_charges.json");
+            var req = BuildRequestUri("application_charges.json");
             var content = new JsonContent(new { application_charge = charge });
 
             var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Post, cancellationToken, content, "application_charge");
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Charge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"application_charges/{id}.json");
+            var req = BuildRequestUri($"application_charges/{id}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> CreateAsync(Checkout checkout, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("checkouts.json");
+            var req = BuildRequestUri("checkouts.json");
             var body = checkout.ToDictionary();
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, cancellationToken, new JsonContent(new { checkout }), "checkout");
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> CompleteAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/complete.json");
+            var req = BuildRequestUri($"checkouts/{token}/complete.json");
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> GetAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Get, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> UpdateAsync(string token, Checkout updatedCheckout, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Put, cancellationToken, new JsonContent(new { checkout = updatedCheckout }), "checkout");
             return response.Result;
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<CheckoutShippingRate>> ListShippingRatesAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
+            var req = BuildRequestUri($"checkouts/{token}/shipping_rates.json");
 
             var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, cancellationToken, rootElement: "shipping_rates");
             return response.Result;

--- a/ShopifySharp/Services/CheckoutSalesChannel/CheckoutSalesChannelService.cs
+++ b/ShopifySharp/Services/CheckoutSalesChannel/CheckoutSalesChannelService.cs
@@ -18,7 +18,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CheckoutSalesChannel> GetAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Get, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -28,7 +28,7 @@ namespace ShopifySharp
         public virtual async Task<CheckoutSalesChannel> CreateAsync(CheckoutSalesChannel checkout,
             CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("checkouts.json");
+            var req = BuildRequestUri("checkouts.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Post, cancellationToken,
                 new JsonContent(new {checkout}), "checkout");
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CheckoutSalesChannel> CompleteAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/complete.json");
+            var req = BuildRequestUri($"checkouts/{token}/complete.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Post, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -48,7 +48,7 @@ namespace ShopifySharp
         public virtual async Task<CheckoutSalesChannel> UpdateAsync(string token, CheckoutSalesChannel checkout,
             CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Put, cancellationToken,
                 new JsonContent(new { checkout }), "checkout");
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<CheckoutShippingRate>> ListShippingRatesAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
+            var req = BuildRequestUri($"checkouts/{token}/shipping_rates.json");
 
             var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, cancellationToken, rootElement: "shipping_rates");
             return response.Result;
@@ -68,7 +68,7 @@ namespace ShopifySharp
         public virtual async Task<PaymentSalesChannel> CreatePaymentAsync(string token, CreatePayment createPayment,
             CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/payments.json");
+            var req = BuildRequestUri($"checkouts/{token}/payments.json");
 
             var response = await ExecuteRequestAsync<PaymentSalesChannel>(req, HttpMethod.Post, cancellationToken,
                 new JsonContent(new {payment = createPayment}), "payment");

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Collect> CreateAsync(Collect collect, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("collects.json");
+            var req = BuildRequestUri("collects.json");
             var content = new JsonContent(new
             {
                 collect = collect
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long collectId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"collects/{collectId}.json");
+            var req = BuildRequestUri($"collects/{collectId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Country/CountryService.cs
+++ b/ShopifySharp/Services/Country/CountryService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Country> CreateAsync(Country country, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("countries.json");
+            var req = BuildRequestUri("countries.json");
             var content = new JsonContent(new
             {
                 country = country
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Country> UpdateAsync(long countryId, Country country, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"countries/{countryId}.json");
+            var req = BuildRequestUri($"countries/{countryId}.json");
             var content = new JsonContent(new
             {
                 country = country
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long countryId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"countries/{countryId}.json");
+            var req = BuildRequestUri($"countries/{countryId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomCollection> CreateAsync(CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("custom_collections.json");
+            var req = BuildRequestUri("custom_collections.json");
             var content = new JsonContent(new
             {
                 custom_collection = customCollection
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long customCollectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
+            var req = BuildRequestUri($"custom_collections/{customCollectionId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomCollection> UpdateAsync(long customCollectionId, CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
+            var req = BuildRequestUri($"custom_collections/{customCollectionId}.json");
             var content = new JsonContent(new
             {
                 custom_collection = customCollection

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Customer> CreateAsync(Customer customer, CustomerCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("customers.json");
+            var req = BuildRequestUri("customers.json");
             var body = customer.ToDictionary();
 
             if (options != null)
@@ -67,7 +67,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Customer> UpdateAsync(long customerId, Customer customer, CustomerUpdateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}.json");
+            var req = BuildRequestUri($"customers/{customerId}.json");
             var body = customer.ToDictionary();
 
             if (options != null)
@@ -90,7 +90,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long customerId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}.json");
+            var req = BuildRequestUri($"customers/{customerId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
@@ -98,7 +98,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomerInvite> SendInviteAsync(long customerId, CustomerInvite invite = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/send_invite.json");
+            var req = BuildRequestUri($"customers/{customerId}/send_invite.json");
 
             var content = new JsonContent(new
             {
@@ -112,7 +112,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<string> GetAccountActivationUrl(long customerid, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerid}/account_activation_url.json");
+            var req = BuildRequestUri($"customers/{customerid}/account_activation_url.json");
             var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken);
 
             return response.Result.SelectToken("account_activation_url").ToString();

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -23,7 +23,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> GetAsync(long customerId, long addressId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}.json");
 
             if (string.IsNullOrEmpty(fields) == false)
             {
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> CreateAsync(long customerId, Address address, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses.json");
             var addressBody = address.ToDictionary();
             var content = new JsonContent(new
             {
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> UpdateAsync(long customerId, long addressId, Address address, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}.json");
             var addressBody = address.ToDictionary();
 
             var content = new JsonContent(new
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> SetDefault(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}/default.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}/default.json");
 
             var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, cancellationToken, rootElement: "customer_address");
             return response.Result;

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomerSavedSearch> GetAsync(long customerSearchId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{RootResource}/{customerSearchId}.json");
+            var req = BuildRequestUri($"{RootResource}/{customerSearchId}.json");
 
             if (string.IsNullOrEmpty(fields) == false)
             {
@@ -59,7 +59,7 @@ namespace ShopifySharp
                 throw new ArgumentException("Name property is required", nameof(customerSavedSearch));
             }
 
-            var req = PrepareRequest($"{RootResource}.json");
+            var req = BuildRequestUri($"{RootResource}.json");
             var body = customerSavedSearch.ToDictionary();
 
             var content = new JsonContent(new
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomerSavedSearch> UpdateAsync(long customerSavedSearchId, CustomerSavedSearch customerSavedSearch, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
+            var req = BuildRequestUri($"{RootResource}/{customerSavedSearchId}.json");
             var body = customerSavedSearch.ToDictionary();
 
             var content = new JsonContent(new
@@ -89,7 +89,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual Task DeleteAsync(long customerSavedSearchId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
+            var req = BuildRequestUri($"{RootResource}/{customerSavedSearchId}.json");
 
             return ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRuleDiscountCode> CreateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes.json");
+            var req = BuildRequestUri($"price_rules/{priceRuleId}/discount_codes.json");
             var body = code.ToDictionary();
 
             var content = new JsonContent(new
@@ -61,7 +61,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRuleDiscountCode> UpdateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{code.Id.Value}.json");
+            var req = BuildRequestUri($"price_rules/{priceRuleId}/discount_codes/{code.Id.Value}.json");
             var content = new JsonContent(new
             {
                 discount_code = code
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long priceRuleId, long discountCodeId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
+            var req = BuildRequestUri($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, bool useCustomerDefaultAddress, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("draft_orders.json");
+            var req = BuildRequestUri("draft_orders.json");
             var body = order.ToDictionary();
 
             body.Add("use_customer_default_address", useCustomerDefaultAddress);
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("draft_orders.json");
+            var req = BuildRequestUri("draft_orders.json");
             var content = new JsonContent(new
             {
                 draft_order = order.ToDictionary()
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> UpdateAsync(long id, DraftOrder order, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}.json");
+            var req = BuildRequestUri($"draft_orders/{id}.json");
             var content = new JsonContent(new
             {
                 draft_order = order.ToDictionary()
@@ -79,7 +79,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}.json");
+            var req = BuildRequestUri($"draft_orders/{id}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> CompleteAsync(long id, bool paymentPending = false, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}/complete.json");
+            var req = BuildRequestUri($"draft_orders/{id}/complete.json");
             req.QueryParams.Add("payment_pending", paymentPending);
 
             var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, cancellationToken, rootElement: "draft_order");
@@ -97,7 +97,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrderInvoice> SendInvoiceAsync(long id, DraftOrderInvoice customInvoice = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}/send_invoice.json");
+            var req = BuildRequestUri($"draft_orders/{id}/send_invoice.json");
             // If the custom invoice is not null, use that as the body. Else use an empty dictionary object which will send the default invoice
             var body = customInvoice?.ToDictionary() ?? new Dictionary<string, object>();
             var content = new JsonContent(new

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Fulfillment> CreateAsync(FulfillmentShipping fulfillment, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillments.json");
+            var req = BuildRequestUri($"fulfillments.json");
             var body = fulfillment.ToDictionary();
 
             var content = new JsonContent(new
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Fulfillment> UpdateTrackingAsync(long fulfillmentId, FulfillmentShipping fulfillment, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillments/{fulfillmentId}/update_tracking.json");
+            var req = BuildRequestUri($"fulfillments/{fulfillmentId}/update_tracking.json");
             var body = fulfillment.ToDictionary();
             var content = new JsonContent(new
             {
@@ -71,7 +71,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Fulfillment> CancelAsync(long fulfillmentId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillments/{fulfillmentId}/cancel.json");
+            var req = BuildRequestUri($"fulfillments/{fulfillmentId}/cancel.json");
 
             var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment");
             return response.Result;

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentEvent> CreateAsync(long orderId, long fulfillmentId, FulfillmentEvent @event, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json");
+            var req = BuildRequestUri($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json");
 
             var content = new JsonContent(new
             {
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
+            var req = BuildRequestUri($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CancelAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/cancel.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/cancel.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -40,7 +40,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/close.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/close.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -55,7 +55,7 @@ namespace ShopifySharp
                 fulfillment_hold = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -73,7 +73,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/move.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/move.json");
 
             //needs to be original_fulfillment_order
             var response = await ExecuteRequestAsync<FulfillmentOrderMove>(req, HttpMethod.Post, cancellationToken, content);
@@ -84,7 +84,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> OpenAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/open.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/open.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> ReleaseHoldAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/release_hold.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/release_hold.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -111,7 +111,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/reschedule.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/reschedule.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -120,7 +120,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> GetAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Get, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -129,7 +129,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<FulfillmentOrder>> ListAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/fulfillment_orders.json");
+            var req = BuildRequestUri($"orders/{orderId}/fulfillment_orders.json");
             var response = await ExecuteRequestAsync<IEnumerable<FulfillmentOrder>>(req, HttpMethod.Get, cancellationToken, rootElement: "fulfillment_orders");
 
             return response.Result;

--- a/ShopifySharp/Services/FulfillmentRequest/FulfillmentRequestService.cs
+++ b/ShopifySharp/Services/FulfillmentRequest/FulfillmentRequestService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CreateAsync(long fulfillmentOrderId, FulfillmentRequest fulfillmentRequest, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request.json");
             var body = fulfillmentRequest.ToDictionary();
 
             var content = new JsonContent(new
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> AcceptAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/accept.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/accept.json");
             var fulfillmentRequest = new FulfillmentRequest { Message = message };
             var body = fulfillmentRequest.ToDictionary();
 
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> RejectAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/reject.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/reject.json");
             var fulfillmentRequest = new FulfillmentRequest { Message = message };
             var body = fulfillmentRequest.ToDictionary();
 

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentServiceEntity> CreateAsync(FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_services.json");
+            var req = BuildRequestUri($"fulfillment_services.json");
             var body = fulfillmentServiceEntity.ToDictionary();
 
             var content = new JsonContent(new
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentServiceEntity> UpdateAsync(long fulfillmentServiceId, FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
+            var req = BuildRequestUri($"fulfillment_services/{fulfillmentServiceId}.json");
             var body = fulfillmentServiceEntity.ToDictionary();
 
             var content = new JsonContent(new
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long fulfillmentServiceId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
+            var req = BuildRequestUri($"fulfillment_services/{fulfillmentServiceId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<GiftCard> CreateAsync(GiftCard giftCard, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("gift_cards.json");
+            var req = BuildRequestUri("gift_cards.json");
             var body = giftCard.ToDictionary();
 
             var content = new JsonContent(new
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<GiftCard> UpdateAsync(long giftCardId, GiftCard giftCard, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"gift_cards/{giftCardId}.json");
+            var req = BuildRequestUri($"gift_cards/{giftCardId}.json");
             var content = new JsonContent(new
             {
                 gift_card = giftCard
@@ -71,7 +71,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<GiftCard> DisableAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"gift_cards/{giftCardId}/disable.json");
+            var req = BuildRequestUri($"gift_cards/{giftCardId}/disable.json");
             var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, cancellationToken, rootElement: "gift_card");
             return response.Result;
         }

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
 
         public virtual async Task<GiftCardAdjustment> CreateAsync(long giftCardId, GiftCardAdjustment adjustment, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"gift_cards/{giftCardId}/adjustments.json");
+            var req = BuildRequestUri($"gift_cards/{giftCardId}/adjustments.json");
             var content = new JsonContent(new
             {
                 adjustment = adjustment

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -82,7 +82,7 @@ namespace ShopifySharp
 
         private async Task<T> PostAsync<T>(string body, string mediaType, int? graphqlQueryCost, CancellationToken cancellationToken)
         {
-            var req = PrepareRequest("graphql.json");
+            var req = BuildRequestUri("graphql.json");
 
             var content = new StringContent(body, Encoding.UTF8, mediaType);
 

--- a/ShopifySharp/Services/IShopifyService.cs
+++ b/ShopifySharp/Services/IShopifyService.cs
@@ -1,8 +1,12 @@
+#nullable enable
+// ReSharper disable InconsistentNaming
+
 namespace ShopifySharp
 {
     public interface IShopifyService
     {
         string APIVersion { get; }
+        bool SupportsAPIVersioning { get; }
 
         void SetExecutionPolicy(IRequestExecutionPolicy policy);
 

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<InventoryItem> UpdateAsync( long inventoryItemId, InventoryItem inventoryItem, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest( $"inventory_items/{inventoryItemId}.json" );
+            var req = BuildRequestUri( $"inventory_items/{inventoryItemId}.json" );
             var content = new JsonContent( new
             {
                 inventory_item = inventoryItem

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -28,13 +28,16 @@ namespace ShopifySharp
 			await ListAsync(filter?.AsListFilter(), cancellationToken);
 
         /// <inheritdoc />
-        public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default) =>
-			await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete, cancellationToken);
+        public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = BuildRequestUri($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}");
+            await ExecuteRequestAsync(requestUri, HttpMethod.Delete, cancellationToken);
+        }
 
         /// <inheritdoc />
         public virtual async Task<InventoryLevel> SetAsync(InventoryLevel updatedInventoryLevel, bool disconnectIfNecessary = false, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"inventory_levels/set.json");
+            var req = BuildRequestUri($"inventory_levels/set.json");
             var body = updatedInventoryLevel.ToDictionary();
             
             body.Add("disconnect_if_necessary", disconnectIfNecessary);
@@ -48,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<InventoryLevel> AdjustAsync(InventoryLevelAdjust updatedInventoryLevel, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"inventory_levels/adjust.json");
+            var req = BuildRequestUri($"inventory_levels/adjust.json");
             var body = updatedInventoryLevel.ToDictionary();
             var content = new JsonContent(body);
             var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, cancellationToken, content, "inventory_level");
@@ -59,7 +62,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<InventoryLevel> ConnectAsync(long inventoryItemId, long locationId, bool relocateIfNecessary = false, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"inventory_levels/connect.json");
+            var req = BuildRequestUri($"inventory_levels/connect.json");
             var content = new JsonContent(new
             {
                 location_id = locationId,

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("metafields.json");
+            var req = BuildRequestUri("metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -75,7 +75,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json");
+            var req = BuildRequestUri($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -88,7 +88,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{resourceType.ToLower()}/{resourceId}/metafields.json");
+            var req = BuildRequestUri($"{resourceType.ToLower()}/{resourceId}/metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -101,7 +101,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> UpdateAsync(long metafieldId, MetaField metafield, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"metafields/{metafieldId}.json");
+            var req = BuildRequestUri($"metafields/{metafieldId}.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -114,7 +114,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long metafieldId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"metafields/{metafieldId}.json");
+            var req = BuildRequestUri($"metafields/{metafieldId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> CloseAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{id}/close.json");
+            var req = BuildRequestUri($"orders/{id}/close.json");
             var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, rootElement: "order");
 
             return response.Result;
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> OpenAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{id}/open.json");
+            var req = BuildRequestUri($"orders/{id}/open.json");
             var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, rootElement: "order");
 
             return response.Result;
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> CreateAsync(Order order, OrderCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("orders.json");
+            var req = BuildRequestUri("orders.json");
             var body = order.ToDictionary();
 
             if (options != null)
@@ -80,7 +80,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> UpdateAsync(long orderId, Order order, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}.json");
+            var req = BuildRequestUri($"orders/{orderId}.json");
             var content = new JsonContent(new
             {
                 order = order
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}.json");
+            var req = BuildRequestUri($"orders/{orderId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -101,7 +101,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task CancelAsync(long orderId, OrderCancelOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/cancel.json");
+            var req = BuildRequestUri($"orders/{orderId}/cancel.json");
             var content = new JsonContent(options ?? new OrderCancelOptions());
 
             await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content);
@@ -110,7 +110,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/metafields.json");
+            var req = BuildRequestUri($"orders/{orderId}/metafields.json");
             var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, cancellationToken, rootElement: "metafields");
 
             return response.Result;

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<OrderRisk> CreateAsync(long orderId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/risks.json");
+            var req = BuildRequestUri($"orders/{orderId}/risks.json");
             var content = new JsonContent(new
             {
                 risk = risk
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<OrderRisk> UpdateAsync(long orderId, long orderRiskId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/risks/{orderRiskId}.json");
+            var req = BuildRequestUri($"orders/{orderId}/risks/{orderRiskId}.json");
             var content = new JsonContent(new
             {
                 risk = risk
@@ -54,7 +54,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/risks/{riskId}.json");
+            var req = BuildRequestUri($"orders/{orderId}/risks/{riskId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Page> GetAsync(long pageId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"pages/{pageId}.json");
+            var req = BuildRequestUri($"pages/{pageId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Page> CreateAsync(Page page, PageCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("pages.json");
+            var req = BuildRequestUri("pages.json");
             var body = page.ToDictionary();
 
             if (options != null)
@@ -72,7 +72,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Page> UpdateAsync(long pageId, Page page, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"pages/{pageId}.json");
+            var req = BuildRequestUri($"pages/{pageId}.json");
             var content = new JsonContent(new
             {
                 page = page
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long pageId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"pages/{pageId}.json");
+            var req = BuildRequestUri($"pages/{pageId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Policy/PolicyService.cs
+++ b/ShopifySharp/Services/Policy/PolicyService.cs
@@ -17,7 +17,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<Policy>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest("policies.json");
+            var request = BuildRequestUri("policies.json");
             var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, cancellationToken, rootElement: "policies");
 
             return response.Result;

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRule> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{id}.json");
+            var req = BuildRequestUri($"price_rules/{id}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRule> CreateAsync(PriceRule rule, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("price_rules.json");
+            var req = BuildRequestUri("price_rules.json");
             var body = rule.ToDictionary();
             var content = new JsonContent(new
             {
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRule> UpdateAsync(long id, PriceRule rule, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{id}.json");
+            var req = BuildRequestUri($"price_rules/{id}.json");
             var content = new JsonContent(new
             {
                 price_rule = rule
@@ -73,7 +73,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{id}.json");
+            var req = BuildRequestUri($"price_rules/{id}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
 
         public virtual async Task<Product> CreateAsync(Product product, ProductCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("products.json");
+            var req = BuildRequestUri("products.json");
             var body = product.ToDictionary();
 
             if (options != null)
@@ -56,7 +56,7 @@ namespace ShopifySharp
 
         public virtual async Task<Product> UpdateAsync(long productId, Product product, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}.json");
+            var req = BuildRequestUri($"products/{productId}.json");
             var content = new JsonContent(new
             {
                 product = product
@@ -68,14 +68,14 @@ namespace ShopifySharp
 
         public virtual async Task DeleteAsync(long productId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}.json");
+            var req = BuildRequestUri($"products/{productId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         public virtual async Task<Product> PublishAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{id}.json");
+            var req = BuildRequestUri($"products/{id}.json");
             var content = new JsonContent(new
             {
                 product = new
@@ -91,7 +91,7 @@ namespace ShopifySharp
 
         public virtual async Task<Product> UnpublishAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{id}.json");
+            var req = BuildRequestUri($"products/{id}.json");
             var content = new JsonContent(new
             {
                 product = new

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ProductImage> CreateAsync(long productId, ProductImage image, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/images.json");
+            var req = BuildRequestUri($"products/{productId}/images.json");
             var content = new JsonContent(new
             {
                 image = image
@@ -53,7 +53,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ProductImage> UpdateAsync(long productId, long productImageId, ProductImage image, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/images/{productImageId}.json");
+            var req = BuildRequestUri($"products/{productId}/images/{productImageId}.json");
             var content = new JsonContent(new
             {
                 image = image
@@ -66,7 +66,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task DeleteAsync(long productId, long imageId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/images/{imageId}.json");
+            var req = BuildRequestUri($"products/{productId}/images/{imageId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/ProductListing/ProductListingService.cs
+++ b/ShopifySharp/Services/ProductListing/ProductListingService.cs
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ProductListing> CreateAsync(long productId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"product_listings/{productId}.json");
+            var req = BuildRequestUri($"product_listings/{productId}.json");
             var content = new JsonContent(new
             {
                 product_listing = new { product_id = productId }
@@ -55,7 +55,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long productId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"product_listings/{productId}.json");
+            var req = BuildRequestUri($"product_listings/{productId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ProductVariant> CreateAsync(long productId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/variants.json");
+            var req = BuildRequestUri($"products/{productId}/variants.json");
             var content = new JsonContent(new
             {
                 variant = variant
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ProductVariant> UpdateAsync(long productVariantId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"variants/{productVariantId}.json");
+            var req = BuildRequestUri($"variants/{productVariantId}.json");
             var content = new JsonContent(new
             {
                 variant = variant
@@ -72,7 +72,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long productId, long variantId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/variants/{variantId}.json");
+            var req = BuildRequestUri($"products/{productId}/variants/{variantId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Redirect> GetAsync(long redirectId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"redirects/{redirectId}.json");
+            var req = BuildRequestUri($"redirects/{redirectId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Redirect> CreateAsync(Redirect redirect, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("redirects.json");
+            var req = BuildRequestUri("redirects.json");
             var content = new JsonContent(new
             {
                 redirect = redirect
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Redirect> UpdateAsync(long redirectId, Redirect redirect, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"redirects/{redirectId}.json");
+            var req = BuildRequestUri($"redirects/{redirectId}.json");
             var content = new JsonContent(new
             {
                 redirect = redirect
@@ -75,7 +75,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long redirectId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"redirects/{redirectId}.json");
+            var req = BuildRequestUri($"redirects/{redirectId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Refund> CalculateAsync(long orderId, Refund options, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/refunds/calculate.json");
+            var req = BuildRequestUri($"orders/{orderId}/refunds/calculate.json");
             var content = new JsonContent(new { refund = options });
             var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, cancellationToken, content, "refund");
 
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Refund> RefundAsync(long orderId, Refund options, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/refunds.json");
+            var req = BuildRequestUri($"orders/{orderId}/refunds.json");
             var content = new JsonContent(new { refund = options });
             var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, cancellationToken, content, "refund");
 

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ScriptTag> GetAsync(long tagId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"script_tags/{tagId}.json");
+            var req = BuildRequestUri($"script_tags/{tagId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -55,7 +55,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ScriptTag> CreateAsync(ScriptTag tag, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("script_tags.json");
+            var req = BuildRequestUri("script_tags.json");
             var content = new JsonContent(new
             {
                 script_tag = tag
@@ -68,7 +68,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ScriptTag> UpdateAsync(long scriptTagId, ScriptTag tag, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"script_tags/{scriptTagId}.json");
+            var req = BuildRequestUri($"script_tags/{scriptTagId}.json");
             var content = new JsonContent(new
             {
                 script_tag = tag
@@ -81,7 +81,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task DeleteAsync(long tagId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"script_tags/{tagId}.json");
+            var req = BuildRequestUri($"script_tags/{tagId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
+++ b/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<ShippingZone>> ListAsync(ShippingZoneListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("shipping_zones.json");
+            var req = BuildRequestUri("shipping_zones.json");
             
             if (filter != null)
             {

--- a/ShopifySharp/Services/Shop/ShopService.cs
+++ b/ShopifySharp/Services/Shop/ShopService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task UninstallAppAsync(CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest("api_permissions/current.json");
+            var request = BuildRequestUri("api_permissions/current.json");
 
             await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken: cancellationToken);
         }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -218,9 +218,6 @@ namespace ShopifySharp
         /// Executes a request and returns a JToken for querying. Throws an exception when the response is invalid.
         /// Use this method when the expected response is a single line or simple object that doesn't warrant its own class.
         /// </summary>
-        /// <remarks>
-        /// This method will automatically dispose the <paramref name="baseClient"/> and <paramref name="content" /> when finished.
-        /// </remarks>
         protected async Task<RequestResult<JToken>> ExecuteRequestAsync(
             RequestUri uri,
             HttpMethod method,
@@ -236,9 +233,6 @@ namespace ShopifySharp
         /// Executes a request and returns the given type. Throws an exception when the response is invalid.
         /// Use this method when the expected response is a single line or simple object that doesn't warrant its own class.
         /// </summary>
-        /// <remarks>
-        /// This method will automatically dispose the <paramref name="baseRequestMessage" /> when finished.
-        /// </remarks>
         protected async Task<RequestResult<T>> ExecuteRequestAsync<T>(
             RequestUri uri,
             HttpMethod method,

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -20,10 +20,10 @@ namespace ShopifySharp
         #nullable enable
 
         public virtual string APIVersion => "2023-07";
+        public virtual bool SupportsAPIVersioning => true;
 
         protected Uri _ShopUri { get; set; }
         protected string _AccessToken { get; set; }
-        protected virtual bool SupportsAPIVersioning => true;
 
         private static IRequestExecutionPolicy _GlobalExecutionPolicy = new DefaultRequestExecutionPolicy();
         private static IHttpClientFactory _HttpClientFactory = new InternalHttpClientFactory();

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> CreateAsync(SmartCollection collection, bool published = true, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections.json");
+            var req = BuildRequestUri($"smart_collections.json");
             var body = collection.ToDictionary();
 
             body.Add("published", published);
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> UpdateAsync(long smartCollectionId, SmartCollection collection, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}.json");
             var content = new JsonContent(new
             {
                 smart_collection = collection
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> PublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}.json");
             var body = new Dictionary<string, object>()
             {
                 { "id", smartCollectionId },
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> UnpublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}.json");
             var body = new Dictionary<string, object>()
             {
                 { "id", smartCollectionId },
@@ -105,7 +105,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task UpdateProductOrderAsync(long smartCollectionId, string sortOrder = null, params long[] productIds)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}/order.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}/order.json");
             var content = new JsonContent(new
             {
                 sort_order = sortOrder,
@@ -117,7 +117,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task UpdateProductOrderAsync(long smartCollectionId, CancellationToken cancellationToken, string sortOrder = null, params long[] productIds)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}/order.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}/order.json");
             var content = new JsonContent(new
             {
                 sort_order = sortOrder,
@@ -129,7 +129,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long collectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{collectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{collectionId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/StorefrontAccessToken/StorefrontAccessTokenService.cs
+++ b/ShopifySharp/Services/StorefrontAccessToken/StorefrontAccessTokenService.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public async Task<StorefrontAccessToken> CreateAsync(string title, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("storefront_access_tokens.json");
+            var req = BuildRequestUri("storefront_access_tokens.json");
             var content = new JsonContent(new
             {
                 storefront_access_token = new
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"storefront_access_tokens/{id}.json");
+            var req = BuildRequestUri($"storefront_access_tokens/{id}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public async Task<IEnumerable<StorefrontAccessToken>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("storefront_access_tokens.json");
+            var req = BuildRequestUri("storefront_access_tokens.json");
             var response = await ExecuteRequestAsync<IEnumerable<StorefrontAccessToken>>(req, HttpMethod.Get, cancellationToken, rootElement: "storefront_access_tokens");
 
             return response.Result;

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Theme> GetAsync(long themeId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}.json");
+            var req = BuildRequestUri($"themes/{themeId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<Theme> UpdateAsync(long themeId, Theme theme, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}.json");
+            var req = BuildRequestUri($"themes/{themeId}.json");
             var content = new JsonContent(new
             {
                 theme = theme
@@ -62,14 +62,14 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task DeleteAsync(long themeId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}.json");
+            var req = BuildRequestUri($"themes/{themeId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         private async Task<Theme> _CreateAsync(Theme theme, CancellationToken cancellationToken, string sourceUrl = null)
         {
-            var req = PrepareRequest("themes.json");
+            var req = BuildRequestUri("themes.json");
             var body = theme.ToDictionary();
 
             if (!string.IsNullOrEmpty(sourceUrl))

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
 
         public virtual async Task<Transaction> CreateAsync(long orderId, Transaction transaction, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/transactions.json");
+            var req = BuildRequestUri($"orders/{orderId}/transactions.json");
             var content = new JsonContent(new
             {
                 transaction = transaction

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<UsageCharge> CreateAsync(long recurringChargeId, string description, decimal price, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
+            var req = BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
             var content = new JsonContent(new
             {
                 usage_charge = new
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<UsageCharge> GetAsync(long recurringChargeId, long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges/{id}.json");
+            var req = BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges/{id}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -54,7 +54,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, UsageChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
+            var req = BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
 
             if (filter != null)
             {


### PR DESCRIPTION
This change is aimed at making it easier to control the final url for API requests when you need to create your own Shopify service class, and that service does not send requests to the two paths that were built by `ShopifyService.PrepareRequest`.

(This was an actual painpoint of mine when I had to implement my own version of the PartnerService in a different project before we added it to ShopifySharp.)

This change also makes testing ShopifySharp services much easier in situations where you want to stub calls to the Shopify API. You should now be able to completely control where the requests are going to be sent, so instead of the OrderService sending tests to `example.myshopify.com/admin/api/2023-10/orders.json` you can have your stub send requests to `localhost:whatever/shopify/stub/orders.json`.