### PR TITLE
Let the service factories inject the IShopifyDomainUtility into Shopify services

### DIFF
--- a/.github/scripts/generate_internal_constructors.fish
+++ b/.github/scripts/generate_internal_constructors.fish
@@ -1,0 +1,20 @@
+#! /usr/bin/env fish
+
+for service_file in (ls ShopifySharp/Services/*/*Service.cs)
+    set service_name (rg -o -e "public class ([A-Z]\w+)Service" "$service_file")
+    set service_name (string replace "public class " "" "$service_name")
+
+    # The for loop will have matched interfaces as well, don't operate on those.
+    # The PartnerService and GraphService have constructors that are multiple lines long, which is not worth the extra complication of dealing with in this script.
+    if test -n "$service_name" -a "$service_name" != "PartnerService" -a "$service_name" != "GraphService"
+        rg --vimgrep "public $service_name\(" "$service_file" | while read -l line
+            set file (echo $line | awk -F":" '{print $1}')
+            set line_number (echo $line | awk -F":" '{print $2}')
+            echo "$file"
+            sed -i '' "$line_number a\\
+        internal $service_name(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}\\
+ " $file
+        end
+        echo $service_name
+    end
+end

--- a/ShopifySharp.Experimental/ApplicationCredit.fs
+++ b/ShopifySharp.Experimental/ApplicationCredit.fs
@@ -60,11 +60,11 @@ module ApplicationCredits =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (data : ApplicationCreditProperties) =
-            let req = base.PrepareRequest "application_credits.json"
+            let req = base.BuildRequestUri("application_credits.json")
             let data = dict [ "application_credit" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<ApplicationCredit>(req, HttpMethod.Post, CancellationToken.None, content, "usage_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/Charges.fs
+++ b/ShopifySharp.Experimental/Charges.fs
@@ -61,11 +61,11 @@ module Charges =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (data : ChargeProperties) =
-            let req = base.PrepareRequest "application_charges.json"
+            let req = base.BuildRequestUri("application_charges.json")
             let data = dict [ "application_charge" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Charge>(req, HttpMethod.Post, CancellationToken.None, content, "application_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/Orders.fs
+++ b/ShopifySharp.Experimental/Orders.fs
@@ -3,8 +3,6 @@
 open System.Collections.Generic
 open System.Net.Http
 open System.Threading
-open System.Threading
-open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -274,25 +272,25 @@ module Orders =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (order: OrderProperties) =
-            let req = base.PrepareRequest "orders.json"
+            let req = base.BuildRequestUri("orders.json")
             let data = dict [ "order" => order ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, CancellationToken.None, content, "order")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.CreateAsync(order: OrderProperties, options: CreationOptions.CreationOptionProperties) =
-            let req = base.PrepareRequest "orders.json"
+            let req = base.BuildRequestUri("orders.json")
             let data = dict [ "order", mergeOrderAndCreationOptions order options |> JsonValue.MapPropertyValuesToObjects ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Order>(req, HttpMethod.Post, CancellationToken.None, content, "order")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.UpdateAsync (id: int64, order: OrderProperties) =
-            let req = base.PrepareRequest (sprintf "orders/%i.json" id)
+            let req = base.BuildRequestUri($"orders/{id}.json")
             let data = dict [ "order" => order ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<Order>(req, HttpMethod.Put, CancellationToken.None, content, "order")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/RecurringCharges.fs
+++ b/ShopifySharp.Experimental/RecurringCharges.fs
@@ -73,11 +73,11 @@ module RecurringCharges =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (data : RecurringChargeProperties) =
-            let req = base.PrepareRequest "recurring_application_charges.json"
+            let req = base.BuildRequestUri("recurring_application_charges.json")
             let data = dict [ "recurring_application_charge" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<RecurringCharge>(req, HttpMethod.Post, CancellationToken.None, content, "recurring_application_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/ScriptTags.fs
+++ b/ShopifySharp.Experimental/ScriptTags.fs
@@ -2,7 +2,6 @@
 
 open System.Net.Http
 open System.Threading
-open System.Threading
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -79,18 +78,18 @@ module ScriptTags =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (tag : ScriptTagProperties) =
-            let req = base.PrepareRequest "script_tags.json"
+            let req = base.BuildRequestUri("script_tags.json")
             let data = dict [ "script_tag" => tag ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Post, CancellationToken.None, content, "script_tag")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.UpdateAsync (id : int64, tag : ScriptTagProperties) =
-            let req = base.PrepareRequest (sprintf "script_tags/%i.json" id)
+            let req = base.BuildRequestUri($"script_tags/{id}.json")
             let data = dict [ "script_tag" => tag ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<ScriptTag>(req, HttpMethod.Put, CancellationToken.None, content, "script_tag")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/UsageCharges.fs
+++ b/ShopifySharp.Experimental/UsageCharges.fs
@@ -53,11 +53,11 @@ module UsageCharges =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
 
         member x.CreateAsync (recurringChargeId : int64, data : UsageChargeProperties) =
-            let req = base.PrepareRequest (sprintf "recurring_application_charges/%i/usage_charges.json" recurringChargeId)
+            let req = base.BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges.json")
             let data = dict [ "usage_charge" => data ]
             let content = new JsonContent(data)
             base.ExecuteRequestAsync<UsageCharge>(req, HttpMethod.Post, CancellationToken.None, content, "usage_charge")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Experimental/Webhooks.fs
+++ b/ShopifySharp.Experimental/Webhooks.fs
@@ -2,8 +2,6 @@ namespace ShopifySharp.Experimental
 
 open System.Net.Http
 open System.Threading
-open System.Threading
-open System.Threading.Tasks
 open ShopifySharp
 open ShopifySharp.Infrastructure
 
@@ -80,20 +78,20 @@ module Webhooks =
         do match policy with | None -> (); | Some p -> base.SetExecutionPolicy p
              
         member x.CreateAsync (webhook: WebhookProperties) =
-            let req = base.PrepareRequest "webhooks.json"
+            let req = base.BuildRequestUri("webhooks.json")
             let data = dict [ "webhook" => webhook ]
             let content = new JsonContent(data)
             
             base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Post, CancellationToken.None, content, "webhook")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
             
         member x.UpdateAsync (id: int64, webhook: WebhookProperties) =
-            let req = base.PrepareRequest (sprintf "webhooks/%i.json" id)
+            let req = base.BuildRequestUri($"webhooks/{id}.json")
             let data = dict [ "webhook" => webhook ]
             let content = new JsonContent(data)
             
             base.ExecuteRequestAsync<Webhook>(req, HttpMethod.Put, CancellationToken.None, content, "webhook")
-            |> mapTask (fun response -> response.Result)
+            |> mapTask (_.Result)
 
         static member NewService domain accessToken = Service(domain, accessToken)
         static member NewServiceWithPolicy domain accessToken policy = Service(domain, accessToken, policy)

--- a/ShopifySharp.Extensions.DependencyInjection.Tests/FactoryServiceTests.cs
+++ b/ShopifySharp.Extensions.DependencyInjection.Tests/FactoryServiceTests.cs
@@ -1,3 +1,5 @@
+using ShopifySharp.Utilities;
+
 namespace ShopifySharp.Extensions.DependencyInjection.Tests;
 
 public class FactoryServiceTests
@@ -31,6 +33,28 @@ public class FactoryServiceTests
         var container = new ServiceCollection();
         container.AddShopifySharpServiceFactories();
         container.AddShopifySharpRequestExecutionPolicy<TestRequestExecutionPolicy>();
+        var serviceProvider = container.BuildServiceProvider();
+
+        // Act
+        var orderServiceFactory = serviceProvider.GetRequiredService<IOrderServiceFactory>();
+        var orderService = orderServiceFactory.Create(_credentials);
+        var act = () => orderService.ListAsync();
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<TestException>();
+    }
+
+    [Fact]
+    public async Task FactoryServices_WhenDomainUtilityIsInjected_ShouldCreateServiceWithTheUtility()
+    {
+        // Setup
+        var container = new ServiceCollection();
+        container.AddShopifySharpServiceFactories();
+        container.AddShopifySharpUtilities(options =>
+        {
+            options.DomainUtility = new ShopifyDomainUtility();
+        });
         var serviceProvider = container.BuildServiceProvider();
 
         // Act

--- a/ShopifySharp.Extensions.DependencyInjection.Tests/ServiceCollectionExtensionTests.cs
+++ b/ShopifySharp.Extensions.DependencyInjection.Tests/ServiceCollectionExtensionTests.cs
@@ -24,13 +24,35 @@ public class ServiceCollectionExtensionTests
     }
 
     [Fact]
+    public void AddShopifySharpRequestExecutionPolicy_AllowsAddingMoreThanOnePolicy()
+    {
+        // Setup
+        var container = new ServiceCollection();
+
+        // Act
+        container.AddShopifySharpRequestExecutionPolicy<DefaultRequestExecutionPolicy>()
+            .AddShopifySharpRequestExecutionPolicy<LeakyBucketExecutionPolicy>()
+            .AddShopifySharpRequestExecutionPolicy<TestRequestExecutionPolicy>();
+
+        // Assert
+        var serviceProvider = container.BuildServiceProvider();
+        var policy = serviceProvider.GetService<IRequestExecutionPolicy>();
+
+        policy.Should()
+            .NotBeNull()
+            .And
+            .BeOfType<TestRequestExecutionPolicy>();
+    }
+
+    [Fact]
     public void AddShopifySharpUtilities_AddsUtilities()
     {
         // Setup
         var container = new ServiceCollection();
 
         // Act
-        var serviceProvider = container.AddShopifySharpUtilities().BuildServiceProvider();
+        var serviceProvider = container.AddShopifySharpUtilities()
+            .BuildServiceProvider();
 
         // Assert
         serviceProvider.GetService<IShopifyDomainUtility>()
@@ -48,6 +70,63 @@ public class ServiceCollectionExtensionTests
             .NotBeNull()
             .And.BeOfType<ShopifyRequestValidationUtility>()
             .And.BeAssignableTo<IShopifyRequestValidationUtility>();
+    }
+
+    [Fact]
+    public void AddShopifySharpUtilities_HandlesNullUtilities()
+    {
+        // Setup
+        var container = new ServiceCollection();
+
+        // Act
+        var serviceProvider = container.AddShopifySharpUtilities(options =>
+            {
+                options.DomainUtility = null;
+                options.OauthUtility = null;
+                options.RequestValidationUtility = null;
+            })
+            .BuildServiceProvider();
+
+        // Assert
+        serviceProvider.GetService<IShopifyDomainUtility>()
+            .Should()
+            .NotBeNull()
+            .And.BeOfType<ShopifyDomainUtility>()
+            .And.BeAssignableTo<IShopifyDomainUtility>();
+        serviceProvider.GetService<IShopifyOauthUtility>()
+            .Should()
+            .NotBeNull()
+            .And.BeOfType<ShopifyOauthUtility>()
+            .And.BeAssignableTo<IShopifyOauthUtility>();
+        serviceProvider.GetService<IShopifyRequestValidationUtility>()
+            .Should()
+            .NotBeNull()
+            .And.BeOfType<ShopifyRequestValidationUtility>()
+            .And.BeAssignableTo<IShopifyRequestValidationUtility>();
+    }
+
+    [Fact]
+    public void AddShopifySharpUtilities_AddsCustomUtilities()
+    {
+        // Setup
+        var container = new ServiceCollection();
+
+        // Act
+        var domainUtility = container.AddShopifySharpUtilities(options =>
+            {
+                options.DomainUtility = new TestDomainUtility();
+            })
+            .BuildServiceProvider()
+            .GetService<IShopifyDomainUtility>();
+        var getUri = () => domainUtility!.BuildShopDomainUri("some-shop-domain");
+
+        // Assert
+        domainUtility.Should()
+            .NotBeNull()
+            .And.BeOfType<TestDomainUtility>()
+            .And.BeAssignableTo<IShopifyDomainUtility>();
+
+        getUri.Should().Throw<TestException>();
     }
 
     [Fact]

--- a/ShopifySharp.Extensions.DependencyInjection.Tests/TestClasses.cs
+++ b/ShopifySharp.Extensions.DependencyInjection.Tests/TestClasses.cs
@@ -1,4 +1,5 @@
 using ShopifySharp.Infrastructure;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Extensions.DependencyInjection.Tests;
 
@@ -12,6 +13,21 @@ public class TestRequestExecutionPolicy : IRequestExecutionPolicy
         CancellationToken cancellationToken,
         int? graphqlQueryCost = null
     )
+    {
+        throw new TestException();
+    }
+}
+
+public class TestDomainUtility : IShopifyDomainUtility
+{
+    /// <inheritdoc />
+    public Uri BuildShopDomainUri(string shopDomain)
+    {
+        throw new TestException();
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsValidShopDomainAsync(string shopDomain, CancellationToken cancellationToken = default)
     {
         throw new TestException();
     }

--- a/ShopifySharp.Extensions.DependencyInjection/ConfigurationOptions.cs
+++ b/ShopifySharp.Extensions.DependencyInjection/ConfigurationOptions.cs
@@ -1,0 +1,10 @@
+using ShopifySharp.Utilities;
+
+namespace ShopifySharp.Extensions.DependencyInjection;
+
+public record ShopifySharpUtilityOptions
+{
+    public IShopifyDomainUtility? DomainUtility { get; set; }
+    public IShopifyOauthUtility? OauthUtility { get; set; }
+    public IShopifyRequestValidationUtility? RequestValidationUtility { get; set; }
+}

--- a/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -16,13 +16,14 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds a <see cref="IRequestExecutionPolicy"/> to your Dependency Injection container. ShopifySharp service factories
     /// managed by your container will use this policy when creating ShopifySharp services.
+    /// <p>Note: Policies are not true middleware, ShopifySharp services can only use one policy at this time.</p>
     /// </summary>
     /// <typeparam name="T">A class that implements ShopifySharp's <see cref="IRequestExecutionPolicy"/> interface.</typeparam>
     public static IServiceCollection AddShopifySharpRequestExecutionPolicy<T>(this IServiceCollection services)
         where T : class, IRequestExecutionPolicy
     {
         // TODO: add ServiceLifetime parameter
-        services.TryAddSingleton<IRequestExecutionPolicy, T>();
+        services.AddSingleton<IRequestExecutionPolicy, T>();
         return services;
     }
 

--- a/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using ShopifySharp.Factories;
@@ -32,13 +33,40 @@ public static class ServiceCollectionExtensions
     /// <item><see cref="IShopifyDomainUtility"/></item>
     /// <item><see cref="IShopifyRequestValidationUtility"/></item>
     /// </list>
+    /// <param name="configure">An optional configuration action for configuring the utilities.</param>
     /// </summary>
-    public static IServiceCollection AddShopifySharpUtilities(this IServiceCollection services)
+    public static IServiceCollection AddShopifySharpUtilities(this IServiceCollection services, Action<ShopifySharpUtilityOptions>? configure = null)
     {
+        var options = new ShopifySharpUtilityOptions();
+        configure?.Invoke(options);
+
         // TODO: add ServiceLifetime parameter
-        services.TryAddSingleton<IShopifyOauthUtility, ShopifyOauthUtility>();
-        services.TryAddSingleton<IShopifyDomainUtility, ShopifyDomainUtility>();
-        services.TryAddSingleton<IShopifyRequestValidationUtility, ShopifyRequestValidationUtility>();
+        if(options.OauthUtility != null)
+        {
+            services.AddSingleton(options.OauthUtility);
+        }
+        else
+        {
+            services.TryAddSingleton<IShopifyOauthUtility, ShopifyOauthUtility>();
+        }
+
+        if(options.DomainUtility != null)
+        {
+            services.AddSingleton(options.DomainUtility);
+        }
+        else
+        {
+            services.TryAddSingleton<IShopifyDomainUtility, ShopifyDomainUtility>();
+        }
+
+        if(options.RequestValidationUtility != null)
+        {
+            services.AddSingleton(options.RequestValidationUtility);
+        }
+        else
+        {
+            services.TryAddSingleton<IShopifyRequestValidationUtility, ShopifyRequestValidationUtility>();
+        }
 
         return services;
     }

--- a/ShopifySharp.Tests/Services/ShopifyServiceTests.cs
+++ b/ShopifySharp.Tests/Services/ShopifyServiceTests.cs
@@ -1,0 +1,30 @@
+using System;
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Tests.TestClasses;
+using Xunit;
+
+namespace ShopifySharp.Tests.Services;
+
+[Trait("Category", "ShopifyService")]
+[TestSubject(typeof(ShopifyService))]
+public class ShopifyServiceTests
+{
+    #region PrepareRequest(string path) and BuildRequestUri
+
+    [Fact]
+    public void BuildRequestUri_ShouldReturnOverridenUri()
+    {
+        // Setup
+        var expectedUri = new Uri("https://some-expected-uri.com", UriKind.Absolute);
+        var service = new TestBuildRequestUriShopifyService(expectedUri);
+
+        // Act
+        var result = service.BuildRequestUriProxy();
+
+        // Assert
+        result.ToUri().Should().Be(expectedUri);
+    }
+
+    #endregion
+}

--- a/ShopifySharp.Tests/ShopifyService_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyService_Tests.cs
@@ -5,12 +5,16 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using ShopifySharp.Filters;
 using Xunit;
+
+// TODO: move the tests in this file to the ShopifySharp.Tests.Services.ShopifyServiceTests file
 
 namespace ShopifySharp.Tests
 {
     [Trait("Category", "ShopifyService"), Trait("Category", "DotNetFramework"), Collection("DotNetFramework tests")]
+    [TestSubject(typeof(ShopifyService))]
     public class ShopifyService_Tests
     {
         string ReasonPhrase(HttpStatusCode code)

--- a/ShopifySharp.Tests/TestClasses/TestBuildRequestUriShopifyService.cs
+++ b/ShopifySharp.Tests/TestClasses/TestBuildRequestUriShopifyService.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+
+namespace ShopifySharp.Tests.TestClasses;
+
+/// <summary>
+/// A test ShopifyService that overrides the <see cref="ShopifyService.BuildRequestUri(string)"/> method for testing.
+/// </summary>
+/// <param name="requestUri">The uri you want the overriden <see cref="ShopifyService.BuildRequestUri(string)"/> to return for testing.</param>
+public class TestBuildRequestUriShopifyService(Uri requestUri) : ShopifyService("some-shop-domain", "some-access-token")
+{
+    protected override RequestUri BuildRequestUri(string _)
+    {
+        return new RequestUri(requestUri);
+    }
+
+    public RequestUri BuildRequestUriProxy() => BuildRequestUri("some-path");
+}

--- a/ShopifySharp/Factories/AccessScopeServiceFactory.cs
+++ b/ShopifySharp/Factories/AccessScopeServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IAccessScopeServiceFactory
     IAccessScopeService Create(ShopifyApiCredentials credentials);
 }
 
-public class AccessScopeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IAccessScopeServiceFactory
+public class AccessScopeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IAccessScopeServiceFactory
 {
     /// <inheritDoc />
     public virtual IAccessScopeService Create(string shopDomain, string accessToken)
     {
-        var service = new AccessScopeService(shopDomain, accessToken);
+        IAccessScopeService service = shopifyDomainUtility is null ? new AccessScopeService(shopDomain, accessToken) : new AccessScopeService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
+++ b/ShopifySharp/Factories/ApplicationCreditServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IApplicationCreditServiceFactory
     IApplicationCreditService Create(ShopifyApiCredentials credentials);
 }
 
-public class ApplicationCreditServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IApplicationCreditServiceFactory
+public class ApplicationCreditServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IApplicationCreditServiceFactory
 {
     /// <inheritDoc />
     public virtual IApplicationCreditService Create(string shopDomain, string accessToken)
     {
-        var service = new ApplicationCreditService(shopDomain, accessToken);
+        IApplicationCreditService service = shopifyDomainUtility is null ? new ApplicationCreditService(shopDomain, accessToken) : new ApplicationCreditService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ArticleServiceFactory.cs
+++ b/ShopifySharp/Factories/ArticleServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IArticleServiceFactory
     IArticleService Create(ShopifyApiCredentials credentials);
 }
 
-public class ArticleServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IArticleServiceFactory
+public class ArticleServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IArticleServiceFactory
 {
     /// <inheritDoc />
     public virtual IArticleService Create(string shopDomain, string accessToken)
     {
-        var service = new ArticleService(shopDomain, accessToken);
+        IArticleService service = shopifyDomainUtility is null ? new ArticleService(shopDomain, accessToken) : new ArticleService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/AssetServiceFactory.cs
+++ b/ShopifySharp/Factories/AssetServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IAssetServiceFactory
     IAssetService Create(ShopifyApiCredentials credentials);
 }
 
-public class AssetServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IAssetServiceFactory
+public class AssetServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IAssetServiceFactory
 {
     /// <inheritDoc />
     public virtual IAssetService Create(string shopDomain, string accessToken)
     {
-        var service = new AssetService(shopDomain, accessToken);
+        IAssetService service = shopifyDomainUtility is null ? new AssetService(shopDomain, accessToken) : new AssetService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/AssignedFulfillmentOrderServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IAssignedFulfillmentOrderServiceFactory
     IAssignedFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class AssignedFulfillmentOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IAssignedFulfillmentOrderServiceFactory
+public class AssignedFulfillmentOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IAssignedFulfillmentOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IAssignedFulfillmentOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new AssignedFulfillmentOrderService(shopDomain, accessToken);
+        IAssignedFulfillmentOrderService service = shopifyDomainUtility is null ? new AssignedFulfillmentOrderService(shopDomain, accessToken) : new AssignedFulfillmentOrderService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/BlogServiceFactory.cs
+++ b/ShopifySharp/Factories/BlogServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IBlogServiceFactory
     IBlogService Create(ShopifyApiCredentials credentials);
 }
 
-public class BlogServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IBlogServiceFactory
+public class BlogServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IBlogServiceFactory
 {
     /// <inheritDoc />
     public virtual IBlogService Create(string shopDomain, string accessToken)
     {
-        var service = new BlogService(shopDomain, accessToken);
+        IBlogService service = shopifyDomainUtility is null ? new BlogService(shopDomain, accessToken) : new BlogService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/CancellationRequestServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICancellationRequestServiceFactory
     ICancellationRequestService Create(ShopifyApiCredentials credentials);
 }
 
-public class CancellationRequestServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICancellationRequestServiceFactory
+public class CancellationRequestServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICancellationRequestServiceFactory
 {
     /// <inheritDoc />
     public virtual ICancellationRequestService Create(string shopDomain, string accessToken)
     {
-        var service = new CancellationRequestService(shopDomain, accessToken);
+        ICancellationRequestService service = shopifyDomainUtility is null ? new CancellationRequestService(shopDomain, accessToken) : new CancellationRequestService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CarrierServiceFactory.cs
+++ b/ShopifySharp/Factories/CarrierServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICarrierServiceFactory
     ICarrierService Create(ShopifyApiCredentials credentials);
 }
 
-public class CarrierServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICarrierServiceFactory
+public class CarrierServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICarrierServiceFactory
 {
     /// <inheritDoc />
     public virtual ICarrierService Create(string shopDomain, string accessToken)
     {
-        var service = new CarrierService(shopDomain, accessToken);
+        ICarrierService service = shopifyDomainUtility is null ? new CarrierService(shopDomain, accessToken) : new CarrierService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/ChargeServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IChargeServiceFactory
     IChargeService Create(ShopifyApiCredentials credentials);
 }
 
-public class ChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IChargeServiceFactory
+public class ChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IChargeServiceFactory
 {
     /// <inheritDoc />
     public virtual IChargeService Create(string shopDomain, string accessToken)
     {
-        var service = new ChargeService(shopDomain, accessToken);
+        IChargeService service = shopifyDomainUtility is null ? new ChargeService(shopDomain, accessToken) : new ChargeService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutSalesChannelServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICheckoutSalesChannelServiceFactory
     ICheckoutSalesChannelService Create(ShopifyApiCredentials credentials);
 }
 
-public class CheckoutSalesChannelServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICheckoutSalesChannelServiceFactory
+public class CheckoutSalesChannelServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICheckoutSalesChannelServiceFactory
 {
     /// <inheritDoc />
     public virtual ICheckoutSalesChannelService Create(string shopDomain, string accessToken)
     {
-        var service = new CheckoutSalesChannelService(shopDomain, accessToken);
+        ICheckoutSalesChannelService service = shopifyDomainUtility is null ? new CheckoutSalesChannelService(shopDomain, accessToken) : new CheckoutSalesChannelService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CheckoutServiceFactory.cs
+++ b/ShopifySharp/Factories/CheckoutServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICheckoutServiceFactory
     ICheckoutService Create(ShopifyApiCredentials credentials);
 }
 
-public class CheckoutServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICheckoutServiceFactory
+public class CheckoutServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICheckoutServiceFactory
 {
     /// <inheritDoc />
     public virtual ICheckoutService Create(string shopDomain, string accessToken)
     {
-        var service = new CheckoutService(shopDomain, accessToken);
+        ICheckoutService service = shopifyDomainUtility is null ? new CheckoutService(shopDomain, accessToken) : new CheckoutService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CollectServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICollectServiceFactory
     ICollectService Create(ShopifyApiCredentials credentials);
 }
 
-public class CollectServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICollectServiceFactory
+public class CollectServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICollectServiceFactory
 {
     /// <inheritDoc />
     public virtual ICollectService Create(string shopDomain, string accessToken)
     {
-        var service = new CollectService(shopDomain, accessToken);
+        ICollectService service = shopifyDomainUtility is null ? new CollectService(shopDomain, accessToken) : new CollectService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CollectionListingServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionListingServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICollectionListingServiceFactory
     ICollectionListingService Create(ShopifyApiCredentials credentials);
 }
 
-public class CollectionListingServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICollectionListingServiceFactory
+public class CollectionListingServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICollectionListingServiceFactory
 {
     /// <inheritDoc />
     public virtual ICollectionListingService Create(string shopDomain, string accessToken)
     {
-        var service = new CollectionListingService(shopDomain, accessToken);
+        ICollectionListingService service = shopifyDomainUtility is null ? new CollectionListingService(shopDomain, accessToken) : new CollectionListingService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CollectionServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICollectionServiceFactory
     ICollectionService Create(ShopifyApiCredentials credentials);
 }
 
-public class CollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICollectionServiceFactory
+public class CollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICollectionServiceFactory
 {
     /// <inheritDoc />
     public virtual ICollectionService Create(string shopDomain, string accessToken)
     {
-        var service = new CollectionService(shopDomain, accessToken);
+        ICollectionService service = shopifyDomainUtility is null ? new CollectionService(shopDomain, accessToken) : new CollectionService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CountryServiceFactory.cs
+++ b/ShopifySharp/Factories/CountryServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICountryServiceFactory
     ICountryService Create(ShopifyApiCredentials credentials);
 }
 
-public class CountryServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICountryServiceFactory
+public class CountryServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICountryServiceFactory
 {
     /// <inheritDoc />
     public virtual ICountryService Create(string shopDomain, string accessToken)
     {
-        var service = new CountryService(shopDomain, accessToken);
+        ICountryService service = shopifyDomainUtility is null ? new CountryService(shopDomain, accessToken) : new CountryService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomCollectionServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICustomCollectionServiceFactory
     ICustomCollectionService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomCollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomCollectionServiceFactory
+public class CustomCollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICustomCollectionServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomCollectionService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomCollectionService(shopDomain, accessToken);
+        ICustomCollectionService service = shopifyDomainUtility is null ? new CustomCollectionService(shopDomain, accessToken) : new CustomCollectionService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerAddressServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICustomerAddressServiceFactory
     ICustomerAddressService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomerAddressServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomerAddressServiceFactory
+public class CustomerAddressServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICustomerAddressServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomerAddressService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomerAddressService(shopDomain, accessToken);
+        ICustomerAddressService service = shopifyDomainUtility is null ? new CustomerAddressService(shopDomain, accessToken) : new CustomerAddressService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerSavedSearchServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICustomerSavedSearchServiceFactory
     ICustomerSavedSearchService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomerSavedSearchServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomerSavedSearchServiceFactory
+public class CustomerSavedSearchServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICustomerSavedSearchServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomerSavedSearchService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomerSavedSearchService(shopDomain, accessToken);
+        ICustomerSavedSearchService service = shopifyDomainUtility is null ? new CustomerSavedSearchService(shopDomain, accessToken) : new CustomerSavedSearchService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/CustomerServiceFactory.cs
+++ b/ShopifySharp/Factories/CustomerServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ICustomerServiceFactory
     ICustomerService Create(ShopifyApiCredentials credentials);
 }
 
-public class CustomerServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ICustomerServiceFactory
+public class CustomerServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ICustomerServiceFactory
 {
     /// <inheritDoc />
     public virtual ICustomerService Create(string shopDomain, string accessToken)
     {
-        var service = new CustomerService(shopDomain, accessToken);
+        ICustomerService service = shopifyDomainUtility is null ? new CustomerService(shopDomain, accessToken) : new CustomerService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
+++ b/ShopifySharp/Factories/DiscountCodeServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IDiscountCodeServiceFactory
     IDiscountCodeService Create(ShopifyApiCredentials credentials);
 }
 
-public class DiscountCodeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IDiscountCodeServiceFactory
+public class DiscountCodeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IDiscountCodeServiceFactory
 {
     /// <inheritDoc />
     public virtual IDiscountCodeService Create(string shopDomain, string accessToken)
     {
-        var service = new DiscountCodeService(shopDomain, accessToken);
+        IDiscountCodeService service = shopifyDomainUtility is null ? new DiscountCodeService(shopDomain, accessToken) : new DiscountCodeService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/DraftOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/DraftOrderServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IDraftOrderServiceFactory
     IDraftOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class DraftOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IDraftOrderServiceFactory
+public class DraftOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IDraftOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IDraftOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new DraftOrderService(shopDomain, accessToken);
+        IDraftOrderService service = shopifyDomainUtility is null ? new DraftOrderService(shopDomain, accessToken) : new DraftOrderService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/EventServiceFactory.cs
+++ b/ShopifySharp/Factories/EventServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IEventServiceFactory
     IEventService Create(ShopifyApiCredentials credentials);
 }
 
-public class EventServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IEventServiceFactory
+public class EventServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IEventServiceFactory
 {
     /// <inheritDoc />
     public virtual IEventService Create(string shopDomain, string accessToken)
     {
-        var service = new EventService(shopDomain, accessToken);
+        IEventService service = shopifyDomainUtility is null ? new EventService(shopDomain, accessToken) : new EventService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentEventServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IFulfillmentEventServiceFactory
     IFulfillmentEventService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentEventServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentEventServiceFactory
+public class FulfillmentEventServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IFulfillmentEventServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentEventService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentEventService(shopDomain, accessToken);
+        IFulfillmentEventService service = shopifyDomainUtility is null ? new FulfillmentEventService(shopDomain, accessToken) : new FulfillmentEventService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentOrderServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IFulfillmentOrderServiceFactory
     IFulfillmentOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentOrderServiceFactory
+public class FulfillmentOrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IFulfillmentOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentOrderService(shopDomain, accessToken);
+        IFulfillmentOrderService service = shopifyDomainUtility is null ? new FulfillmentOrderService(shopDomain, accessToken) : new FulfillmentOrderService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentRequestServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IFulfillmentRequestServiceFactory
     IFulfillmentRequestService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentRequestServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentRequestServiceFactory
+public class FulfillmentRequestServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IFulfillmentRequestServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentRequestService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentRequestService(shopDomain, accessToken);
+        IFulfillmentRequestService service = shopifyDomainUtility is null ? new FulfillmentRequestService(shopDomain, accessToken) : new FulfillmentRequestService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/FulfillmentServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IFulfillmentServiceFactory
     IFulfillmentService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentServiceFactory
+public class FulfillmentServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IFulfillmentServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentService(shopDomain, accessToken);
+        IFulfillmentService service = shopifyDomainUtility is null ? new FulfillmentService(shopDomain, accessToken) : new FulfillmentService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
+++ b/ShopifySharp/Factories/FulfillmentServiceServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IFulfillmentServiceServiceFactory
     IFulfillmentServiceService Create(ShopifyApiCredentials credentials);
 }
 
-public class FulfillmentServiceServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IFulfillmentServiceServiceFactory
+public class FulfillmentServiceServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IFulfillmentServiceServiceFactory
 {
     /// <inheritDoc />
     public virtual IFulfillmentServiceService Create(string shopDomain, string accessToken)
     {
-        var service = new FulfillmentServiceService(shopDomain, accessToken);
+        IFulfillmentServiceService service = shopifyDomainUtility is null ? new FulfillmentServiceService(shopDomain, accessToken) : new FulfillmentServiceService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardAdjustmentServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IGiftCardAdjustmentServiceFactory
     IGiftCardAdjustmentService Create(ShopifyApiCredentials credentials);
 }
 
-public class GiftCardAdjustmentServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IGiftCardAdjustmentServiceFactory
+public class GiftCardAdjustmentServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IGiftCardAdjustmentServiceFactory
 {
     /// <inheritDoc />
     public virtual IGiftCardAdjustmentService Create(string shopDomain, string accessToken)
     {
-        var service = new GiftCardAdjustmentService(shopDomain, accessToken);
+        IGiftCardAdjustmentService service = shopifyDomainUtility is null ? new GiftCardAdjustmentService(shopDomain, accessToken) : new GiftCardAdjustmentService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/GiftCardServiceFactory.cs
+++ b/ShopifySharp/Factories/GiftCardServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IGiftCardServiceFactory
     IGiftCardService Create(ShopifyApiCredentials credentials);
 }
 
-public class GiftCardServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IGiftCardServiceFactory
+public class GiftCardServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IGiftCardServiceFactory
 {
     /// <inheritDoc />
     public virtual IGiftCardService Create(string shopDomain, string accessToken)
     {
-        var service = new GiftCardService(shopDomain, accessToken);
+        IGiftCardService service = shopifyDomainUtility is null ? new GiftCardService(shopDomain, accessToken) : new GiftCardService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/GraphServiceFactory.cs
+++ b/ShopifySharp/Factories/GraphServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IGraphServiceFactory
     IGraphService Create(ShopifyApiCredentials credentials);
 }
 
-public class GraphServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IGraphServiceFactory
+public class GraphServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IGraphServiceFactory
 {
     /// <inheritDoc />
     public virtual IGraphService Create(string shopDomain, string accessToken)
     {
-        var service = new GraphService(shopDomain, accessToken);
+        IGraphService service = shopifyDomainUtility is null ? new GraphService(shopDomain, accessToken) : new GraphService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/InventoryItemServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryItemServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IInventoryItemServiceFactory
     IInventoryItemService Create(ShopifyApiCredentials credentials);
 }
 
-public class InventoryItemServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IInventoryItemServiceFactory
+public class InventoryItemServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IInventoryItemServiceFactory
 {
     /// <inheritDoc />
     public virtual IInventoryItemService Create(string shopDomain, string accessToken)
     {
-        var service = new InventoryItemService(shopDomain, accessToken);
+        IInventoryItemService service = shopifyDomainUtility is null ? new InventoryItemService(shopDomain, accessToken) : new InventoryItemService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
+++ b/ShopifySharp/Factories/InventoryLevelServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IInventoryLevelServiceFactory
     IInventoryLevelService Create(ShopifyApiCredentials credentials);
 }
 
-public class InventoryLevelServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IInventoryLevelServiceFactory
+public class InventoryLevelServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IInventoryLevelServiceFactory
 {
     /// <inheritDoc />
     public virtual IInventoryLevelService Create(string shopDomain, string accessToken)
     {
-        var service = new InventoryLevelService(shopDomain, accessToken);
+        IInventoryLevelService service = shopifyDomainUtility is null ? new InventoryLevelService(shopDomain, accessToken) : new InventoryLevelService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/LocationServiceFactory.cs
+++ b/ShopifySharp/Factories/LocationServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ILocationServiceFactory
     ILocationService Create(ShopifyApiCredentials credentials);
 }
 
-public class LocationServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ILocationServiceFactory
+public class LocationServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ILocationServiceFactory
 {
     /// <inheritDoc />
     public virtual ILocationService Create(string shopDomain, string accessToken)
     {
-        var service = new LocationService(shopDomain, accessToken);
+        ILocationService service = shopifyDomainUtility is null ? new LocationService(shopDomain, accessToken) : new LocationService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/MetaFieldServiceFactory.cs
+++ b/ShopifySharp/Factories/MetaFieldServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IMetaFieldServiceFactory
     IMetaFieldService Create(ShopifyApiCredentials credentials);
 }
 
-public class MetaFieldServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IMetaFieldServiceFactory
+public class MetaFieldServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IMetaFieldServiceFactory
 {
     /// <inheritDoc />
     public virtual IMetaFieldService Create(string shopDomain, string accessToken)
     {
-        var service = new MetaFieldService(shopDomain, accessToken);
+        IMetaFieldService service = shopifyDomainUtility is null ? new MetaFieldService(shopDomain, accessToken) : new MetaFieldService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/OrderRiskServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderRiskServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IOrderRiskServiceFactory
     IOrderRiskService Create(ShopifyApiCredentials credentials);
 }
 
-public class OrderRiskServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IOrderRiskServiceFactory
+public class OrderRiskServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IOrderRiskServiceFactory
 {
     /// <inheritDoc />
     public virtual IOrderRiskService Create(string shopDomain, string accessToken)
     {
-        var service = new OrderRiskService(shopDomain, accessToken);
+        IOrderRiskService service = shopifyDomainUtility is null ? new OrderRiskService(shopDomain, accessToken) : new OrderRiskService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/OrderServiceFactory.cs
+++ b/ShopifySharp/Factories/OrderServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IOrderServiceFactory
     IOrderService Create(ShopifyApiCredentials credentials);
 }
 
-public class OrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IOrderServiceFactory
+public class OrderServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IOrderServiceFactory
 {
     /// <inheritDoc />
     public virtual IOrderService Create(string shopDomain, string accessToken)
     {
-        var service = new OrderService(shopDomain, accessToken);
+        IOrderService service = shopifyDomainUtility is null ? new OrderService(shopDomain, accessToken) : new OrderService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/PageServiceFactory.cs
+++ b/ShopifySharp/Factories/PageServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IPageServiceFactory
     IPageService Create(ShopifyApiCredentials credentials);
 }
 
-public class PageServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPageServiceFactory
+public class PageServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IPageServiceFactory
 {
     /// <inheritDoc />
     public virtual IPageService Create(string shopDomain, string accessToken)
     {
-        var service = new PageService(shopDomain, accessToken);
+        IPageService service = shopifyDomainUtility is null ? new PageService(shopDomain, accessToken) : new PageService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/PartnerServiceFactory.cs
+++ b/ShopifySharp/Factories/PartnerServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IPartnerServiceFactory
     IPartnerService Create(ShopifyPartnerApiCredentials credentials);
 }
 
-public class PartnerServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPartnerServiceFactory
+public class PartnerServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IPartnerServiceFactory
 {
     /// <inheritDoc />
     public virtual IPartnerService Create(long partnerOrganizationId, string accessToken)
     {
-        var service = new PartnerService(partnerOrganizationId, accessToken);
+        var service = shopifyDomainUtility is null ? new PartnerService(partnerOrganizationId, accessToken) : new PartnerService(partnerOrganizationId, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/PolicyServiceFactory.cs
+++ b/ShopifySharp/Factories/PolicyServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IPolicyServiceFactory
     IPolicyService Create(ShopifyApiCredentials credentials);
 }
 
-public class PolicyServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPolicyServiceFactory
+public class PolicyServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IPolicyServiceFactory
 {
     /// <inheritDoc />
     public virtual IPolicyService Create(string shopDomain, string accessToken)
     {
-        var service = new PolicyService(shopDomain, accessToken);
+        IPolicyService service = shopifyDomainUtility is null ? new PolicyService(shopDomain, accessToken) : new PolicyService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/PriceRuleServiceFactory.cs
+++ b/ShopifySharp/Factories/PriceRuleServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IPriceRuleServiceFactory
     IPriceRuleService Create(ShopifyApiCredentials credentials);
 }
 
-public class PriceRuleServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IPriceRuleServiceFactory
+public class PriceRuleServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IPriceRuleServiceFactory
 {
     /// <inheritDoc />
     public virtual IPriceRuleService Create(string shopDomain, string accessToken)
     {
-        var service = new PriceRuleService(shopDomain, accessToken);
+        IPriceRuleService service = shopifyDomainUtility is null ? new PriceRuleService(shopDomain, accessToken) : new PriceRuleService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ProductImageServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductImageServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IProductImageServiceFactory
     IProductImageService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductImageServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductImageServiceFactory
+public class ProductImageServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IProductImageServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductImageService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductImageService(shopDomain, accessToken);
+        IProductImageService service = shopifyDomainUtility is null ? new ProductImageService(shopDomain, accessToken) : new ProductImageService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ProductListingServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductListingServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IProductListingServiceFactory
     IProductListingService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductListingServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductListingServiceFactory
+public class ProductListingServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IProductListingServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductListingService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductListingService(shopDomain, accessToken);
+        IProductListingService service = shopifyDomainUtility is null ? new ProductListingService(shopDomain, accessToken) : new ProductListingService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ProductServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IProductServiceFactory
     IProductService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductServiceFactory
+public class ProductServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IProductServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductService(shopDomain, accessToken);
+        IProductService service = shopifyDomainUtility is null ? new ProductService(shopDomain, accessToken) : new ProductService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ProductVariantServiceFactory.cs
+++ b/ShopifySharp/Factories/ProductVariantServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IProductVariantServiceFactory
     IProductVariantService Create(ShopifyApiCredentials credentials);
 }
 
-public class ProductVariantServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IProductVariantServiceFactory
+public class ProductVariantServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IProductVariantServiceFactory
 {
     /// <inheritDoc />
     public virtual IProductVariantService Create(string shopDomain, string accessToken)
     {
-        var service = new ProductVariantService(shopDomain, accessToken);
+        IProductVariantService service = shopifyDomainUtility is null ? new ProductVariantService(shopDomain, accessToken) : new ProductVariantService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/RecurringChargeServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IRecurringChargeServiceFactory
     IRecurringChargeService Create(ShopifyApiCredentials credentials);
 }
 
-public class RecurringChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IRecurringChargeServiceFactory
+public class RecurringChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IRecurringChargeServiceFactory
 {
     /// <inheritDoc />
     public virtual IRecurringChargeService Create(string shopDomain, string accessToken)
     {
-        var service = new RecurringChargeService(shopDomain, accessToken);
+        IRecurringChargeService service = shopifyDomainUtility is null ? new RecurringChargeService(shopDomain, accessToken) : new RecurringChargeService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/RedirectServiceFactory.cs
+++ b/ShopifySharp/Factories/RedirectServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IRedirectServiceFactory
     IRedirectService Create(ShopifyApiCredentials credentials);
 }
 
-public class RedirectServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IRedirectServiceFactory
+public class RedirectServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IRedirectServiceFactory
 {
     /// <inheritDoc />
     public virtual IRedirectService Create(string shopDomain, string accessToken)
     {
-        var service = new RedirectService(shopDomain, accessToken);
+        IRedirectService service = shopifyDomainUtility is null ? new RedirectService(shopDomain, accessToken) : new RedirectService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/RefundServiceFactory.cs
+++ b/ShopifySharp/Factories/RefundServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IRefundServiceFactory
     IRefundService Create(ShopifyApiCredentials credentials);
 }
 
-public class RefundServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IRefundServiceFactory
+public class RefundServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IRefundServiceFactory
 {
     /// <inheritDoc />
     public virtual IRefundService Create(string shopDomain, string accessToken)
     {
-        var service = new RefundService(shopDomain, accessToken);
+        IRefundService service = shopifyDomainUtility is null ? new RefundService(shopDomain, accessToken) : new RefundService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ScriptTagServiceFactory.cs
+++ b/ShopifySharp/Factories/ScriptTagServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IScriptTagServiceFactory
     IScriptTagService Create(ShopifyApiCredentials credentials);
 }
 
-public class ScriptTagServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IScriptTagServiceFactory
+public class ScriptTagServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IScriptTagServiceFactory
 {
     /// <inheritDoc />
     public virtual IScriptTagService Create(string shopDomain, string accessToken)
     {
-        var service = new ScriptTagService(shopDomain, accessToken);
+        IScriptTagService service = shopifyDomainUtility is null ? new ScriptTagService(shopDomain, accessToken) : new ScriptTagService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
+++ b/ShopifySharp/Factories/ShippingZoneServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IShippingZoneServiceFactory
     IShippingZoneService Create(ShopifyApiCredentials credentials);
 }
 
-public class ShippingZoneServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IShippingZoneServiceFactory
+public class ShippingZoneServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IShippingZoneServiceFactory
 {
     /// <inheritDoc />
     public virtual IShippingZoneService Create(string shopDomain, string accessToken)
     {
-        var service = new ShippingZoneService(shopDomain, accessToken);
+        IShippingZoneService service = shopifyDomainUtility is null ? new ShippingZoneService(shopDomain, accessToken) : new ShippingZoneService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ShopServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IShopServiceFactory
     IShopService Create(ShopifyApiCredentials credentials);
 }
 
-public class ShopServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IShopServiceFactory
+public class ShopServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IShopServiceFactory
 {
     /// <inheritDoc />
     public virtual IShopService Create(string shopDomain, string accessToken)
     {
-        var service = new ShopService(shopDomain, accessToken);
+        IShopService service = shopifyDomainUtility is null ? new ShopService(shopDomain, accessToken) : new ShopService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopifyPaymentsServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IShopifyPaymentsServiceFactory
     IShopifyPaymentsService Create(ShopifyApiCredentials credentials);
 }
 
-public class ShopifyPaymentsServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IShopifyPaymentsServiceFactory
+public class ShopifyPaymentsServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IShopifyPaymentsServiceFactory
 {
     /// <inheritDoc />
     public virtual IShopifyPaymentsService Create(string shopDomain, string accessToken)
     {
-        var service = new ShopifyPaymentsService(shopDomain, accessToken);
+        IShopifyPaymentsService service = shopifyDomainUtility is null ? new ShopifyPaymentsService(shopDomain, accessToken) : new ShopifyPaymentsService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
+++ b/ShopifySharp/Factories/SmartCollectionServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ISmartCollectionServiceFactory
     ISmartCollectionService Create(ShopifyApiCredentials credentials);
 }
 
-public class SmartCollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ISmartCollectionServiceFactory
+public class SmartCollectionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ISmartCollectionServiceFactory
 {
     /// <inheritDoc />
     public virtual ISmartCollectionService Create(string shopDomain, string accessToken)
     {
-        var service = new SmartCollectionService(shopDomain, accessToken);
+        ISmartCollectionService service = shopifyDomainUtility is null ? new SmartCollectionService(shopDomain, accessToken) : new SmartCollectionService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
+++ b/ShopifySharp/Factories/StorefrontAccessTokenServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IStorefrontAccessTokenServiceFactory
     IStorefrontAccessTokenService Create(ShopifyApiCredentials credentials);
 }
 
-public class StorefrontAccessTokenServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IStorefrontAccessTokenServiceFactory
+public class StorefrontAccessTokenServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IStorefrontAccessTokenServiceFactory
 {
     /// <inheritDoc />
     public virtual IStorefrontAccessTokenService Create(string shopDomain, string accessToken)
     {
-        var service = new StorefrontAccessTokenService(shopDomain, accessToken);
+        IStorefrontAccessTokenService service = shopifyDomainUtility is null ? new StorefrontAccessTokenService(shopDomain, accessToken) : new StorefrontAccessTokenService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TenderTransactionServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ITenderTransactionServiceFactory
     ITenderTransactionService Create(ShopifyApiCredentials credentials);
 }
 
-public class TenderTransactionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ITenderTransactionServiceFactory
+public class TenderTransactionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ITenderTransactionServiceFactory
 {
     /// <inheritDoc />
     public virtual ITenderTransactionService Create(string shopDomain, string accessToken)
     {
-        var service = new TenderTransactionService(shopDomain, accessToken);
+        ITenderTransactionService service = shopifyDomainUtility is null ? new TenderTransactionService(shopDomain, accessToken) : new TenderTransactionService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/ThemeServiceFactory.cs
+++ b/ShopifySharp/Factories/ThemeServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IThemeServiceFactory
     IThemeService Create(ShopifyApiCredentials credentials);
 }
 
-public class ThemeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IThemeServiceFactory
+public class ThemeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IThemeServiceFactory
 {
     /// <inheritDoc />
     public virtual IThemeService Create(string shopDomain, string accessToken)
     {
-        var service = new ThemeService(shopDomain, accessToken);
+        IThemeService service = shopifyDomainUtility is null ? new ThemeService(shopDomain, accessToken) : new ThemeService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/TransactionServiceFactory.cs
+++ b/ShopifySharp/Factories/TransactionServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface ITransactionServiceFactory
     ITransactionService Create(ShopifyApiCredentials credentials);
 }
 
-public class TransactionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : ITransactionServiceFactory
+public class TransactionServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : ITransactionServiceFactory
 {
     /// <inheritDoc />
     public virtual ITransactionService Create(string shopDomain, string accessToken)
     {
-        var service = new TransactionService(shopDomain, accessToken);
+        ITransactionService service = shopifyDomainUtility is null ? new TransactionService(shopDomain, accessToken) : new TransactionService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/UsageChargeServiceFactory.cs
+++ b/ShopifySharp/Factories/UsageChargeServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IUsageChargeServiceFactory
     IUsageChargeService Create(ShopifyApiCredentials credentials);
 }
 
-public class UsageChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IUsageChargeServiceFactory
+public class UsageChargeServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IUsageChargeServiceFactory
 {
     /// <inheritDoc />
     public virtual IUsageChargeService Create(string shopDomain, string accessToken)
     {
-        var service = new UsageChargeService(shopDomain, accessToken);
+        IUsageChargeService service = shopifyDomainUtility is null ? new UsageChargeService(shopDomain, accessToken) : new UsageChargeService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/UserServiceFactory.cs
+++ b/ShopifySharp/Factories/UserServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IUserServiceFactory
     IUserService Create(ShopifyApiCredentials credentials);
 }
 
-public class UserServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IUserServiceFactory
+public class UserServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IUserServiceFactory
 {
     /// <inheritDoc />
     public virtual IUserService Create(string shopDomain, string accessToken)
     {
-        var service = new UserService(shopDomain, accessToken);
+        IUserService service = shopifyDomainUtility is null ? new UserService(shopDomain, accessToken) : new UserService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/WebhookServiceFactory.cs
+++ b/ShopifySharp/Factories/WebhookServiceFactory.cs
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface IWebhookServiceFactory
     IWebhookService Create(ShopifyApiCredentials credentials);
 }
 
-public class WebhookServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null) : IWebhookServiceFactory
+public class WebhookServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IWebhookServiceFactory
 {
     /// <inheritDoc />
     public virtual IWebhookService Create(string shopDomain, string accessToken)
     {
-        var service = new WebhookService(shopDomain, accessToken);
+        IWebhookService service = shopifyDomainUtility is null ? new WebhookService(shopDomain, accessToken) : new WebhookService(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Factories/factory-service-template.txt
+++ b/ShopifySharp/Factories/factory-service-template.txt
@@ -3,6 +3,7 @@
 // This class is auto-generated from a template. Please do not edit it or change it directly.
 
 using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp.Factories;
 
@@ -18,12 +19,12 @@ public interface I@@REPLACEME@@Factory
     I@@REPLACEME@@ Create(ShopifyApiCredentials credentials);
 }
 
-public class @@REPLACEME@@Factory(IRequestExecutionPolicy? requestExecutionPolicy = null) : I@@REPLACEME@@Factory
+public class @@REPLACEME@@Factory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : I@@REPLACEME@@Factory
 {
     /// <inheritDoc />
     public virtual I@@REPLACEME@@ Create(string shopDomain, string accessToken)
     {
-        var service = new @@REPLACEME@@(shopDomain, accessToken);
+        I@@REPLACEME@@ service = shopifyDomainUtility is null ? new @@REPLACEME@@(shopDomain, accessToken) : new @@REPLACEME@@(shopDomain, accessToken, shopifyDomainUtility);
 
         if (requestExecutionPolicy is not null)
         {

--- a/ShopifySharp/Services/AccessScope/AccessScopeService.cs
+++ b/ShopifySharp/Services/AccessScope/AccessScopeService.cs
@@ -12,7 +12,7 @@ namespace ShopifySharp
     public class AccessScopeService : ShopifyService, IAccessScopeService
     {
         //oauth endpoints don't support versioning
-        protected override bool SupportsAPIVersioning => false;
+        public override bool SupportsAPIVersioning => false;
 
         /// <summary>
         /// Creates a new instance of the service.

--- a/ShopifySharp/Services/AccessScope/AccessScopeService.cs
+++ b/ShopifySharp/Services/AccessScope/AccessScopeService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -20,7 +21,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public AccessScopeService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal AccessScopeService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<AccessScope>> ListAsync(CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ApplicationCredit> CreateAsync(ApplicationCredit credit, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"application_credits.json");
+            var req = BuildRequestUri($"application_credits.json");
             var body = new JsonContent(new
             {
                 application_credit = credit,

--- a/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
+++ b/ShopifySharp/Services/ApplicationCredit/ApplicationCreditService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ApplicationCreditService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ApplicationCreditService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<ApplicationCredit>> ListAsync(ListFilter<ApplicationCredit> filter, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync("application_credits.json", "application_credits", filter, cancellationToken);

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Article> GetAsync(long blogId, long articleId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/{articleId}.json");
 
             if (fields != null)
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Article> CreateAsync(long blogId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles.json");
             var body = article.ToDictionary();
 
             if (metafields != null)
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Article> UpdateAsync(long blogId, long articleId, Article article, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/{articleId}.json");
             var body = article.ToDictionary();
 
             if (metafields != null)
@@ -89,7 +89,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long blogId, long articleId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/{articleId}.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/{articleId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -97,7 +97,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<string>> ListAuthorsAsync(CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"articles/authors.json");
+            var req = BuildRequestUri($"articles/authors.json");
 
             var response = await ExecuteRequestAsync<List<string>>(req, HttpMethod.Get, cancellationToken, rootElement: "authors");
             return response.Result;
@@ -106,7 +106,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<string>> ListTagsAsync(int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"articles/tags.json");
+            var req = BuildRequestUri($"articles/tags.json");
 
             if (popular.HasValue)
             {
@@ -125,7 +125,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<string>> ListTagsForBlogAsync(long blogId, int? popular = null, int? limit = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"blogs/{blogId}/articles/tags.json");
+            var req = BuildRequestUri($"blogs/{blogId}/articles/tags.json");
 
             if (popular.HasValue)
             {

--- a/ShopifySharp/Services/Article/ArticleService.cs
+++ b/ShopifySharp/Services/Article/ArticleService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -19,7 +20,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ArticleService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ArticleService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<Article>> ListAsync(long blogId, ListFilter<Article> filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync($"blogs/{blogId}/articles.json", "articles", filter, cancellationToken);

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Asset> GetAsync(long themeId, string key, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}/assets.json");
+            var req = BuildRequestUri($"themes/{themeId}/assets.json");
             // Add the proper asset querystring
             req = SetAssetQuerystring(req, key, themeId);
 
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Asset> CreateOrUpdateAsync(long themeId, Asset asset, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}/assets.json");
+            var req = BuildRequestUri($"themes/{themeId}/assets.json");
             var content = new JsonContent(new
             {
                 asset = asset
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long themeId, string key, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}/assets.json");
+            var req = BuildRequestUri($"themes/{themeId}/assets.json");
 
             req = SetAssetQuerystring(req, key, themeId);
 

--- a/ShopifySharp/Services/Asset/AssetService.cs
+++ b/ShopifySharp/Services/Asset/AssetService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public AssetService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal AssetService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<Asset> GetAsync(long themeId, string key, string fields = null, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/AssignedFulfillmentOrder/AssignedFulfillmentOrderService.cs
+++ b/ShopifySharp/Services/AssignedFulfillmentOrder/AssignedFulfillmentOrderService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -13,7 +14,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public AssignedFulfillmentOrderService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal AssignedFulfillmentOrderService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         public virtual async Task<IEnumerable<FulfillmentOrder>> ListAsync(AssignedFulfillmentOrderFilter filter, CancellationToken cancellationToken = default) =>
 			await ExecuteGetAsync<List<FulfillmentOrder>>("assigned_fulfillment_orders.json", "fulfillment_orders", filter, cancellationToken);
     }

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -20,7 +21,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public BlogService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal BlogService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<Blog>> ListAsync(ListFilter<Blog> filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync("blogs.json", "blogs", filter, cancellationToken);

--- a/ShopifySharp/Services/Blog/BlogService.cs
+++ b/ShopifySharp/Services/Blog/BlogService.cs
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Blog> CreateAsync(Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest("blogs.json");
+            var request = BuildRequestUri("blogs.json");
             var body = blog.ToDictionary();
 
             if (metafields != null && metafields.Any())
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Blog> UpdateAsync(long blogId, Blog blog, IEnumerable<MetaField> metafields = null, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest($"blogs/{blogId}.json");
+            var request = BuildRequestUri($"blogs/{blogId}.json");
             var body = blog.ToDictionary();
 
             if (metafields != null && metafields.Count() >= 1)
@@ -76,7 +76,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Blog> GetAsync(long id, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest($"blogs/{id}.json");
+            var request = BuildRequestUri($"blogs/{id}.json");
 
             var response = await ExecuteRequestAsync<Blog>(request, HttpMethod.Get, cancellationToken, rootElement: "blog");
             return response.Result;
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest($"blogs/{id}.json");
+            var request = BuildRequestUri($"blogs/{id}.json");
 
             await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/CancellationRequest/CancellationRequestService.cs
+++ b/ShopifySharp/Services/CancellationRequest/CancellationRequestService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CreateAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request.json");
             var cancellationRequest = new CancellationRequest { Message = message };
             var body = cancellationRequest.ToDictionary();
 
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> AcceptAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/accept.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/accept.json");
             var cancellationRequest = new CancellationRequest { Message = message };
             var body = cancellationRequest.ToDictionary();
 
@@ -52,7 +52,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> RejectAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/reject.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/cancellation_request/reject.json");
             var cancellationRequest = new CancellationRequest { Message = message };
             var body = cancellationRequest.ToDictionary();
 

--- a/ShopifySharp/Services/CancellationRequest/CancellationRequestService.cs
+++ b/ShopifySharp/Services/CancellationRequest/CancellationRequestService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CancellationRequestService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CancellationRequestService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CreateAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Carrier> CreateAsync(Carrier carrier, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("carrier_services.json");
+            var req = BuildRequestUri("carrier_services.json");
             var content = new JsonContent(new
             {
                 carrier_service = carrier
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Carrier> GetAsync(long carrierId, CancellationToken cancellationToken = default)
         {            
-            var req = PrepareRequest($"carrier_services/{carrierId}.json");
+            var req = BuildRequestUri($"carrier_services/{carrierId}.json");
 
             var response = await ExecuteRequestAsync<Carrier>(req, HttpMethod.Get, cancellationToken, rootElement: "carrier_service");
             return response.Result;
@@ -47,7 +47,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long carrierId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"carrier_services/{carrierId}.json");
+            var req = BuildRequestUri($"carrier_services/{carrierId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -55,7 +55,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Carrier> UpdateAsync(long carrierId, Carrier carrier, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"carrier_services/{carrierId}.json");
+            var req = BuildRequestUri($"carrier_services/{carrierId}.json");
             var content = new JsonContent(new
             {
                 carrier_service = carrier

--- a/ShopifySharp/Services/Carrier/CarrierService.cs
+++ b/ShopifySharp/Services/Carrier/CarrierService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -17,7 +18,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CarrierService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }        
-
+        internal CarrierService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<Carrier>> ListAsync(CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync< IEnumerable < Carrier >>("carrier_services.json", "carrier_services", cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ChargeService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ChargeService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<Charge> CreateAsync(Charge charge, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Charge/ChargeService.cs
+++ b/ShopifySharp/Services/Charge/ChargeService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Charge> CreateAsync(Charge charge, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("application_charges.json");
+            var req = BuildRequestUri("application_charges.json");
             var content = new JsonContent(new { application_charge = charge });
 
             var response = await ExecuteRequestAsync<Charge>(req, HttpMethod.Post, cancellationToken, content, "application_charge");
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Charge> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"application_charges/{id}.json");
+            var req = BuildRequestUri($"application_charges/{id}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> CreateAsync(Checkout checkout, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("checkouts.json");
+            var req = BuildRequestUri("checkouts.json");
             var body = checkout.ToDictionary();
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, cancellationToken, new JsonContent(new { checkout }), "checkout");
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> CompleteAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/complete.json");
+            var req = BuildRequestUri($"checkouts/{token}/complete.json");
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Post, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> GetAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Get, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Checkout> UpdateAsync(string token, Checkout updatedCheckout, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<Checkout>(req, HttpMethod.Put, cancellationToken, new JsonContent(new { checkout = updatedCheckout }), "checkout");
             return response.Result;
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<CheckoutShippingRate>> ListShippingRatesAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
+            var req = BuildRequestUri($"checkouts/{token}/shipping_rates.json");
 
             var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, cancellationToken, rootElement: "shipping_rates");
             return response.Result;

--- a/ShopifySharp/Services/Checkout/CheckoutService.cs
+++ b/ShopifySharp/Services/Checkout/CheckoutService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CheckoutService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CheckoutService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(CheckoutCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("checkouts/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/CheckoutSalesChannel/CheckoutSalesChannelService.cs
+++ b/ShopifySharp/Services/CheckoutSalesChannel/CheckoutSalesChannelService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Entities.SalesChannel;
 using ShopifySharp.Infrastructure;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -14,7 +15,8 @@ namespace ShopifySharp
     public class CheckoutSalesChannelService: ShopifyService, ICheckoutSalesChannelService
     {
         public CheckoutSalesChannelService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CheckoutSalesChannelService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<CheckoutSalesChannel> GetAsync(string token, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/CheckoutSalesChannel/CheckoutSalesChannelService.cs
+++ b/ShopifySharp/Services/CheckoutSalesChannel/CheckoutSalesChannelService.cs
@@ -18,7 +18,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CheckoutSalesChannel> GetAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Get, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -28,7 +28,7 @@ namespace ShopifySharp
         public virtual async Task<CheckoutSalesChannel> CreateAsync(CheckoutSalesChannel checkout,
             CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("checkouts.json");
+            var req = BuildRequestUri("checkouts.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Post, cancellationToken,
                 new JsonContent(new {checkout}), "checkout");
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CheckoutSalesChannel> CompleteAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/complete.json");
+            var req = BuildRequestUri($"checkouts/{token}/complete.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Post, cancellationToken, rootElement: "checkout");
             return response.Result;
@@ -48,7 +48,7 @@ namespace ShopifySharp
         public virtual async Task<CheckoutSalesChannel> UpdateAsync(string token, CheckoutSalesChannel checkout,
             CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}.json");
+            var req = BuildRequestUri($"checkouts/{token}.json");
 
             var response = await ExecuteRequestAsync<CheckoutSalesChannel>(req, HttpMethod.Put, cancellationToken,
                 new JsonContent(new { checkout }), "checkout");
@@ -58,7 +58,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<CheckoutShippingRate>> ListShippingRatesAsync(string token, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/shipping_rates.json");
+            var req = BuildRequestUri($"checkouts/{token}/shipping_rates.json");
 
             var response = await ExecuteRequestAsync<List<CheckoutShippingRate>>(req, HttpMethod.Get, cancellationToken, rootElement: "shipping_rates");
             return response.Result;
@@ -68,7 +68,7 @@ namespace ShopifySharp
         public virtual async Task<PaymentSalesChannel> CreatePaymentAsync(string token, CreatePayment createPayment,
             CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"checkouts/{token}/payments.json");
+            var req = BuildRequestUri($"checkouts/{token}/payments.json");
 
             var response = await ExecuteRequestAsync<PaymentSalesChannel>(req, HttpMethod.Post, cancellationToken,
                 new JsonContent(new {payment = createPayment}), "payment");

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Collect> CreateAsync(Collect collect, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("collects.json");
+            var req = BuildRequestUri("collects.json");
             var content = new JsonContent(new
             {
                 collect = collect
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long collectId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"collects/{collectId}.json");
+            var req = BuildRequestUri($"collects/{collectId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Collect/CollectService.cs
+++ b/ShopifySharp/Services/Collect/CollectService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CollectService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CollectService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(CollectCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("collects/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/Collection/CollectionService.cs
+++ b/ShopifySharp/Services/Collection/CollectionService.cs
@@ -2,6 +2,7 @@ using ShopifySharp.Filters;
 using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CollectionService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CollectionService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<Product>> ListProductsAsync(long collectionId, ListFilter<Product> filter, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync($"collections/{collectionId}/products.json", "products", filter, cancellationToken);

--- a/ShopifySharp/Services/CollectionListing/CollectionListingService.cs
+++ b/ShopifySharp/Services/CollectionListing/CollectionListingService.cs
@@ -2,6 +2,7 @@
 using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CollectionListingService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CollectionListingService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         public virtual async Task<ListResult<CollectionListing>> ListAsync(ListFilter<CollectionListing> filter = default, CancellationToken cancellationToken = default) => 
             await ExecuteGetListAsync("collection_listings.json", "collection_listings", filter, cancellationToken);
 

--- a/ShopifySharp/Services/Country/CountryService.cs
+++ b/ShopifySharp/Services/Country/CountryService.cs
@@ -38,7 +38,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Country> CreateAsync(Country country, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("countries.json");
+            var req = BuildRequestUri("countries.json");
             var content = new JsonContent(new
             {
                 country = country
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Country> UpdateAsync(long countryId, Country country, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"countries/{countryId}.json");
+            var req = BuildRequestUri($"countries/{countryId}.json");
             var content = new JsonContent(new
             {
                 country = country
@@ -64,7 +64,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long countryId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"countries/{countryId}.json");
+            var req = BuildRequestUri($"countries/{countryId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Country/CountryService.cs
+++ b/ShopifySharp/Services/Country/CountryService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CountryService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CountryService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(CountryCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("countries/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -15,7 +16,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CustomCollectionService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CustomCollectionService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<CustomCollection>> ListAsync(ListFilter<CustomCollection> filter = null, CancellationToken cancellationToken = default) => await ExecuteGetListAsync("custom_collections.json", "custom_collections", filter, cancellationToken);
 

--- a/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
+++ b/ShopifySharp/Services/CustomCollection/CustomCollectionService.cs
@@ -25,7 +25,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomCollection> CreateAsync(CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("custom_collections.json");
+            var req = BuildRequestUri("custom_collections.json");
             var content = new JsonContent(new
             {
                 custom_collection = customCollection
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long customCollectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
+            var req = BuildRequestUri($"custom_collections/{customCollectionId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomCollection> UpdateAsync(long customCollectionId, CustomCollection customCollection, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"custom_collections/{customCollectionId}.json");
+            var req = BuildRequestUri($"custom_collections/{customCollectionId}.json");
             var content = new JsonContent(new
             {
                 custom_collection = customCollection

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CustomerService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CustomerService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>($"customers/count.json", "count", cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/Customer/CustomerService.cs
+++ b/ShopifySharp/Services/Customer/CustomerService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Customer> CreateAsync(Customer customer, CustomerCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("customers.json");
+            var req = BuildRequestUri("customers.json");
             var body = customer.ToDictionary();
 
             if (options != null)
@@ -67,7 +67,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Customer> UpdateAsync(long customerId, Customer customer, CustomerUpdateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}.json");
+            var req = BuildRequestUri($"customers/{customerId}.json");
             var body = customer.ToDictionary();
 
             if (options != null)
@@ -90,7 +90,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long customerId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}.json");
+            var req = BuildRequestUri($"customers/{customerId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
@@ -98,7 +98,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomerInvite> SendInviteAsync(long customerId, CustomerInvite invite = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/send_invite.json");
+            var req = BuildRequestUri($"customers/{customerId}/send_invite.json");
 
             var content = new JsonContent(new
             {
@@ -112,7 +112,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<string> GetAccountActivationUrl(long customerid, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerid}/account_activation_url.json");
+            var req = BuildRequestUri($"customers/{customerid}/account_activation_url.json");
             var response = await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken);
 
             return response.Result.SelectToken("account_activation_url").ToString();

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -15,7 +16,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CustomerAddressService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CustomerAddressService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<Address>> ListAsync(long customerId, ListFilter<Address> filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync($"customers/{customerId}/addresses.json", "addresses", filter, cancellationToken);

--- a/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
+++ b/ShopifySharp/Services/CustomerAddress/CustomerAddressService.cs
@@ -23,7 +23,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> GetAsync(long customerId, long addressId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}.json");
 
             if (string.IsNullOrEmpty(fields) == false)
             {
@@ -37,7 +37,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> CreateAsync(long customerId, Address address, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses.json");
             var addressBody = address.ToDictionary();
             var content = new JsonContent(new
             {
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> UpdateAsync(long customerId, long addressId, Address address, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}.json");
             var addressBody = address.ToDictionary();
 
             var content = new JsonContent(new
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Address> SetDefault(long customerId, long addressId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"customers/{customerId}/addresses/{addressId}/default.json");
+            var req = BuildRequestUri($"customers/{customerId}/addresses/{addressId}/default.json");
 
             var response = await ExecuteRequestAsync<Address>(req, HttpMethod.Put, cancellationToken, rootElement: "customer_address");
             return response.Result;

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -24,7 +25,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public CustomerSavedSearchService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal CustomerSavedSearchService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(CustomerSavedSearchCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>($"{RootResource}/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
+++ b/ShopifySharp/Services/CustomerSavedSearch/CustomerSavedSearchService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomerSavedSearch> GetAsync(long customerSearchId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{RootResource}/{customerSearchId}.json");
+            var req = BuildRequestUri($"{RootResource}/{customerSearchId}.json");
 
             if (string.IsNullOrEmpty(fields) == false)
             {
@@ -59,7 +59,7 @@ namespace ShopifySharp
                 throw new ArgumentException("Name property is required", nameof(customerSavedSearch));
             }
 
-            var req = PrepareRequest($"{RootResource}.json");
+            var req = BuildRequestUri($"{RootResource}.json");
             var body = customerSavedSearch.ToDictionary();
 
             var content = new JsonContent(new
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<CustomerSavedSearch> UpdateAsync(long customerSavedSearchId, CustomerSavedSearch customerSavedSearch, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
+            var req = BuildRequestUri($"{RootResource}/{customerSavedSearchId}.json");
             var body = customerSavedSearch.ToDictionary();
 
             var content = new JsonContent(new
@@ -89,7 +89,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual Task DeleteAsync(long customerSavedSearchId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{RootResource}/{customerSavedSearchId}.json");
+            var req = BuildRequestUri($"{RootResource}/{customerSavedSearchId}.json");
 
             return ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRuleDiscountCode> CreateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes.json");
+            var req = BuildRequestUri($"price_rules/{priceRuleId}/discount_codes.json");
             var body = code.ToDictionary();
 
             var content = new JsonContent(new
@@ -61,7 +61,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRuleDiscountCode> UpdateAsync(long priceRuleId, PriceRuleDiscountCode code, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{code.Id.Value}.json");
+            var req = BuildRequestUri($"price_rules/{priceRuleId}/discount_codes/{code.Id.Value}.json");
             var content = new JsonContent(new
             {
                 discount_code = code
@@ -74,7 +74,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long priceRuleId, long discountCodeId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
+            var req = BuildRequestUri($"price_rules/{priceRuleId}/discount_codes/{discountCodeId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
+++ b/ShopifySharp/Services/DiscountCode/DiscountCodeService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -15,7 +16,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public DiscountCodeService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal DiscountCodeService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<PriceRuleDiscountCode>> ListAsync(long priceRuleId, ListFilter<PriceRuleDiscountCode> filter, CancellationToken cancellationToken = default) =>
 			await ExecuteGetListAsync($"price_rules/{priceRuleId}/discount_codes.json", "discount_codes", filter, cancellationToken);

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public DraftOrderService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal DraftOrderService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(DraftOrderCountFilter filter = null, CancellationToken cancellationToken = default) =>
 			await ExecuteGetAsync<int>("draft_orders/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
+++ b/ShopifySharp/Services/DraftOrder/DraftOrderService.cs
@@ -36,7 +36,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, bool useCustomerDefaultAddress, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("draft_orders.json");
+            var req = BuildRequestUri("draft_orders.json");
             var body = order.ToDictionary();
 
             body.Add("use_customer_default_address", useCustomerDefaultAddress);
@@ -53,7 +53,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> CreateAsync(DraftOrder order, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("draft_orders.json");
+            var req = BuildRequestUri("draft_orders.json");
             var content = new JsonContent(new
             {
                 draft_order = order.ToDictionary()
@@ -66,7 +66,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> UpdateAsync(long id, DraftOrder order, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}.json");
+            var req = BuildRequestUri($"draft_orders/{id}.json");
             var content = new JsonContent(new
             {
                 draft_order = order.ToDictionary()
@@ -79,7 +79,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}.json");
+            var req = BuildRequestUri($"draft_orders/{id}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrder> CompleteAsync(long id, bool paymentPending = false, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}/complete.json");
+            var req = BuildRequestUri($"draft_orders/{id}/complete.json");
             req.QueryParams.Add("payment_pending", paymentPending);
 
             var response = await ExecuteRequestAsync<DraftOrder>(req, HttpMethod.Put, cancellationToken, rootElement: "draft_order");
@@ -97,7 +97,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<DraftOrderInvoice> SendInvoiceAsync(long id, DraftOrderInvoice customInvoice = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"draft_orders/{id}/send_invoice.json");
+            var req = BuildRequestUri($"draft_orders/{id}/send_invoice.json");
             // If the custom invoice is not null, use that as the body. Else use an empty dictionary object which will send the default invoice
             var body = customInvoice?.ToDictionary() ?? new Dictionary<string, object>();
             var content = new JsonContent(new

--- a/ShopifySharp/Services/Event/EventService.cs
+++ b/ShopifySharp/Services/Event/EventService.cs
@@ -3,6 +3,7 @@ using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public EventService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal EventService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(EventCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("events/count.json", "count", filter, cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public FulfillmentService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal FulfillmentService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(long orderId, FulfillmentCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>($"orders/{orderId}/fulfillments/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
+++ b/ShopifySharp/Services/Fulfillment/FulfillmentService.cs
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Fulfillment> CreateAsync(FulfillmentShipping fulfillment, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillments.json");
+            var req = BuildRequestUri($"fulfillments.json");
             var body = fulfillment.ToDictionary();
 
             var content = new JsonContent(new
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Fulfillment> UpdateTrackingAsync(long fulfillmentId, FulfillmentShipping fulfillment, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillments/{fulfillmentId}/update_tracking.json");
+            var req = BuildRequestUri($"fulfillments/{fulfillmentId}/update_tracking.json");
             var body = fulfillment.ToDictionary();
             var content = new JsonContent(new
             {
@@ -71,7 +71,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Fulfillment> CancelAsync(long fulfillmentId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillments/{fulfillmentId}/cancel.json");
+            var req = BuildRequestUri($"fulfillments/{fulfillmentId}/cancel.json");
 
             var response = await ExecuteRequestAsync<Fulfillment>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment");
             return response.Result;

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -29,7 +29,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentEvent> CreateAsync(long orderId, long fulfillmentId, FulfillmentEvent @event, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json");
+            var req = BuildRequestUri($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json");
 
             var content = new JsonContent(new
             {
@@ -43,7 +43,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long orderId, long fulfillmentId, long fulfillmentEventId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
+            var req = BuildRequestUri($"orders/{orderId}/fulfillments/{fulfillmentId}/events/{fulfillmentEventId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
+++ b/ShopifySharp/Services/FulfillmentEvent/FulfillmentEventService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -17,7 +18,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public FulfillmentEventService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal FulfillmentEventService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<FulfillmentEvent>> ListAsync(long orderId, long fulfillmentId, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<IEnumerable<FulfillmentEvent>>($"orders/{orderId}/fulfillments/{fulfillmentId}/events.json", "fulfillment_events", cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CancelAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/cancel.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/cancel.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -40,7 +40,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/close.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/close.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -55,7 +55,7 @@ namespace ShopifySharp
                 fulfillment_hold = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/hold.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -73,7 +73,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/move.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/move.json");
 
             //needs to be original_fulfillment_order
             var response = await ExecuteRequestAsync<FulfillmentOrderMove>(req, HttpMethod.Post, cancellationToken, content);
@@ -84,7 +84,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> OpenAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/open.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/open.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> ReleaseHoldAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/release_hold.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/release_hold.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -111,7 +111,7 @@ namespace ShopifySharp
                 fulfillment_order = body,
             });
 
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/reschedule.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/reschedule.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Post, cancellationToken, content, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -120,7 +120,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> GetAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}.json");
             var response = await ExecuteRequestAsync<FulfillmentOrder>(req, HttpMethod.Get, cancellationToken, rootElement: "fulfillment_order");
 
             return response.Result;
@@ -129,7 +129,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<FulfillmentOrder>> ListAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/fulfillment_orders.json");
+            var req = BuildRequestUri($"orders/{orderId}/fulfillment_orders.json");
             var response = await ExecuteRequestAsync<IEnumerable<FulfillmentOrder>>(req, HttpMethod.Get, cancellationToken, rootElement: "fulfillment_orders");
 
             return response.Result;

--- a/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
+++ b/ShopifySharp/Services/FulfillmentOrders/FulfillmentOrderService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public FulfillmentOrderService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal FulfillmentOrderService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CancelAsync(long fulfillmentOrderId, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/FulfillmentRequest/FulfillmentRequestService.cs
+++ b/ShopifySharp/Services/FulfillmentRequest/FulfillmentRequestService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CreateAsync(long fulfillmentOrderId, FulfillmentRequest fulfillmentRequest, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request.json");
             var body = fulfillmentRequest.ToDictionary();
 
             var content = new JsonContent(new
@@ -35,7 +35,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> AcceptAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/accept.json");
+            var req = BuildRequestUri($"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/accept.json");
             var fulfillmentRequest = new FulfillmentRequest { Message = message };
             var body = fulfillmentRequest.ToDictionary();
 
@@ -51,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> RejectAsync(long fulfillmentOrderId, string message, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/reject.json");
+            var req = BuildRequestUri($@"fulfillment_orders/{fulfillmentOrderId}/fulfillment_request/reject.json");
             var fulfillmentRequest = new FulfillmentRequest { Message = message };
             var body = fulfillmentRequest.ToDictionary();
 

--- a/ShopifySharp/Services/FulfillmentRequest/FulfillmentRequestService.cs
+++ b/ShopifySharp/Services/FulfillmentRequest/FulfillmentRequestService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public FulfillmentRequestService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal FulfillmentRequestService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<FulfillmentOrder> CreateAsync(long fulfillmentOrderId, FulfillmentRequest fulfillmentRequest, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -15,7 +16,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public FulfillmentServiceService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal FulfillmentServiceService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<FulfillmentServiceEntity>> ListAsync(FulfillmentServiceListFilter filter = null, CancellationToken cancellationToken = default) => 
             await ExecuteGetAsync<List<FulfillmentServiceEntity>>("fulfillment_services.json", "fulfillment_services", filter, cancellationToken);

--- a/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
+++ b/ShopifySharp/Services/FulfillmentService/FulfillmentServiceService.cs
@@ -27,7 +27,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentServiceEntity> CreateAsync(FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_services.json");
+            var req = BuildRequestUri($"fulfillment_services.json");
             var body = fulfillmentServiceEntity.ToDictionary();
 
             var content = new JsonContent(new
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<FulfillmentServiceEntity> UpdateAsync(long fulfillmentServiceId, FulfillmentServiceEntity fulfillmentServiceEntity, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
+            var req = BuildRequestUri($"fulfillment_services/{fulfillmentServiceId}.json");
             var body = fulfillmentServiceEntity.ToDictionary();
 
             var content = new JsonContent(new
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long fulfillmentServiceId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"fulfillment_services/{fulfillmentServiceId}.json");
+            var req = BuildRequestUri($"fulfillment_services/{fulfillmentServiceId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<GiftCard> CreateAsync(GiftCard giftCard, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("gift_cards.json");
+            var req = BuildRequestUri("gift_cards.json");
             var body = giftCard.ToDictionary();
 
             var content = new JsonContent(new
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<GiftCard> UpdateAsync(long giftCardId, GiftCard giftCard, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"gift_cards/{giftCardId}.json");
+            var req = BuildRequestUri($"gift_cards/{giftCardId}.json");
             var content = new JsonContent(new
             {
                 gift_card = giftCard
@@ -71,7 +71,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<GiftCard> DisableAsync(long giftCardId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"gift_cards/{giftCardId}/disable.json");
+            var req = BuildRequestUri($"gift_cards/{giftCardId}/disable.json");
             var response = await ExecuteRequestAsync<GiftCard>(req, HttpMethod.Post, cancellationToken, rootElement: "gift_card");
             return response.Result;
         }

--- a/ShopifySharp/Services/GiftCard/GiftCardService.cs
+++ b/ShopifySharp/Services/GiftCard/GiftCardService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public GiftCardService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal GiftCardService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(GiftCardCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>($"gift_cards/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
 
         public virtual async Task<GiftCardAdjustment> CreateAsync(long giftCardId, GiftCardAdjustment adjustment, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"gift_cards/{giftCardId}/adjustments.json");
+            var req = BuildRequestUri($"gift_cards/{giftCardId}/adjustments.json");
             var content = new JsonContent(new
             {
                 adjustment = adjustment

--- a/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
+++ b/ShopifySharp/Services/GiftCardAdjustment/GiftCardAdjustmentService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -17,7 +18,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public GiftCardAdjustmentService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal GiftCardAdjustmentService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         public virtual async Task<IEnumerable<GiftCardAdjustment>> ListAsync(long giftCardId, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<IEnumerable<GiftCardAdjustment>>($"gift_cards/{giftCardId}/adjustments.json", "adjustments", cancellationToken: cancellationToken);
 

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using System;
 using System.Text.Json;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -30,6 +31,11 @@ namespace ShopifySharp
         public GraphService(string myShopifyUrl, string shopAccessToken, string apiVersion = null) : base(myShopifyUrl, shopAccessToken) 
         {
             _apiVersion = apiVersion;
+        }
+
+        public GraphService(string myShopifyUrl, string shopAccessToken, IShopifyDomainUtility shopifyDomainUtility) : base(myShopifyUrl, shopAccessToken, shopifyDomainUtility)
+        {
+
         }
 
         public virtual async Task<JToken> PostAsync(JToken body, int? graphqlQueryCost = null, CancellationToken cancellationToken = default)

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -82,7 +82,7 @@ namespace ShopifySharp
 
         private async Task<T> PostAsync<T>(string body, string mediaType, int? graphqlQueryCost, CancellationToken cancellationToken)
         {
-            var req = PrepareRequest("graphql.json");
+            var req = BuildRequestUri("graphql.json");
 
             var content = new StringContent(body, Encoding.UTF8, mediaType);
 

--- a/ShopifySharp/Services/IShopifyService.cs
+++ b/ShopifySharp/Services/IShopifyService.cs
@@ -1,8 +1,12 @@
+#nullable enable
+// ReSharper disable InconsistentNaming
+
 namespace ShopifySharp
 {
     public interface IShopifyService
     {
         string APIVersion { get; }
+        bool SupportsAPIVersioning { get; }
 
         void SetExecutionPolicy(IRequestExecutionPolicy policy);
 

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<InventoryItem> UpdateAsync( long inventoryItemId, InventoryItem inventoryItem, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest( $"inventory_items/{inventoryItemId}.json" );
+            var req = BuildRequestUri( $"inventory_items/{inventoryItemId}.json" );
             var content = new JsonContent( new
             {
                 inventory_item = inventoryItem

--- a/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
+++ b/ShopifySharp/Services/InventoryItem/InventoryItemService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public InventoryItemService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal InventoryItemService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<InventoryItem>> ListAsync(ListFilter<InventoryItem> filter, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync($"inventory_items.json", "inventory_items", filter, cancellationToken);

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -28,13 +28,16 @@ namespace ShopifySharp
 			await ListAsync(filter?.AsListFilter(), cancellationToken);
 
         /// <inheritdoc />
-        public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default) =>
-			await ExecuteRequestAsync(PrepareRequest($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}"), HttpMethod.Delete, cancellationToken);
+        public virtual async Task DeleteAsync(long inventoryItemId, long locationId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = BuildRequestUri($"inventory_levels.json?inventory_item_id={inventoryItemId}&location_id={locationId}");
+            await ExecuteRequestAsync(requestUri, HttpMethod.Delete, cancellationToken);
+        }
 
         /// <inheritdoc />
         public virtual async Task<InventoryLevel> SetAsync(InventoryLevel updatedInventoryLevel, bool disconnectIfNecessary = false, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"inventory_levels/set.json");
+            var req = BuildRequestUri($"inventory_levels/set.json");
             var body = updatedInventoryLevel.ToDictionary();
             
             body.Add("disconnect_if_necessary", disconnectIfNecessary);
@@ -48,7 +51,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<InventoryLevel> AdjustAsync(InventoryLevelAdjust updatedInventoryLevel, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"inventory_levels/adjust.json");
+            var req = BuildRequestUri($"inventory_levels/adjust.json");
             var body = updatedInventoryLevel.ToDictionary();
             var content = new JsonContent(body);
             var response = await ExecuteRequestAsync<InventoryLevel>(req, HttpMethod.Post, cancellationToken, content, "inventory_level");
@@ -59,7 +62,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<InventoryLevel> ConnectAsync(long inventoryItemId, long locationId, bool relocateIfNecessary = false, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"inventory_levels/connect.json");
+            var req = BuildRequestUri($"inventory_levels/connect.json");
             var content = new JsonContent(new
             {
                 location_id = locationId,

--- a/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
+++ b/ShopifySharp/Services/InventoryLevel/InventoryLevelService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public InventoryLevelService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal InventoryLevelService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<InventoryLevel>> ListAsync(ListFilter<InventoryLevel> filter, CancellationToken cancellationToken = default) =>
 			await ExecuteGetListAsync($"inventory_levels.json", "inventory_levels", filter, cancellationToken);

--- a/ShopifySharp/Services/Location/LocationService.cs
+++ b/ShopifySharp/Services/Location/LocationService.cs
@@ -2,6 +2,7 @@
 using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public LocationService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal LocationService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         public virtual async Task<Location> GetAsync(long id, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<Location>($"locations/{id}.json", "location", cancellationToken: cancellationToken);
 

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("metafields.json");
+            var req = BuildRequestUri("metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -75,7 +75,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, long parentResourceId, string parentResourceType, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json");
+            var req = BuildRequestUri($"{parentResourceType.ToLower()}/{parentResourceId}/{resourceType.ToLower()}/{resourceId}/metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -88,7 +88,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> CreateAsync(MetaField metafield, long resourceId, string resourceType, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"{resourceType.ToLower()}/{resourceId}/metafields.json");
+            var req = BuildRequestUri($"{resourceType.ToLower()}/{resourceId}/metafields.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -101,7 +101,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<MetaField> UpdateAsync(long metafieldId, MetaField metafield, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"metafields/{metafieldId}.json");
+            var req = BuildRequestUri($"metafields/{metafieldId}.json");
             var content = new JsonContent(new
             {
                 metafield = metafield
@@ -114,7 +114,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long metafieldId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"metafields/{metafieldId}.json");
+            var req = BuildRequestUri($"metafields/{metafieldId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/MetaField/MetaFieldService.cs
+++ b/ShopifySharp/Services/MetaField/MetaFieldService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public MetaFieldService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal MetaFieldService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(CancellationToken cancellationToken = default) =>
 			await _CountAsync("metafields/count.json", cancellationToken);

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -20,8 +21,10 @@ namespace ShopifySharp
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public OrderService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
+        internal OrderService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+
         /// <inheritdoc />
-        public virtual async Task<int> CountAsync(OrderCountFilter filter = null, CancellationToken cancellationToken = default) => 
+        public virtual async Task<int> CountAsync(OrderCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("orders/count.json", "count", filter, cancellationToken);
 
         /// <inheritdoc />

--- a/ShopifySharp/Services/Order/OrderService.cs
+++ b/ShopifySharp/Services/Order/OrderService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> CloseAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{id}/close.json");
+            var req = BuildRequestUri($"orders/{id}/close.json");
             var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, rootElement: "order");
 
             return response.Result;
@@ -48,7 +48,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> OpenAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{id}/open.json");
+            var req = BuildRequestUri($"orders/{id}/open.json");
             var response = await ExecuteRequestAsync<Order>(req, HttpMethod.Post, cancellationToken, rootElement: "order");
 
             return response.Result;
@@ -57,7 +57,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> CreateAsync(Order order, OrderCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("orders.json");
+            var req = BuildRequestUri("orders.json");
             var body = order.ToDictionary();
 
             if (options != null)
@@ -80,7 +80,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Order> UpdateAsync(long orderId, Order order, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}.json");
+            var req = BuildRequestUri($"orders/{orderId}.json");
             var content = new JsonContent(new
             {
                 order = order
@@ -93,7 +93,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}.json");
+            var req = BuildRequestUri($"orders/{orderId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -101,7 +101,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task CancelAsync(long orderId, OrderCancelOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/cancel.json");
+            var req = BuildRequestUri($"orders/{orderId}/cancel.json");
             var content = new JsonContent(options ?? new OrderCancelOptions());
 
             await ExecuteRequestAsync(req, HttpMethod.Post, cancellationToken, content);
@@ -110,7 +110,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<MetaField>> GetMetaFieldsAsync(long orderId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/metafields.json");
+            var req = BuildRequestUri($"orders/{orderId}/metafields.json");
             var response = await ExecuteRequestAsync<List<MetaField>>(req, HttpMethod.Get, cancellationToken, rootElement: "metafields");
 
             return response.Result;

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -28,7 +28,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<OrderRisk> CreateAsync(long orderId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/risks.json");
+            var req = BuildRequestUri($"orders/{orderId}/risks.json");
             var content = new JsonContent(new
             {
                 risk = risk
@@ -41,7 +41,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<OrderRisk> UpdateAsync(long orderId, long orderRiskId, OrderRisk risk, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/risks/{orderRiskId}.json");
+            var req = BuildRequestUri($"orders/{orderId}/risks/{orderRiskId}.json");
             var content = new JsonContent(new
             {
                 risk = risk
@@ -54,7 +54,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long orderId, long riskId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/risks/{riskId}.json");
+            var req = BuildRequestUri($"orders/{orderId}/risks/{riskId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
+++ b/ShopifySharp/Services/OrderRisk/OrderRiskService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -19,6 +20,8 @@ namespace ShopifySharp
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public OrderRiskService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
 
+        internal OrderRiskService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<OrderRisk>> ListAsync(long orderId, ListFilter<OrderRisk> filter = null, CancellationToken cancellationToken = default) => await ExecuteGetListAsync($"orders/{orderId}/risks.json", "risks", filter, cancellationToken);
 

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Page> GetAsync(long pageId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"pages/{pageId}.json");
+            var req = BuildRequestUri($"pages/{pageId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Page> CreateAsync(Page page, PageCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("pages.json");
+            var req = BuildRequestUri("pages.json");
             var body = page.ToDictionary();
 
             if (options != null)
@@ -72,7 +72,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Page> UpdateAsync(long pageId, Page page, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"pages/{pageId}.json");
+            var req = BuildRequestUri($"pages/{pageId}.json");
             var content = new JsonContent(new
             {
                 page = page
@@ -85,7 +85,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long pageId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"pages/{pageId}.json");
+            var req = BuildRequestUri($"pages/{pageId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Page/PageService.cs
+++ b/ShopifySharp/Services/Page/PageService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public PageService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal PageService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(PageCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("pages/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -26,6 +27,11 @@ namespace ShopifySharp
         {
             _organizationId = organizationId;
             _apiVersion = apiVersion;
+        }
+
+        public PartnerService(long organizationId, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base("partners.shopify.com", accessToken, shopifyDomainUtility)
+        {
+            _organizationId = organizationId;
         }
 
         /// <inheritdoc />

--- a/ShopifySharp/Services/Policy/PolicyService.cs
+++ b/ShopifySharp/Services/Policy/PolicyService.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -13,7 +14,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public PolicyService(string myShopifyUrl, string shopAccessToken): base(myShopifyUrl, shopAccessToken) { }
-
+        internal PolicyService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<Policy>> ListAsync(CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Policy/PolicyService.cs
+++ b/ShopifySharp/Services/Policy/PolicyService.cs
@@ -17,7 +17,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<Policy>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest("policies.json");
+            var request = BuildRequestUri("policies.json");
             var response = await ExecuteRequestAsync<List<Policy>>(request, HttpMethod.Get, cancellationToken, rootElement: "policies");
 
             return response.Result;

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -31,7 +31,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRule> GetAsync(long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{id}.json");
+            var req = BuildRequestUri($"price_rules/{id}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRule> CreateAsync(PriceRule rule, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("price_rules.json");
+            var req = BuildRequestUri("price_rules.json");
             var body = rule.ToDictionary();
             var content = new JsonContent(new
             {
@@ -60,7 +60,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<PriceRule> UpdateAsync(long id, PriceRule rule, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{id}.json");
+            var req = BuildRequestUri($"price_rules/{id}.json");
             var content = new JsonContent(new
             {
                 price_rule = rule
@@ -73,7 +73,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"price_rules/{id}.json");
+            var req = BuildRequestUri($"price_rules/{id}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/PriceRule/PriceRuleService.cs
+++ b/ShopifySharp/Services/PriceRule/PriceRuleService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -15,7 +16,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public PriceRuleService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal PriceRuleService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<PriceRule>> ListAsync(ListFilter<PriceRule> filter, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -19,7 +20,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ProductService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ProductService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         public virtual async Task<int> CountAsync(ProductCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("products/count.json", "count", filter, cancellationToken);
         

--- a/ShopifySharp/Services/Product/ProductService.cs
+++ b/ShopifySharp/Services/Product/ProductService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
 
         public virtual async Task<Product> CreateAsync(Product product, ProductCreateOptions options = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("products.json");
+            var req = BuildRequestUri("products.json");
             var body = product.ToDictionary();
 
             if (options != null)
@@ -56,7 +56,7 @@ namespace ShopifySharp
 
         public virtual async Task<Product> UpdateAsync(long productId, Product product, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}.json");
+            var req = BuildRequestUri($"products/{productId}.json");
             var content = new JsonContent(new
             {
                 product = product
@@ -68,14 +68,14 @@ namespace ShopifySharp
 
         public virtual async Task DeleteAsync(long productId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}.json");
+            var req = BuildRequestUri($"products/{productId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         public virtual async Task<Product> PublishAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{id}.json");
+            var req = BuildRequestUri($"products/{id}.json");
             var content = new JsonContent(new
             {
                 product = new
@@ -91,7 +91,7 @@ namespace ShopifySharp
 
         public virtual async Task<Product> UnpublishAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{id}.json");
+            var req = BuildRequestUri($"products/{id}.json");
             var content = new JsonContent(new
             {
                 product = new

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ProductImageService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ProductImageService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
 		///<inheritdoc />
         public virtual async Task<int> CountAsync(long productId, ProductImageCountFilter filter = null, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/ProductImage/ProductImageService.cs
+++ b/ShopifySharp/Services/ProductImage/ProductImageService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ProductImage> CreateAsync(long productId, ProductImage image, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/images.json");
+            var req = BuildRequestUri($"products/{productId}/images.json");
             var content = new JsonContent(new
             {
                 image = image
@@ -53,7 +53,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ProductImage> UpdateAsync(long productId, long productImageId, ProductImage image, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/images/{productImageId}.json");
+            var req = BuildRequestUri($"products/{productId}/images/{productImageId}.json");
             var content = new JsonContent(new
             {
                 image = image
@@ -66,7 +66,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task DeleteAsync(long productId, long imageId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/images/{imageId}.json");
+            var req = BuildRequestUri($"products/{productId}/images/{imageId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/ProductListing/ProductListingService.cs
+++ b/ShopifySharp/Services/ProductListing/ProductListingService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ProductListingService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ProductListingService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<ProductListing>> ListAsync(ListFilter<ProductListing> filter, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync("product_listings.json", "product_listings", filter, cancellationToken);

--- a/ShopifySharp/Services/ProductListing/ProductListingService.cs
+++ b/ShopifySharp/Services/ProductListing/ProductListingService.cs
@@ -42,7 +42,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ProductListing> CreateAsync(long productId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"product_listings/{productId}.json");
+            var req = BuildRequestUri($"product_listings/{productId}.json");
             var content = new JsonContent(new
             {
                 product_listing = new { product_id = productId }
@@ -55,7 +55,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long productId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"product_listings/{productId}.json");
+            var req = BuildRequestUri($"product_listings/{productId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ProductVariantService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ProductVariantService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(long productId, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
+++ b/ShopifySharp/Services/ProductVariant/ProductVariantService.cs
@@ -46,7 +46,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ProductVariant> CreateAsync(long productId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/variants.json");
+            var req = BuildRequestUri($"products/{productId}/variants.json");
             var content = new JsonContent(new
             {
                 variant = variant
@@ -59,7 +59,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<ProductVariant> UpdateAsync(long productVariantId, ProductVariant variant, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"variants/{productVariantId}.json");
+            var req = BuildRequestUri($"variants/{productVariantId}.json");
             var content = new JsonContent(new
             {
                 variant = variant
@@ -72,7 +72,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long productId, long variantId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"products/{productId}/variants/{variantId}.json");
+            var req = BuildRequestUri($"products/{productId}/variants/{variantId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
+++ b/ShopifySharp/Services/RecurringCharge/RecurringChargeService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public RecurringChargeService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal RecurringChargeService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<RecurringCharge> CreateAsync(RecurringCharge charge, CancellationToken cancellationToken = default) =>
             await ExecutePostAsync<RecurringCharge>("recurring_application_charges.json", "recurring_application_charge", cancellationToken, new { recurring_application_charge = charge });

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Redirect> GetAsync(long redirectId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"redirects/{redirectId}.json");
+            var req = BuildRequestUri($"redirects/{redirectId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Redirect> CreateAsync(Redirect redirect, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("redirects.json");
+            var req = BuildRequestUri("redirects.json");
             var content = new JsonContent(new
             {
                 redirect = redirect
@@ -62,7 +62,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Redirect> UpdateAsync(long redirectId, Redirect redirect, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"redirects/{redirectId}.json");
+            var req = BuildRequestUri($"redirects/{redirectId}.json");
             var content = new JsonContent(new
             {
                 redirect = redirect
@@ -75,7 +75,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long redirectId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"redirects/{redirectId}.json");
+            var req = BuildRequestUri($"redirects/{redirectId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/Redirect/RedirectService.cs
+++ b/ShopifySharp/Services/Redirect/RedirectService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public RedirectService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal RedirectService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(RedirectCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("redirects/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -34,7 +34,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Refund> CalculateAsync(long orderId, Refund options, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/refunds/calculate.json");
+            var req = BuildRequestUri($"orders/{orderId}/refunds/calculate.json");
             var content = new JsonContent(new { refund = options });
             var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, cancellationToken, content, "refund");
 
@@ -44,7 +44,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Refund> RefundAsync(long orderId, Refund options, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/refunds.json");
+            var req = BuildRequestUri($"orders/{orderId}/refunds.json");
             var content = new JsonContent(new { refund = options });
             var response = await ExecuteRequestAsync<Refund>(req, HttpMethod.Post, cancellationToken, content, "refund");
 

--- a/ShopifySharp/Services/Refund/RefundService.cs
+++ b/ShopifySharp/Services/Refund/RefundService.cs
@@ -4,6 +4,7 @@ using ShopifySharp.Lists;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public RefundService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal RefundService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<Refund>> ListForOrderAsync(long orderId, ListFilter<Refund> filter, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync($"orders/{orderId}/refunds.json", "refunds", filter, cancellationToken);

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -40,7 +40,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ScriptTag> GetAsync(long tagId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"script_tags/{tagId}.json");
+            var req = BuildRequestUri($"script_tags/{tagId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -55,7 +55,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ScriptTag> CreateAsync(ScriptTag tag, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("script_tags.json");
+            var req = BuildRequestUri("script_tags.json");
             var content = new JsonContent(new
             {
                 script_tag = tag
@@ -68,7 +68,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<ScriptTag> UpdateAsync(long scriptTagId, ScriptTag tag, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"script_tags/{scriptTagId}.json");
+            var req = BuildRequestUri($"script_tags/{scriptTagId}.json");
             var content = new JsonContent(new
             {
                 script_tag = tag
@@ -81,7 +81,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task DeleteAsync(long tagId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"script_tags/{tagId}.json");
+            var req = BuildRequestUri($"script_tags/{tagId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
+++ b/ShopifySharp/Services/ScriptTag/ScriptTagService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ScriptTagService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-        
+        internal ScriptTagService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+         
 		///<inheritdoc />
         public virtual async Task<int> CountAsync(ScriptTagCountFilter filter = null, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
+++ b/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
@@ -21,7 +21,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<ShippingZone>> ListAsync(ShippingZoneListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("shipping_zones.json");
+            var req = BuildRequestUri("shipping_zones.json");
             
             if (filter != null)
             {

--- a/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
+++ b/ShopifySharp/Services/ShippingZone/ShippingZoneService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -17,7 +18,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ShippingZoneService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ShippingZoneService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<ShippingZone>> ListAsync(ShippingZoneListFilter filter = null, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/Shop/ShopService.cs
+++ b/ShopifySharp/Services/Shop/ShopService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -12,7 +13,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ShopService(string myShopifyUrl, string shopAccessToken): base(myShopifyUrl, shopAccessToken) { }
-        
+        internal ShopService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+         
         /// <inheritdoc />
         public virtual async Task<Shop> GetAsync(CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<Shop>("shop.json", "shop", cancellationToken: cancellationToken);

--- a/ShopifySharp/Services/Shop/ShopService.cs
+++ b/ShopifySharp/Services/Shop/ShopService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task UninstallAppAsync(CancellationToken cancellationToken = default)
         {
-            var request = PrepareRequest("api_permissions/current.json");
+            var request = BuildRequestUri("api_permissions/current.json");
 
             await ExecuteRequestAsync(request, HttpMethod.Delete, cancellationToken: cancellationToken);
         }

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ShopifyPaymentsService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ShopifyPaymentsService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -27,9 +27,16 @@ namespace ShopifySharp
 
         private static IRequestExecutionPolicy _GlobalExecutionPolicy = new DefaultRequestExecutionPolicy();
         private static IHttpClientFactory _HttpClientFactory = new InternalHttpClientFactory();
-        private readonly IShopifyDomainUtility _domainUtility = new ShopifyDomainUtility();
         private IRequestExecutionPolicy _ExecutionPolicy;
         private HttpClient _Client;
+
+        protected ShopifyService(string shopDomain, string accessToken, IShopifyDomainUtility domainUtility)
+        {
+            _ShopUri = domainUtility.BuildShopDomainUri(shopDomain);
+            _AccessToken = accessToken;
+            _Client = _HttpClientFactory.CreateClient();
+            _ExecutionPolicy = _GlobalExecutionPolicy;
+        }
 
         /// <summary>
         /// Creates a new instance of the service using a Shopify shop domain and access token.
@@ -38,7 +45,8 @@ namespace ShopifySharp
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         protected ShopifyService(string myShopifyUrl, string shopAccessToken)
         {
-            _ShopUri = _domainUtility.BuildShopDomainUri(myShopifyUrl);
+            var domainUtility = new ShopifyDomainUtility();
+            _ShopUri = domainUtility.BuildShopDomainUri(myShopifyUrl);
             _AccessToken = shopAccessToken;
             _Client = _HttpClientFactory.CreateClient();
             _ExecutionPolicy = _GlobalExecutionPolicy;
@@ -49,7 +57,8 @@ namespace ShopifySharp
         /// </summary>
         protected ShopifyService(ShopifyApiCredentials credentials)
         {
-            _ShopUri = _domainUtility.BuildShopDomainUri(credentials.ShopDomain);
+            var domainUtility = new ShopifyDomainUtility();
+            _ShopUri = domainUtility.BuildShopDomainUri(credentials.ShopDomain);
             _AccessToken = credentials.AccessToken;
             _Client = _HttpClientFactory.CreateClient();
             _ExecutionPolicy = _GlobalExecutionPolicy;

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -218,9 +218,6 @@ namespace ShopifySharp
         /// Executes a request and returns a JToken for querying. Throws an exception when the response is invalid.
         /// Use this method when the expected response is a single line or simple object that doesn't warrant its own class.
         /// </summary>
-        /// <remarks>
-        /// This method will automatically dispose the <paramref name="baseClient"/> and <paramref name="content" /> when finished.
-        /// </remarks>
         protected async Task<RequestResult<JToken>> ExecuteRequestAsync(
             RequestUri uri,
             HttpMethod method,
@@ -236,9 +233,6 @@ namespace ShopifySharp
         /// Executes a request and returns the given type. Throws an exception when the response is invalid.
         /// Use this method when the expected response is a single line or simple object that doesn't warrant its own class.
         /// </summary>
-        /// <remarks>
-        /// This method will automatically dispose the <paramref name="baseRequestMessage" /> when finished.
-        /// </remarks>
         protected async Task<RequestResult<T>> ExecuteRequestAsync<T>(
             RequestUri uri,
             HttpMethod method,

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -55,8 +55,6 @@ namespace ShopifySharp
             _ExecutionPolicy = _GlobalExecutionPolicy;
         }
 
-        #nullable disable
-
         /// <summary>
         /// Attempts to build a shop API <see cref="Uri"/> for the given shop.
         /// </summary>
@@ -79,6 +77,8 @@ namespace ShopifySharp
 
             return uriBuilder.Uri;
         }
+
+        #nullable disable
 
         /// <summary>
         /// Sets the execution policy for this instance only. This policy will always be used over the global execution policy.

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -20,10 +20,10 @@ namespace ShopifySharp
         #nullable enable
 
         public virtual string APIVersion => "2023-07";
+        public virtual bool SupportsAPIVersioning => true;
 
         protected Uri _ShopUri { get; set; }
         protected string _AccessToken { get; set; }
-        protected virtual bool SupportsAPIVersioning => true;
 
         private static IRequestExecutionPolicy _GlobalExecutionPolicy = new DefaultRequestExecutionPolicy();
         private static IHttpClientFactory _HttpClientFactory = new InternalHttpClientFactory();

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> CreateAsync(SmartCollection collection, bool published = true, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections.json");
+            var req = BuildRequestUri($"smart_collections.json");
             var body = collection.ToDictionary();
 
             body.Add("published", published);
@@ -56,7 +56,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> UpdateAsync(long smartCollectionId, SmartCollection collection, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}.json");
             var content = new JsonContent(new
             {
                 smart_collection = collection
@@ -69,7 +69,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> PublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}.json");
             var body = new Dictionary<string, object>()
             {
                 { "id", smartCollectionId },
@@ -87,7 +87,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<SmartCollection> UnpublishAsync(long smartCollectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}.json");
             var body = new Dictionary<string, object>()
             {
                 { "id", smartCollectionId },
@@ -105,7 +105,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task UpdateProductOrderAsync(long smartCollectionId, string sortOrder = null, params long[] productIds)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}/order.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}/order.json");
             var content = new JsonContent(new
             {
                 sort_order = sortOrder,
@@ -117,7 +117,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task UpdateProductOrderAsync(long smartCollectionId, CancellationToken cancellationToken, string sortOrder = null, params long[] productIds)
         {
-            var req = PrepareRequest($"smart_collections/{smartCollectionId}/order.json");
+            var req = BuildRequestUri($"smart_collections/{smartCollectionId}/order.json");
             var content = new JsonContent(new
             {
                 sort_order = sortOrder,
@@ -129,7 +129,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task DeleteAsync(long collectionId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"smart_collections/{collectionId}.json");
+            var req = BuildRequestUri($"smart_collections/{collectionId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }

--- a/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
+++ b/ShopifySharp/Services/SmartCollection/SmartCollectionService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -19,7 +20,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public SmartCollectionService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal SmartCollectionService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(SmartCollectionCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("smart_collections/count.json", "count", filter, cancellationToken);

--- a/ShopifySharp/Services/StorefrontAccessToken/StorefrontAccessTokenService.cs
+++ b/ShopifySharp/Services/StorefrontAccessToken/StorefrontAccessTokenService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -12,7 +13,8 @@ namespace ShopifySharp
     public class StorefrontAccessTokenService : ShopifyService, IStorefrontAccessTokenService
     {
         public StorefrontAccessTokenService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal StorefrontAccessTokenService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public async Task<StorefrontAccessToken> CreateAsync(string title, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/StorefrontAccessToken/StorefrontAccessTokenService.cs
+++ b/ShopifySharp/Services/StorefrontAccessToken/StorefrontAccessTokenService.cs
@@ -16,7 +16,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public async Task<StorefrontAccessToken> CreateAsync(string title, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("storefront_access_tokens.json");
+            var req = BuildRequestUri("storefront_access_tokens.json");
             var content = new JsonContent(new
             {
                 storefront_access_token = new
@@ -32,7 +32,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"storefront_access_tokens/{id}.json");
+            var req = BuildRequestUri($"storefront_access_tokens/{id}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
@@ -40,7 +40,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public async Task<IEnumerable<StorefrontAccessToken>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest("storefront_access_tokens.json");
+            var req = BuildRequestUri("storefront_access_tokens.json");
             var response = await ExecuteRequestAsync<IEnumerable<StorefrontAccessToken>>(req, HttpMethod.Get, cancellationToken, rootElement: "storefront_access_tokens");
 
             return response.Result;

--- a/ShopifySharp/Services/TenderTransaction/TenderTransactionService.cs
+++ b/ShopifySharp/Services/TenderTransaction/TenderTransactionService.cs
@@ -2,6 +2,7 @@
 using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public TenderTransactionService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal TenderTransactionService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<TenderTransaction>> ListAsync(ListFilter<TenderTransaction> filter, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync("tender_transactions.json", "tender_transactions", filter, cancellationToken);

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public ThemeService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal ThemeService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<Theme>> ListAsync(ThemeListFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<IEnumerable<Theme>>("themes.json", "themes", filter, cancellationToken);

--- a/ShopifySharp/Services/Theme/ThemeService.cs
+++ b/ShopifySharp/Services/Theme/ThemeService.cs
@@ -26,7 +26,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<Theme> GetAsync(long themeId, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}.json");
+            var req = BuildRequestUri($"themes/{themeId}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -49,7 +49,7 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task<Theme> UpdateAsync(long themeId, Theme theme, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}.json");
+            var req = BuildRequestUri($"themes/{themeId}.json");
             var content = new JsonContent(new
             {
                 theme = theme
@@ -62,14 +62,14 @@ namespace ShopifySharp
 		///<inheritdoc />
         public virtual async Task DeleteAsync(long themeId, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"themes/{themeId}.json");
+            var req = BuildRequestUri($"themes/{themeId}.json");
 
             await ExecuteRequestAsync(req, HttpMethod.Delete, cancellationToken);
         }
 
         private async Task<Theme> _CreateAsync(Theme theme, CancellationToken cancellationToken, string sourceUrl = null)
         {
-            var req = PrepareRequest("themes.json");
+            var req = BuildRequestUri("themes.json");
             var body = theme.ToDictionary();
 
             if (!string.IsNullOrEmpty(sourceUrl))

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -30,7 +30,7 @@ namespace ShopifySharp
 
         public virtual async Task<Transaction> CreateAsync(long orderId, Transaction transaction, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"orders/{orderId}/transactions.json");
+            var req = BuildRequestUri($"orders/{orderId}/transactions.json");
             var content = new JsonContent(new
             {
                 transaction = transaction

--- a/ShopifySharp/Services/Transaction/TransactionService.cs
+++ b/ShopifySharp/Services/Transaction/TransactionService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public TransactionService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal TransactionService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         public virtual async Task<int> CountAsync(long orderId, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>($"orders/{orderId}/transactions/count.json", "count", cancellationToken: cancellationToken);
 

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -18,7 +19,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public UsageChargeService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal UsageChargeService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<UsageCharge> CreateAsync(long recurringChargeId, string description, decimal price, CancellationToken cancellationToken = default)
         {

--- a/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
+++ b/ShopifySharp/Services/UsageCharge/UsageChargeService.cs
@@ -22,7 +22,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<UsageCharge> CreateAsync(long recurringChargeId, string description, decimal price, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
+            var req = BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
             var content = new JsonContent(new
             {
                 usage_charge = new
@@ -39,7 +39,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<UsageCharge> GetAsync(long recurringChargeId, long id, string fields = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges/{id}.json");
+            var req = BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges/{id}.json");
 
             if (!string.IsNullOrEmpty(fields))
             {
@@ -54,7 +54,7 @@ namespace ShopifySharp
         /// <inheritdoc />
         public virtual async Task<IEnumerable<UsageCharge>> ListAsync(long recurringChargeId, UsageChargeListFilter filter = null, CancellationToken cancellationToken = default)
         {
-            var req = PrepareRequest($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
+            var req = BuildRequestUri($"recurring_application_charges/{recurringChargeId}/usage_charges.json");
 
             if (filter != null)
             {

--- a/ShopifySharp/Services/User/UserService.cs
+++ b/ShopifySharp/Services/User/UserService.cs
@@ -2,6 +2,7 @@ using ShopifySharp.Filters;
 using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public UserService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal UserService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<ListResult<User>> ListAsync(ListFilter<User> filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetListAsync("users.json", "users", filter, cancellationToken);

--- a/ShopifySharp/Services/Webhook/WebhookService.cs
+++ b/ShopifySharp/Services/Webhook/WebhookService.cs
@@ -2,6 +2,7 @@
 using ShopifySharp.Lists;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
@@ -16,7 +17,8 @@ namespace ShopifySharp
         /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
         /// <param name="shopAccessToken">An API access token for the shop.</param>
         public WebhookService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-
+        internal WebhookService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
+ 
         /// <inheritdoc />
         public virtual async Task<int> CountAsync(WebhookCountFilter filter = null, CancellationToken cancellationToken = default) =>
             await ExecuteGetAsync<int>("webhooks/count.json", "count", filter, cancellationToken);


### PR DESCRIPTION
This pull request lets the service factories inject the `IShopifyDomainUtility` directly into the services they create via an internal constructor. The constructor is internal for now because I'm unsure of the design at the moment and plan to iterate on it, so I don't want anyone to rely on it yet.

The PR also adds an overload for the DI package's `AddShopifySharpUtilities` with a configuration action for customizing the utilities added to DI:

```
services.AddShopifySharpUtilities(options =>
{
    options.DomainUtility = new MyDomainUtility();
    options.RequestValidationUtility = new MyRequestValidationUtility();
    options.OauthUtility = new MyOauthUtility();
});
```