### PR TITLE
Add ShopifySharp.Services.ShopPlanService

### DIFF
--- a/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -128,6 +128,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IRefundServiceFactory, RefundServiceFactory>();
         services.TryAddSingleton<IScriptTagServiceFactory, ScriptTagServiceFactory>();
         services.TryAddSingleton<IShippingZoneServiceFactory, ShippingZoneServiceFactory>();
+        services.TryAddSingleton<IShopPlanServiceFactory, ShopPlanServiceFactory>();
         services.TryAddSingleton<IShopServiceFactory, ShopServiceFactory>();
         services.TryAddSingleton<IShopifyPaymentsServiceFactory, ShopifyPaymentsServiceFactory>();
         services.TryAddSingleton<ISmartCollectionServiceFactory, SmartCollectionServiceFactory>();

--- a/ShopifySharp.Tests/Services/ShopPlanServiceTests.cs
+++ b/ShopifySharp.Tests/Services/ShopPlanServiceTests.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Services;
+using Xunit;
+
+namespace ShopifySharp.Tests.Services;
+
+[Trait("Category", "ShopPlanService")]
+[TestSubject(typeof(ShopPlanService))]
+public class ShopPlanServiceTests
+{
+    ShopPlanService service = new(Utils.MyShopifyUrl, Utils.AccessToken);
+
+    [Fact]
+    public async Task GetShopPlanAsync_ShouldGetThePlanAsync()
+    {
+        // Act
+        var result = await service.GetShopPlanAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.DisplayName.Should().NotBeNullOrEmpty();
+        result.PartnerDevelopment.Should().BeTrue();
+        result.ShopifyPlus.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsPartnerDevelopmentPlanAsync_ShouldCheckIfTheShopIsOnADevPlan()
+    {
+        // Act
+        var result = await service.IsPartnerDevelopmentShopAsync();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+}

--- a/ShopifySharp/Entities/ShopPlan.cs
+++ b/ShopifySharp/Entities/ShopPlan.cs
@@ -1,0 +1,21 @@
+#nullable enable
+namespace ShopifySharp;
+
+///<summary>
+///The billing plan of the shop.
+///</summary>
+public class ShopPlan
+{
+    ///<summary>
+    ///The name of the shop's billing plan.
+    ///</summary>
+    public string? DisplayName { get; set; }
+    ///<summary>
+    ///Whether the shop is a partner development shop for testing purposes.
+    ///</summary>
+    public bool? PartnerDevelopment { get; set; }
+    ///<summary>
+    ///Whether the shop has a Shopify Plus subscription.
+    ///</summary>
+    public bool? ShopifyPlus { get; set; }
+}

--- a/ShopifySharp/Factories/ShopPlanServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopPlanServiceFactory.cs
@@ -1,0 +1,41 @@
+#nullable enable
+// Notice:
+// This class is auto-generated from a template. Please do not edit it or change it directly.
+
+using ShopifySharp.Credentials;
+using ShopifySharp.Utilities;
+using ShopifySharp.Services;
+
+namespace ShopifySharp.Factories;
+
+public interface IShopPlanServiceFactory
+{
+    /// Creates a new instance of the <see cref="IShopPlanService" /> with the given credentials.
+    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
+    /// <param name="accessToken">An API access token for the shop.</param>
+    IShopPlanService Create(string shopDomain, string accessToken);
+
+    /// Creates a new instance of the <see cref="IShopPlanService" /> with the given credentials.
+    /// <param name="credentials">Credentials for authenticating with the Shopify API.</param>
+    IShopPlanService Create(ShopifyApiCredentials credentials);
+}
+
+public class ShopPlanServiceFactory(IRequestExecutionPolicy? requestExecutionPolicy = null, IShopifyDomainUtility? shopifyDomainUtility = null) : IShopPlanServiceFactory
+{
+    /// <inheritDoc />
+    public virtual IShopPlanService Create(string shopDomain, string accessToken)
+    {
+        IShopPlanService service = shopifyDomainUtility is null ? new ShopPlanService(shopDomain, accessToken) : new ShopPlanService(shopDomain, accessToken, shopifyDomainUtility);
+
+        if (requestExecutionPolicy is not null)
+        {
+            service.SetExecutionPolicy(requestExecutionPolicy);
+        }
+
+        return service;
+    }
+
+    /// <inheritDoc />
+    public virtual IShopPlanService Create(ShopifyApiCredentials credentials) =>
+        Create(credentials.ShopDomain, credentials.AccessToken);
+}

--- a/ShopifySharp/Services/ShopPlan/IShopPlanService.cs
+++ b/ShopifySharp/Services/ShopPlan/IShopPlanService.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ShopifySharp;
+
+public interface IShopPlanService
+{
+    /// Uses Shopify's GraphQL API to get the shop's subscription plan.
+    Task<ShopPlan> GetShopPlanAsync(CancellationToken cancellationToken = default);
+
+    /// Uses Shopify's GraphQL API to check if the shop is a development shop. Returns true if 
+    /// `shop.plan.partnerDevelopment` is true.
+    Task<bool> IsPartnerDevelopmentShopAsync(CancellationToken cancellationToken = default);
+}

--- a/ShopifySharp/Services/ShopPlan/IShopPlanService.cs
+++ b/ShopifySharp/Services/ShopPlan/IShopPlanService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp;
 
-public interface IShopPlanService
+public interface IShopPlanService : IShopifyService
 {
     /// Uses Shopify's GraphQL API to get the shop's subscription plan.
     Task<ShopPlan> GetShopPlanAsync(CancellationToken cancellationToken = default);

--- a/ShopifySharp/Services/ShopPlan/ShopPlanService.cs
+++ b/ShopifySharp/Services/ShopPlan/ShopPlanService.cs
@@ -1,9 +1,11 @@
 using System.Threading.Tasks;
 using System.Threading;
 using ShopifySharp.Utilities;
+using Newtonsoft.Json.Linq;
 
 namespace ShopifySharp.Services;
 
+/// A service for getting the shop's current Shopify subscription plan. This is a convenience wrapper around the Shopify GraphQL API.
 public class ShopPlanService : GraphService, IShopPlanService
 {
     public ShopPlanService(string shopDomain, string accessToken) : base(shopDomain, accessToken)
@@ -31,9 +33,8 @@ public class ShopPlanService : GraphService, IShopPlanService
             }
         """;
         var result = await this.PostAsync(query, 1, cancellationToken);
-        var shop = result.SelectToken("shop");
 
-        return shop.Value<ShopPlan>("plan");
+        return result.SelectToken("shop.plan").ToObject<ShopPlan>();
     }
 
     /// <inheritdoc />

--- a/ShopifySharp/Services/ShopPlan/ShopPlanService.cs
+++ b/ShopifySharp/Services/ShopPlan/ShopPlanService.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using System.Threading;
+using ShopifySharp.Utilities;
+
+namespace ShopifySharp.Services;
+
+public class ShopPlanService : GraphService, IShopPlanService
+{
+    public ShopPlanService(string shopDomain, string accessToken) : base(shopDomain, accessToken)
+    {
+    }
+
+    internal ShopPlanService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) 
+    {
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<ShopPlan> GetShopPlanAsync(CancellationToken cancellationToken = default)
+    {
+        var query = """
+            query {
+                shop {
+                    plan {
+                        ...on ShopPlan {
+                            displayName
+                            partnerDevelopment
+                            shopifyPlus
+                        }
+                    }
+                }
+            }
+        """;
+        var result = await this.PostAsync(query, 1, cancellationToken);
+        var shop = result.SelectToken("shop");
+
+        return shop.Value<ShopPlan>("plan");
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<bool> IsPartnerDevelopmentShopAsync(CancellationToken cancellationToken = default)
+    {
+        var plan = await GetShopPlanAsync(cancellationToken);
+        return plan.PartnerDevelopment == true;
+    }
+}


### PR DESCRIPTION
This PR adds a new ShopPlanService class, which is just a convenience wrapper around the GraphQL API for getting a shop's current Shopify subscription. I mainly use it to check if a shop is on a development/test partner plan.

Note: I've added the new service to the `ShopifySharp.Services` namespace and plan to require all new services be in that namespace. In 7.0, we'll probably migrate all current services from `ShopifySharp` to `ShopifySharp.Services` as well.