### PR TITLE
Exception refactoring

### DIFF
--- a/ShopifySharp.Tests/ShopifyException_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyException_Tests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using ShopifySharp.Filters;
 using ShopifySharp.Infrastructure;
 using ShopifySharp.Lists;
@@ -13,6 +14,7 @@ using Xunit;
 namespace ShopifySharp.Tests
 {
     [Trait("Category", "ShopifyException"), Trait("Category", "DotNetFramework"), Collection("DotNetFramework tests")]
+    [TestSubject(typeof(ShopifyException)), TestSubject(typeof(ShopifyRateLimitException))]
     public class ShopifyException_Tests
     {
         private HttpRequestMessage PrepareRequest(HttpMethod method, string path, HttpContent content = null)
@@ -286,6 +288,8 @@ namespace ShopifySharp.Tests
         [Fact]
         public async Task Catches_Rate_Limit()
         {
+            // TODO: refactor this to use Dependency Injection and fake the rate limit response
+
             int requestCount = 60;
             var service = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
             ShopifyRateLimitException ex = null;
@@ -316,6 +320,8 @@ namespace ShopifySharp.Tests
         [Fact]
         public async Task Catches_Rate_Limit_With_Base_Exception()
         {
+            // TODO: refactor this to use Dependency Injection and fake the rate limit response
+
             int requestCount = 60;
             var service = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
             ShopifyException ex = null;

--- a/ShopifySharp/Infrastructure/ShopifyException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyException.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using ShopifySharp.Infrastructure;
 
 namespace ShopifySharp
 {
@@ -12,22 +14,31 @@ namespace ShopifySharp
         public HttpResponseMessage HttpResponse { get; }
 
         /// The Http response status code.
+        [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
         public HttpStatusCode HttpStatusCode { get; }
 
         /// The XRequestId header returned by Shopify. Can be used when working with the Shopify support team to identify the failed request.
+        [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
         public string RequestId { get; }
 
         /// A list of error messages returned by Shopify.
+        [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
         public IEnumerable<string> Errors { get; } = Enumerable.Empty<string>();
 
         /// The raw string body returned by Shopify.
+        [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
         public string RawBody { get; }
 
         public ShopifyException() { }
 
-        public ShopifyException(string message) : base(message) { }
+        public ShopifyException(string message, Exception? innerException = null) : base(message, innerException) { }
 
-        public ShopifyException(HttpResponseMessage response, HttpStatusCode httpStatusCode, IEnumerable<string> errors, string message, string rawBody, string requestId) : base(message)
+        public ShopifyException(HttpResponseMessage response,
+            HttpStatusCode httpStatusCode,
+            IEnumerable<string> errors,
+            string message,
+            string rawBody,
+            string requestId) : base(message)
         {
             HttpResponse = response;
             HttpStatusCode = httpStatusCode;

--- a/ShopifySharp/Infrastructure/ShopifyException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyException.cs
@@ -14,9 +14,9 @@ namespace ShopifySharp
         [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
         public HttpStatusCode HttpStatusCode { get; }
 
-        /// The XRequestId header returned by Shopify. Can be used when working with the Shopify support team to identify the failed request.
+        /// The X-Request-Id header returned by Shopify. Can be used when working with the Shopify support team to identify the failed request.
         [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
-        public string RequestId { get; }
+        public string? RequestId { get; }
 
         /// A list of error messages returned by Shopify.
         [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
@@ -35,7 +35,8 @@ namespace ShopifySharp
             IEnumerable<string> errors,
             string message,
             string rawBody,
-            string requestId) : base(message)
+            string? requestId
+        ) : base(message)
         {
             HttpStatusCode = httpStatusCode;
             Errors = (errors ?? Enumerable.Empty<string>()).ToArray();

--- a/ShopifySharp/Infrastructure/ShopifyException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyException.cs
@@ -10,9 +10,6 @@ namespace ShopifySharp
 {
     public class ShopifyException : Exception
     {
-        [Obsolete("This property is deprecated and will be removed in a future version of ShopifySharp.")]
-        public HttpResponseMessage HttpResponse { get; }
-
         /// The Http response status code.
         [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
         public HttpStatusCode HttpStatusCode { get; }
@@ -33,14 +30,13 @@ namespace ShopifySharp
 
         public ShopifyException(string message, Exception? innerException = null) : base(message, innerException) { }
 
-        public ShopifyException(HttpResponseMessage response,
+        public ShopifyException(
             HttpStatusCode httpStatusCode,
             IEnumerable<string> errors,
             string message,
             string rawBody,
             string requestId) : base(message)
         {
-            HttpResponse = response;
             HttpStatusCode = httpStatusCode;
             Errors = (errors ?? Enumerable.Empty<string>()).ToArray();
             RawBody = rawBody;

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Net;
+
+namespace ShopifySharp.Infrastructure;
+
+public class ShopifyHttpException(
+    HttpStatusCode statusCode,
+    string requestId,
+    ICollection<string> errors,
+    string rawResponseBody) : ShopifyException
+{
+    /// The Http response status code.
+    public new readonly HttpStatusCode HttpStatusCode = statusCode;
+
+    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
+    public new readonly string RequestId = requestId;
+
+    /// A list of error messages returned by Shopify.
+    public new readonly ICollection<string> Errors = errors;
+
+    /// The raw response body returned by Shopify.
+    public new readonly string RawBody = rawResponseBody;
+}

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -6,19 +6,21 @@ namespace ShopifySharp.Infrastructure;
 
 public class ShopifyHttpException(
     HttpStatusCode statusCode,
-    string requestId,
     ICollection<string> errors,
-    string rawResponseBody) : ShopifyException
+    string message,
+    string rawResponseBody,
+    string? requestId
+) : ShopifyException(statusCode, errors, message, rawResponseBody, requestId)
 {
     /// The Http response status code.
     public new readonly HttpStatusCode HttpStatusCode = statusCode;
-
-    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
-    public new readonly string RequestId = requestId;
 
     /// A list of error messages returned by Shopify.
     public new readonly ICollection<string> Errors = errors;
 
     /// The raw response body returned by Shopify.
     public new readonly string RawBody = rawResponseBody;
+
+    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
+    public new readonly string? RequestId = requestId;
 }

--- a/ShopifySharp/Infrastructure/ShopifyRateLimitException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyRateLimitException.cs
@@ -1,42 +1,21 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
+using ShopifySharp.Infrastructure;
 
-namespace ShopifySharp
+namespace ShopifySharp;
+
+/// An exception thrown when an API call has reached Shopify's rate limit.
+public class ShopifyRateLimitException(
+    ShopifyRateLimitReason reason,
+    int? retryAfterSeconds,
+    HttpStatusCode statusCode,
+    string requestId,
+    ICollection<string> errors,
+    string rawResponseBody)
+    : ShopifyHttpException(statusCode, requestId, errors, rawResponseBody)
 {
-    /// <summary>
-    /// An exception thrown when an API call has reached Shopify's rate limit.
-    /// </summary>
-    public class ShopifyRateLimitException : ShopifyException
-    {
-        public int? RetryAfterSeconds { get; private set; }
+    public readonly int? RetryAfterSeconds = retryAfterSeconds;
 
-        //When a 429 is returned because the bucket is full, Shopify doesn't include the X-Shopify-Shop-Api-Call-Limit header in the response
-        public ShopifyRateLimitReason Reason => HttpResponse.Headers.Contains(RestBucketState.RESPONSE_HEADER_API_CALL_LIMIT) ? ShopifyRateLimitReason.Other : ShopifyRateLimitReason.BucketFull;
-
-        public ShopifyRateLimitException(HttpResponseMessage response, 
-                                         HttpStatusCode httpStatusCode,
-                                         IEnumerable<string> errors,
-                                         string message,
-                                         string jsonError,
-                                         string requestId) 
-            : base(response, httpStatusCode, errors, message, jsonError, requestId)
-        {
-            ExtractRetryAfterSeconds(response);
-        }
-
-        private void ExtractRetryAfterSeconds(HttpResponseMessage response)
-        {
-            string strRetryAfer = response.Headers
-                                        .FirstOrDefault(kvp => kvp.Key == "Retry-After")
-                                        .Value
-                                        ?.FirstOrDefault();
-
-            if (int.TryParse(strRetryAfer, out var retryAfterSeconds))
-            {
-                RetryAfterSeconds = retryAfterSeconds;
-            }
-        }
-    }
+    //When a 429 is returned because the bucket is full, Shopify doesn't include the X-Shopify-Shop-Api-Call-Limit header in the response
+    public readonly ShopifyRateLimitReason Reason = reason;
 }

--- a/ShopifySharp/Infrastructure/ShopifyRateLimitException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyRateLimitException.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Net;
 using ShopifySharp.Infrastructure;
 
@@ -6,13 +7,14 @@ namespace ShopifySharp;
 
 /// An exception thrown when an API call has reached Shopify's rate limit.
 public class ShopifyRateLimitException(
-    ShopifyRateLimitReason reason,
-    int? retryAfterSeconds,
     HttpStatusCode statusCode,
-    string requestId,
     ICollection<string> errors,
-    string rawResponseBody)
-    : ShopifyHttpException(statusCode, requestId, errors, rawResponseBody)
+    string message,
+    string rawResponseBody,
+    string? requestId,
+    ShopifyRateLimitReason reason,
+    int? retryAfterSeconds)
+    : ShopifyHttpException(statusCode, errors, message, rawResponseBody, requestId)
 {
     public readonly int? RetryAfterSeconds = retryAfterSeconds;
 

--- a/ShopifySharp/Lists/LinkHeaderParser.cs
+++ b/ShopifySharp/Lists/LinkHeaderParser.cs
@@ -33,6 +33,7 @@ namespace ShopifySharp.Lists
 
             string matchedUrl = match.Groups[1].Value;
 
+            // TODO: refactor this to use the domain utility?
             if (!Uri.TryCreate(matchedUrl, UriKind.Absolute, out var uri))
             {
                 throw new ShopifyException($"Cannot parse page link url: '{matchedUrl}'");

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -139,7 +139,7 @@ namespace ShopifySharp
                 var requestIdHeader = requestResult.Response.Headers.FirstOrDefault(h => h.Key.Equals("X-Request-Id", StringComparison.OrdinalIgnoreCase));
                 var requestId = requestIdHeader.Value?.FirstOrDefault();
 
-                throw new ShopifyException(requestResult.Response, HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
+                throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
             }
         }
     }

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -137,7 +137,7 @@ namespace ShopifySharp
                 var message = res["errors"].FirstOrDefault()?["message"]?.ToString();
                 var requestId = ParseRequestIdResponseHeader(requestResult.Response.Headers);
 
-                throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
+                throw new ShopifyHttpException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
             }
         }
     }

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -135,9 +135,7 @@ namespace ShopifySharp
                 }
 
                 var message = res["errors"].FirstOrDefault()?["message"]?.ToString();
-
-                var requestIdHeader = requestResult.Response.Headers.FirstOrDefault(h => h.Key.Equals("X-Request-Id", StringComparison.OrdinalIgnoreCase));
-                var requestId = requestIdHeader.Value?.FirstOrDefault();
+                var requestId = ParseRequestIdResponseHeader(requestResult.Response.Headers);
 
                 throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
             }

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -134,7 +134,7 @@ namespace ShopifySharp
                     }
                 }
 
-                var message = res["errors"].FirstOrDefault()?["message"]?.ToString();
+                var message = errorList.FirstOrDefault() ?? "Unable to parse Shopify's error response, please inspect exception's RawBody property and report this issue to the ShopifySharp maintainers.";
                 var requestId = ParseRequestIdResponseHeader(requestResult.Response.Headers);
 
                 throw new ShopifyHttpException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);

--- a/ShopifySharp/Services/Multipass/MultipassService.cs
+++ b/ShopifySharp/Services/Multipass/MultipassService.cs
@@ -42,6 +42,7 @@ namespace ShopifySharp
 
         private static string ValidateShopifyUrl(string shopifyUrl)
         {
+            // TODO: refactor this to use the domain utility
             if (Uri.IsWellFormedUriString(shopifyUrl, UriKind.Absolute) == false)
             {
                 //Shopify typically returns the shop URL without a scheme. If the user is storing that as-is, the uri will not be well formed.

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -72,7 +72,7 @@ namespace ShopifySharp
 
             var message = requestResult.Result["errors"].FirstOrDefault()?["message"]?.ToString();
 
-            throw new ShopifyException(requestResult.Response, HttpStatusCode.OK, errorList, message, requestResult.RawResult, "");
+            throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, "");
         }
     }
 }

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -58,6 +58,7 @@ namespace ShopifySharp
                 return;
             }
 
+            var requestId = ParseRequestIdResponseHeader(requestResult.Response.Headers);
             var errorList = new List<string>();
 
             foreach (var error in requestResult.Result["errors"])
@@ -72,7 +73,7 @@ namespace ShopifySharp
 
             var message = requestResult.Result["errors"].FirstOrDefault()?["message"]?.ToString();
 
-            throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, "");
+            throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
         }
     }
 }

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -71,7 +71,7 @@ namespace ShopifySharp
                 }
             }
 
-            var message = requestResult.Result["errors"].FirstOrDefault()?["message"]?.ToString();
+            var message = errorList.FirstOrDefault() ?? "Unable to parse Shopify's error response, please inspect exception's RawBody property and report this issue to the ShopifySharp maintainers.";
 
             throw new ShopifyHttpException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
         }

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -73,7 +73,7 @@ namespace ShopifySharp
 
             var message = requestResult.Result["errors"].FirstOrDefault()?["message"]?.ToString();
 
-            throw new ShopifyException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
+            throw new ShopifyHttpException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
         }
     }
 }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -388,7 +388,7 @@ namespace ShopifySharp
                 }
                 else
                 {
-                    var baseMessage = "Exceeded the rate limit for api client. Reduce request rates to resume uninterrupted service.";
+                    const string baseMessage = "Exceeded the rate limit for api client. Reduce request rates to resume uninterrupted service.";
                     rateExceptionMessage = $"({statusMessage}) {baseMessage}";
                     errors = new List<string> { baseMessage };
                 }
@@ -407,7 +407,7 @@ namespace ShopifySharp
                     retryAfterSeconds = retryValue;
                 }
 
-                throw new ShopifyRateLimitException(reason, retryAfterSeconds, code, requestId, errors.ToList(), rawResponse);
+                throw new ShopifyRateLimitException(code, errors.ToList(), rateExceptionMessage, rawResponse, requestId, reason, retryAfterSeconds);
             }
 
             var contentType = response.Content.Headers.GetValues("Content-Type").FirstOrDefault();

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -447,7 +447,7 @@ namespace ShopifySharp
                     };
                 }
 
-                throw new ShopifyException(response, code, errors, exceptionMessage, rawResponse, requestId);
+                throw new ShopifyException(code, errors, exceptionMessage, rawResponse, requestId);
             }
 
             var message = $"({statusMessage}) Shopify returned {statusMessage}, but there was no JSON to parse into an error message.";
@@ -456,7 +456,7 @@ namespace ShopifySharp
                 message
             };
 
-            throw new ShopifyException(response, code, customErrors, message, rawResponse, requestId);
+            throw new ShopifyException(code, customErrors, message, rawResponse, requestId);
         }
 
         /// <summary>

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -361,6 +361,8 @@ namespace ShopifySharp
         /// <param name="rawResponse">The response body returned by Shopify.</param>
         public static void CheckResponseExceptions(HttpResponseMessage response, string rawResponse)
         {
+            // TODO: make this method protected virtual so inheriting members can override it (e.g. the PartnerService which is doing its own custom error checking right now)
+
             var statusCode = (int)response.StatusCode;
 
             // No error if response was between 200 and 300.
@@ -410,6 +412,7 @@ namespace ShopifySharp
 
             var contentType = response.Content.Headers.GetValues("Content-Type").FirstOrDefault();
 
+            // TODO: there's probably a better way to check if the content type is json
             if (contentType.StartsWithIgnoreCase("application/json") || contentType.StartsWithIgnoreCase("text/json"))
             {
                 IEnumerable<string> errors;
@@ -461,6 +464,7 @@ namespace ShopifySharp
         /// </summary>
         public static bool TryParseErrorJson(string json, out List<string> output)
         {
+            // TODO: obsolete and replace this with a json error parsing util?
             output = null;
 
             if (string.IsNullOrEmpty(json))

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -441,10 +441,7 @@ namespace ShopifySharp
                 else
                 {
                     exceptionMessage = $"({statusMessage}) Shopify returned {statusMessage}, but ShopifySharp was unable to parse the response JSON.";
-                    errors = new List<string>
-                    {
-                        exceptionMessage
-                    };
+                    errors = [];
                 }
 
                 throw new ShopifyHttpException(code, errors.ToList(), exceptionMessage, rawResponse, requestId);

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -447,7 +447,7 @@ namespace ShopifySharp
                     };
                 }
 
-                throw new ShopifyException(code, errors, exceptionMessage, rawResponse, requestId);
+                throw new ShopifyHttpException(code, errors.ToList(), exceptionMessage, rawResponse, requestId);
             }
 
             var message = $"({statusMessage}) Shopify returned {statusMessage}, but there was no JSON to parse into an error message.";
@@ -456,7 +456,7 @@ namespace ShopifySharp
                 message
             };
 
-            throw new ShopifyException(code, customErrors, message, rawResponse, requestId);
+            throw new ShopifyHttpException(code, customErrors, message, rawResponse, requestId);
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request does a light bit of refactoring on ShopifySharp's exceptions:

- Introduces a new exception type named `ShopifyHttpException`, which inherits from the base `ShopifyException`. This new exception should be thrown whenever an http request fails or returns an error.
- Made the `ShopifyRateLimitException` inherit from the `ShopifyHttpException`.
- Deprecates most HTTP properties on the base `ShopifyException`:
  - `HttpStatusCode`
  - `RequestId`
  - `Errors`
  - `RawBody`
- **Removes** the deprecated `ShopifyException.HttpResponse` property.
- Refactors the base `ShopifyService`, `GraphService` and `PartnerService` classes to throw a `ShopifyHttpException` where applicable.
- Removes a custom error message that was injected into the `ShopifyException.Errors` string list in some cases. This error message was an exact duplicate of the exception's message.