### PR TITLE
Fix #1001 CloneableRequestMessage fails to clone content and throws ObjectDisposed exception

### DIFF
--- a/ShopifySharp.Tests/Infrastructure/CloneableRequestMessageTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/CloneableRequestMessageTests.cs
@@ -1,0 +1,349 @@
+#nullable enable
+using System;
+using System.Text;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Infrastructure;
+using Xunit;
+
+namespace ShopifySharp.Tests.Infrastructure;
+
+[Trait("Category", "DotNetFramework")]
+[Trait("Category", nameof(CloneableRequestMessage))]
+[TestSubject(typeof(CloneableRequestMessage))]
+public class CloneableRequestMessageTests
+{
+    private static readonly Uri Host = new("https://fake-url.com/admin/api.json");
+    private static readonly HttpMethod Method = HttpMethod.Post;
+
+    [Fact]
+    public void Clone_ShouldCloneWithNoHttpContent_AndPreserveHeaders()
+    {
+        // Setup
+        var cloneableRequest = new CloneableRequestMessage(Host, Method);
+        cloneableRequest.Headers.Add("some-key", "some-value");
+
+        // Act
+        var clonedRequest = cloneableRequest.Clone();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().BeNull();
+        clonedRequest.Headers.Should().ContainKey("some-key")
+            .WhoseValue.Should().Contain("some-value");
+    }
+
+    [Fact]
+    public void Clone_ShouldCloneJsonContent_AndPreserveHeaders()
+    {
+        // Setup
+        var jsonContent = new JsonContent(new { Foo = "bar" })
+        {
+            Headers = { {"some-key-1", "some-value-1"} }
+        };
+        var cloneableRequest = new CloneableRequestMessage(Host, Method, jsonContent);
+        cloneableRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var clonedRequest = cloneableRequest.Clone();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().NotBeNull();
+        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+            .WhoseValue.Should().BeEquivalentTo(["application/json"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Headers.Should().ContainKey("some-key-2")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+    }
+
+    [Fact]
+    public void Clone_ShouldCloneMultipleTimesWithoutDisposalExceptions()
+    {
+        // Setup
+        var jsonContent = new JsonContent(new { Foo = "bar" })
+        {
+            Headers = { {"some-key-1", "some-value-1"} }
+        };
+        var baseRequest = new CloneableRequestMessage(Host, Method, jsonContent);
+
+        var act = () =>
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                var clonedRequest = baseRequest.Clone();
+
+                clonedRequest.Should().NotBeNull();
+                clonedRequest.RequestUri.Should().Be(Host);
+                clonedRequest.Method.Should().Be(Method);
+                clonedRequest.Content.Should().NotBeNull();
+                clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+                    .WhoseValue.Should().BeEquivalentTo(["application/json"]);
+            }
+        };
+
+        act.Should().NotThrow();
+    }
+
+    #region CloneAsync
+
+    [Fact]
+    public async Task CloneAsync_ShouldCloneJsonContent_AndPreserveHeaders()
+    {
+        // Setup
+        var jsonContent = new JsonContent(new { Foo = "bar" })
+        {
+            Headers = { {"some-key-1", "some-value-1"} }
+        };
+        var cloneableRequest = new CloneableRequestMessage(Host, Method, jsonContent);
+        cloneableRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var clonedRequest = await cloneableRequest.CloneAsync();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().NotBeNull();
+        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+            .WhoseValue.Should().BeEquivalentTo(["application/json"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Headers.Should().ContainKey("some-key-2")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+    }
+
+    [Fact]
+    public async Task CloneAsync_ShouldCloneStringContent_AndPreserveHeaders()
+    {
+        // Setup
+        var stringContent = new StringContent("some-string-content", System.Text.Encoding.UTF8, MediaTypeHeaderValue.Parse("fake/string"))
+        {
+            Headers = { {"some-key-1", "some-value-1"} }
+        };
+        var cloneableRequest = new CloneableRequestMessage(Host, Method, stringContent);
+        cloneableRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var clonedRequest = await cloneableRequest.CloneAsync();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().NotBeNull();
+        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+            .WhoseValue.Should().BeEquivalentTo(["fake/string"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Headers.Should().ContainKey("some-key-2")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+    }
+
+    [Fact]
+    public async Task CloneAsync_ShouldCloneByteArrayContent_AndPreserveHeaders()
+    {
+        // Setup
+        var str = "some-string-content";
+        var bytes = Encoding.UTF8.GetBytes(str);
+        var byteContent = new ByteArrayContent(bytes)
+        {
+            Headers = 
+            { 
+                {"some-key-1", "some-value-1"}, 
+                { "Content-Type", "fake/bytes" } 
+            }
+        };
+        var cloneableRequest = new CloneableRequestMessage(Host, Method, byteContent);
+        cloneableRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var clonedRequest = await cloneableRequest.CloneAsync();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().NotBeNull();
+        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+            .WhoseValue.Should().BeEquivalentTo(["fake/bytes"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Headers.Should().ContainKey("some-key-2")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+    }
+
+    [Fact]
+    public async Task CloneAsync_ShouldCloneStreamContent_AndPreserveHeaders()
+    {
+        // Setup
+        var bytes = Encoding.UTF8.GetBytes("some-stream-content");
+        var ms = new MemoryStream(bytes);
+        var streamContent = new StreamContent(ms)
+        {
+            Headers = 
+            {
+                {"some-key-1", "some-value-1"}, 
+                { "Content-Type", "fake/stream" }
+            }
+        };
+        var baseRequest = new CloneableRequestMessage(Host, Method, streamContent);
+        baseRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var clonedRequest = await baseRequest.CloneAsync();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().NotBeNull();
+        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+            .WhoseValue.Should().BeEquivalentTo(["fake/stream"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Headers.Should().ContainKey("some-key-2")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+    }
+
+    #if NET6_0_OR_GREATER
+    [Fact]
+    public async Task CloneAsync_ShouldCloneReadOnlyMemoryContent_AndPreserveHeaders()
+    {
+        // Setup
+        var bytes = Encoding.UTF8.GetBytes("some-stream-content");
+        var readOnlyMemory = new ReadOnlyMemory<byte>(bytes);
+        var memoryContent = new ReadOnlyMemoryContent(readOnlyMemory)
+        {
+            Headers = 
+            {
+                {"some-key-1", "some-value-1"}, 
+                { "Content-Type", "fake/memory" }
+            }
+        };
+        var baseRequest = new CloneableRequestMessage(Host, Method, memoryContent);
+        baseRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var clonedRequest = await baseRequest.CloneAsync();
+
+        // Assert
+        clonedRequest.Should().NotBeNull();
+        clonedRequest.RequestUri.Should().Be(Host);
+        clonedRequest.Method.Should().Be(Method);
+        clonedRequest.Content.Should().NotBeNull();
+        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+            .WhoseValue.Should().BeEquivalentTo(["fake/memory"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+        clonedRequest.Headers.Should().ContainKey("some-key-2")
+            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+    }
+    #endif
+
+    [Fact]
+    public async Task CloneAsync_ShouldCloneMultipleTimesWithoutDisposalExceptions()
+    {
+        // Setup
+        var bytes = Encoding.UTF8.GetBytes("some-stream-content");
+        var ms = new MemoryStream(bytes);
+        var streamContent = new StreamContent(ms)
+        {
+            Headers = 
+            {
+                {"some-key-1", "some-value-1"}, 
+                { "Content-Type", "fake/stream" }
+            }
+        };
+        var baseRequest = new CloneableRequestMessage(Host, Method, streamContent);
+        baseRequest.Headers.Add("some-key-2", "some-value-2");
+
+        // Act
+        var act = async () =>
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                var clonedRequest = await baseRequest.CloneAsync();
+
+                // Assert
+                clonedRequest.Should().NotBeNull();
+                clonedRequest.RequestUri.Should().Be(Host);
+                clonedRequest.Method.Should().Be(Method);
+                clonedRequest.Content.Should().NotBeNull();
+                clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
+                    .WhoseValue.Should().BeEquivalentTo(["fake/stream"]);
+                clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+                    .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+                clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
+                    .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
+                clonedRequest.Headers.Should().ContainKey("some-key-2")
+                    .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
+            }
+        };
+
+        await act.Should().NotThrowAsync();
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task Dispose_ShouldDisposeAfterBeingCloned()
+    {
+        // Essentially this should test that there's never a whole bunch of cloneable requests awaiting disposal,
+        // it should only be the previous request and the current request.
+
+        // Setup
+        var stringContent = new StringContent("some-string-content");
+        var baseRequest = new TestCloneableRequestMessage(Host, Method, stringContent);
+
+        // Act
+        var act = async () => 
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                var clonedRequest = await baseRequest.CloneAsync();
+                clonedRequest.Dispose();
+            }
+        };
+
+        await act.Should().NotThrowAsync();
+        baseRequest.Disposed.Should().BeFalse();
+    }
+
+    class TestCloneableRequestMessage : CloneableRequestMessage
+    {
+        public TestCloneableRequestMessage(Uri url, HttpMethod method, HttpContent? content = null) : base(url, method, content)
+        {
+        }
+
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/ShopifySharp.Tests/Services/ShopPlanServiceTests.cs
+++ b/ShopifySharp.Tests/Services/ShopPlanServiceTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using JetBrains.Annotations;
-using ShopifySharp.Services;
 using Xunit;
 
 namespace ShopifySharp.Tests.Services;

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -31,7 +31,7 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Wish.GraphQLSchemaGenerator" Version="1.5.3" />
+    <PackageReference Include="Wish.GraphQLSchemaGenerator" Version="1.5.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="WebhookPayloads\cart_updated_payload.json">

--- a/ShopifySharp/Entities/GraphQL/GraphQLSchema.generated.cs
+++ b/ShopifySharp/Entities/GraphQL/GraphQLSchema.generated.cs
@@ -99,10 +99,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public string? id { get; set; }
         ///<summary>
-        ///A list of the line items in this checkout.
-        ///</summary>
-        public AbandonedCheckoutLineItemConnection? lineItems { get; set; }
-        ///<summary>
         ///The number of products in the checkout.
         ///</summary>
         public int? lineItemsQuantity { get; set; }
@@ -110,111 +106,6 @@ namespace ShopifySharp.GraphQL
         ///The sum of all items in the checkout, including discounts, shipping, taxes, and tips.
         ///</summary>
         public MoneyBag? totalPriceSet { get; set; }
-    }
-
-    ///<summary>
-    ///A single line item in an abandoned checkout.
-    ///</summary>
-    public class AbandonedCheckoutLineItem : GraphQLObject<AbandonedCheckoutLineItem>, INode
-    {
-        ///<summary>
-        ///A list of extra information that has been added to the line item.
-        ///</summary>
-        public IEnumerable<Attribute>? customAttributes { get; set; }
-        ///<summary>
-        ///Final total price for the entire quantity of this line item, including discounts.
-        ///</summary>
-        public MoneyBag? discountedTotalPriceSet { get; set; }
-        ///<summary>
-        ///The total price for the entire quantity of this line item, after all discounts are applied, at both the line item and code-based line item level.
-        ///</summary>
-        public MoneyBag? discountedTotalPriceWithCodeDiscount { get; set; }
-        ///<summary>
-        ///The price of a single variant unit after discounts are applied at the line item level, in shop and presentment currencies.
-        ///</summary>
-        public MoneyBag? discountedUnitPriceSet { get; set; }
-        ///<summary>
-        ///The price of a single variant unit after all discounts are applied, at both the line item and code-based line item level.
-        ///</summary>
-        public MoneyBag? discountedUnitPriceWithCodeDiscount { get; set; }
-        ///<summary>
-        ///A globally-unique ID.
-        ///</summary>
-        public string? id { get; set; }
-        ///<summary>
-        ///The image associated with the line item's variant or product.
-        ///NULL if the line item has no product, or if neither the variant nor the product have an image.
-        ///</summary>
-        public Image? image { get; set; }
-        ///<summary>
-        ///Original total price for the entire quantity of this line item, before discounts.
-        ///</summary>
-        public MoneyBag? originalTotalPriceSet { get; set; }
-        ///<summary>
-        ///Original price for a single unit of this line item, before discounts.
-        ///</summary>
-        public MoneyBag? originalUnitPriceSet { get; set; }
-        ///<summary>
-        ///Product for this line item.
-        ///NULL for custom line items and products that were deleted after checkout began.
-        ///</summary>
-        public Product? product { get; set; }
-        ///<summary>
-        ///The quantity of the line item.
-        ///</summary>
-        public int? quantity { get; set; }
-        ///<summary>
-        ///SKU for the inventory item associated with the variant, if any.
-        ///</summary>
-        public string? sku { get; set; }
-        ///<summary>
-        ///Title of the line item. Defaults to the product's title.
-        ///</summary>
-        public string? title { get; set; }
-        ///<summary>
-        ///Product variant for this line item.
-        ///NULL for custom line items and variants that were deleted after checkout began.
-        ///</summary>
-        public ProductVariant? variant { get; set; }
-        ///<summary>
-        ///Title of the variant for this line item.
-        ///NULL for custom line items and products that don't have distinct variants.
-        ///</summary>
-        public string? variantTitle { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type for paginating through multiple AbandonedCheckoutLineItems.
-    ///</summary>
-    public class AbandonedCheckoutLineItemConnection : GraphQLObject<AbandonedCheckoutLineItemConnection>, IConnectionWithNodesAndEdges<AbandonedCheckoutLineItemEdge, AbandonedCheckoutLineItem>
-    {
-        ///<summary>
-        ///A list of edges.
-        ///</summary>
-        public IEnumerable<AbandonedCheckoutLineItemEdge>? edges { get; set; }
-        ///<summary>
-        ///A list of the nodes contained in AbandonedCheckoutLineItemEdge.
-        ///</summary>
-        public IEnumerable<AbandonedCheckoutLineItem>? nodes { get; set; }
-        ///<summary>
-        ///Information to aid in pagination.
-        ///</summary>
-        public PageInfo? pageInfo { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type which holds one AbandonedCheckoutLineItem and a cursor during pagination.
-    ///</summary>
-    public class AbandonedCheckoutLineItemEdge : GraphQLObject<AbandonedCheckoutLineItemEdge>, IEdge<AbandonedCheckoutLineItem>
-    {
-        ///<summary>
-        ///A cursor for use in pagination.
-        ///</summary>
-        public string? cursor { get; set; }
-        ///<summary>
-        ///The item at the end of AbandonedCheckoutLineItemEdge.
-        ///</summary>
-        public AbandonedCheckoutLineItem? node { get; set; }
     }
 
     ///<summary>
@@ -246,10 +137,6 @@ namespace ShopifySharp.GraphQL
         ///The customer who abandoned this event.
         ///</summary>
         public Customer? customer { get; set; }
-        ///<summary>
-        ///Whether the customer has a draft order since this abandonment has been abandoned.
-        ///</summary>
-        public bool? customerHasNoDraftOrderSinceAbandonment { get; set; }
         ///<summary>
         ///Whether the customer has completed an order since this checkout has been abandoned.
         ///</summary>
@@ -1490,6 +1377,100 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
+    ///Return type for `appRevenueAttributionRecordCreate` mutation.
+    ///</summary>
+    public class AppRevenueAttributionRecordCreatePayload : GraphQLObject<AppRevenueAttributionRecordCreatePayload>
+    {
+        ///<summary>
+        ///The created app revenue attribution record.
+        ///</summary>
+        public AppRevenueAttributionRecord? appRevenueAttributionRecord { get; set; }
+        ///<summary>
+        ///The list of errors that occurred from executing the mutation.
+        ///</summary>
+        public IEnumerable<AppRevenueAttributionRecordCreateUserError>? userErrors { get; set; }
+    }
+
+    ///<summary>
+    ///An error that occurs during the execution of `AppRevenueAttributionRecordCreate`.
+    ///</summary>
+    public class AppRevenueAttributionRecordCreateUserError : GraphQLObject<AppRevenueAttributionRecordCreateUserError>, IDisplayableError
+    {
+        ///<summary>
+        ///The error code.
+        ///</summary>
+        public AppRevenueAttributionRecordCreateUserErrorCode? code { get; set; }
+        ///<summary>
+        ///The path to the input field that caused the error.
+        ///</summary>
+        public IEnumerable<string>? field { get; set; }
+        ///<summary>
+        ///The error message.
+        ///</summary>
+        public string? message { get; set; }
+    }
+
+    ///<summary>
+    ///Possible error codes that can be returned by `AppRevenueAttributionRecordCreateUserError`.
+    ///</summary>
+    public enum AppRevenueAttributionRecordCreateUserErrorCode
+    {
+        ///<summary>
+        ///The input value is invalid.
+        ///</summary>
+        INVALID,
+        ///<summary>
+        ///The input value is already taken.
+        ///</summary>
+        TAKEN,
+    }
+
+    ///<summary>
+    ///Return type for `appRevenueAttributionRecordDelete` mutation.
+    ///</summary>
+    public class AppRevenueAttributionRecordDeletePayload : GraphQLObject<AppRevenueAttributionRecordDeletePayload>
+    {
+        ///<summary>
+        ///The ID of the revenue attribution that was deleted, if one was.
+        ///</summary>
+        public string? deletedId { get; set; }
+        ///<summary>
+        ///The list of errors that occurred from executing the mutation.
+        ///</summary>
+        public IEnumerable<AppRevenueAttributionRecordDeleteUserError>? userErrors { get; set; }
+    }
+
+    ///<summary>
+    ///An error that occurs during the execution of `AppRevenueAttributionRecordDelete`.
+    ///</summary>
+    public class AppRevenueAttributionRecordDeleteUserError : GraphQLObject<AppRevenueAttributionRecordDeleteUserError>, IDisplayableError
+    {
+        ///<summary>
+        ///The error code.
+        ///</summary>
+        public AppRevenueAttributionRecordDeleteUserErrorCode? code { get; set; }
+        ///<summary>
+        ///The path to the input field that caused the error.
+        ///</summary>
+        public IEnumerable<string>? field { get; set; }
+        ///<summary>
+        ///The error message.
+        ///</summary>
+        public string? message { get; set; }
+    }
+
+    ///<summary>
+    ///Possible error codes that can be returned by `AppRevenueAttributionRecordDeleteUserError`.
+    ///</summary>
+    public enum AppRevenueAttributionRecordDeleteUserErrorCode
+    {
+        ///<summary>
+        ///The input value is invalid.
+        ///</summary>
+        INVALID,
+    }
+
+    ///<summary>
     ///An auto-generated type which holds one AppRevenueAttributionRecord and a cursor during pagination.
     ///</summary>
     public class AppRevenueAttributionRecordEdge : GraphQLObject<AppRevenueAttributionRecordEdge>, IEdge<AppRevenueAttributionRecord>
@@ -2144,74 +2125,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///The set of valid sort keys for the BalanceTransaction query.
-    ///</summary>
-    public enum BalanceTransactionSortKeys
-    {
-        ///<summary>
-        ///Sort by the `payout_date` value.
-        ///</summary>
-        PAYOUT_DATE,
-        ///<summary>
-        ///Sort by the `payout_status` value.
-        ///</summary>
-        PAYOUT_STATUS,
-        ///<summary>
-        ///Sort by the `processed_at` value.
-        ///</summary>
-        PROCESSED_AT,
-        ///<summary>
-        ///Sort by the `amount` value.
-        ///</summary>
-        AMOUNT,
-        ///<summary>
-        ///Sort by the `fee` value.
-        ///</summary>
-        FEE,
-        ///<summary>
-        ///Sort by the `net` value.
-        ///</summary>
-        NET,
-        ///<summary>
-        ///Sort by the `transaction_type` value.
-        ///</summary>
-        TRANSACTION_TYPE,
-        ///<summary>
-        ///Sort by the `order_name` value.
-        ///</summary>
-        ORDER_NAME,
-        ///<summary>
-        ///Sort by the `payment_method_name` value.
-        ///</summary>
-        PAYMENT_METHOD_NAME,
-        ///<summary>
-        ///Sort by the `id` value.
-        ///</summary>
-        ID,
-        ///<summary>
-        ///Sort by relevance to the search terms when the `query` parameter is specified on the connection.
-        ///Don't use this sort key when no search query is specified.
-        ///</summary>
-        RELEVANCE,
-    }
-
-    ///<summary>
-    ///Generic payment details that are related to a transaction.
-    ///</summary>
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
-    [JsonDerivedType(typeof(CardPaymentDetails), typeDiscriminator: "CardPaymentDetails")]
-    [JsonDerivedType(typeof(ShopPayInstallmentsPaymentDetails), typeDiscriminator: "ShopPayInstallmentsPaymentDetails")]
-    public interface IBasePaymentDetails : IGraphQLObject
-    {
-        public CardPaymentDetails? AsCardPaymentDetails() => this as CardPaymentDetails;
-        public ShopPayInstallmentsPaymentDetails? AsShopPayInstallmentsPaymentDetails() => this as ShopPayInstallmentsPaymentDetails;
-        ///<summary>
-        ///The name of payment method used by the buyer.
-        ///</summary>
-        public string? paymentMethodName { get; }
-    }
-
-    ///<summary>
     ///Basic events chronicle resource activities such as the creation of an article, the fulfillment of an order, or
     ///the addition of a product.
     ///</summary>
@@ -2303,14 +2216,6 @@ namespace ShopifySharp.GraphQL
         ///Origin time needs to be within the selected billing cycle's start and end at date.
         ///</summary>
         ORIGIN_TIME_OUT_OF_RANGE,
-        ///<summary>
-        ///Subscription contract is under review.
-        ///</summary>
-        CONTRACT_UNDER_REVIEW,
-        ///<summary>
-        ///Subscription contract cannot be billed once terminated.
-        ///</summary>
-        CONTRACT_TERMINATED,
     }
 
     ///<summary>
@@ -3398,7 +3303,7 @@ namespace ShopifySharp.GraphQL
     ///<summary>
     ///Card payment details related to a transaction.
     ///</summary>
-    public class CardPaymentDetails : GraphQLObject<CardPaymentDetails>, IBasePaymentDetails, IPaymentDetails
+    public class CardPaymentDetails : GraphQLObject<CardPaymentDetails>, IPaymentDetails
     {
         ///<summary>
         ///The response code from the address verification system (AVS). The code is always a single letter.
@@ -3433,10 +3338,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public string? number { get; set; }
         ///<summary>
-        ///The name of payment method used by the buyer.
-        ///</summary>
-        public string? paymentMethodName { get; set; }
-        ///<summary>
         ///Digital wallet used for the payment.
         ///</summary>
         public DigitalWallet? wallet { get; set; }
@@ -3447,10 +3348,6 @@ namespace ShopifySharp.GraphQL
     ///</summary>
     public class CartTransform : GraphQLObject<CartTransform>, IHasMetafields, INode
     {
-        ///<summary>
-        ///Whether a run failure will block cart and checkout operations.
-        ///</summary>
-        public bool? blockOnFailure { get; set; }
         ///<summary>
         ///The ID for the Cart Transform function.
         ///</summary>
@@ -3619,36 +3516,6 @@ namespace ShopifySharp.GraphQL
         ///The item at the end of CartTransformEdge.
         ///</summary>
         public CartTransform? node { get; set; }
-    }
-
-    ///<summary>
-    ///Represents the cart transform feature configuration for the shop.
-    ///</summary>
-    public class CartTransformEligibleOperations : GraphQLObject<CartTransformEligibleOperations>
-    {
-        ///<summary>
-        ///The shop is eligible for expand operations.
-        ///</summary>
-        public bool? expandOperation { get; set; }
-        ///<summary>
-        ///The shop is eligible for merge operations.
-        ///</summary>
-        public bool? mergeOperation { get; set; }
-        ///<summary>
-        ///The shop is eligible for update operations.
-        ///</summary>
-        public bool? updateOperation { get; set; }
-    }
-
-    ///<summary>
-    ///Represents the cart transform feature configuration for the shop.
-    ///</summary>
-    public class CartTransformFeature : GraphQLObject<CartTransformFeature>
-    {
-        ///<summary>
-        ///The cart transform operations eligible for the shop.
-        ///</summary>
-        public CartTransformEligibleOperations? eligibleOperations { get; set; }
     }
 
     ///<summary>
@@ -3910,10 +3777,6 @@ namespace ShopifySharp.GraphQL
         ///Quantity rules can be associated only with company location catalogs.
         ///</summary>
         CATALOG_CONTEXT_DOES_NOT_SUPPORT_QUANTITY_RULES,
-        ///<summary>
-        ///Quantity price breaks can be associated only with company location catalogs.
-        ///</summary>
-        CATALOG_CONTEXT_DOES_NOT_SUPPORT_QUANTITY_PRICE_BREAKS,
         ///<summary>
         ///The catalog can't be associated with more than one market.
         ///</summary>
@@ -4191,1158 +4054,6 @@ namespace ShopifySharp.GraphQL
         ///A globally-unique ID.
         ///</summary>
         public string? id { get; set; }
-    }
-
-    ///<summary>
-    ///The settings of checkout visual customizations.
-    ///
-    ///To learn more about updating checkout branding settings, refer to the
-    ///[checkoutBrandingUpsert](https://shopify.dev/api/admin-graphql/unstable/mutations/checkoutBrandingUpsert) mutation.
-    ///</summary>
-    public class CheckoutBranding : GraphQLObject<CheckoutBranding>
-    {
-        ///<summary>
-        ///The customizations that apply to specific components or areas of the user interface.
-        ///</summary>
-        public CheckoutBrandingCustomizations? customizations { get; set; }
-        ///<summary>
-        ///The design system allows you to set values that represent specific attributes
-        ///of your brand like color and font. These attributes are used throughout the user
-        ///interface. This brings consistency and allows you to easily make broad design changes.
-        ///</summary>
-        public CheckoutBrandingDesignSystem? designSystem { get; set; }
-    }
-
-    ///<summary>
-    ///Possible values for the background style.
-    ///</summary>
-    public enum CheckoutBrandingBackgroundStyle
-    {
-        ///<summary>
-        ///The Solid background style.
-        ///</summary>
-        SOLID,
-        ///<summary>
-        ///The None background style.
-        ///</summary>
-        NONE,
-    }
-
-    ///<summary>
-    ///Possible values for the border.
-    ///</summary>
-    public enum CheckoutBrandingBorder
-    {
-        ///<summary>
-        ///The None border.
-        ///</summary>
-        NONE,
-        ///<summary>
-        ///The Block End border.
-        ///</summary>
-        BLOCK_END,
-        ///<summary>
-        ///The Full border.
-        ///</summary>
-        FULL,
-    }
-
-    ///<summary>
-    ///The buttons customizations.
-    ///</summary>
-    public class CheckoutBrandingButton : GraphQLObject<CheckoutBrandingButton>
-    {
-        ///<summary>
-        ///The background style used for buttons.
-        ///</summary>
-        public CheckoutBrandingBackgroundStyle? background { get; set; }
-        ///<summary>
-        ///The block padding used for buttons.
-        ///</summary>
-        public CheckoutBrandingSpacing? blockPadding { get; set; }
-        ///<summary>
-        ///The border used for buttons.
-        ///</summary>
-        public CheckoutBrandingSimpleBorder? border { get; set; }
-        ///<summary>
-        ///The corner radius used for buttons.
-        ///</summary>
-        public CheckoutBrandingCornerRadius? cornerRadius { get; set; }
-        ///<summary>
-        ///The inline padding used for buttons.
-        ///</summary>
-        public CheckoutBrandingSpacing? inlinePadding { get; set; }
-        ///<summary>
-        ///The typography used for buttons.
-        ///</summary>
-        public CheckoutBrandingTypographyStyle? typography { get; set; }
-    }
-
-    ///<summary>
-    ///Colors for buttons.
-    ///</summary>
-    public class CheckoutBrandingButtonColorRoles : GraphQLObject<CheckoutBrandingButtonColorRoles>
-    {
-        ///<summary>
-        ///The color of accented objects (links and focused state).
-        ///</summary>
-        public string? accent { get; set; }
-        ///<summary>
-        ///The color of the background.
-        ///</summary>
-        public string? background { get; set; }
-        ///<summary>
-        ///The color of borders.
-        ///</summary>
-        public string? border { get; set; }
-        ///<summary>
-        ///The decorative color for highlighting specific parts of the user interface.
-        ///</summary>
-        public string? decorative { get; set; }
-        ///<summary>
-        ///The colors of the button on hover.
-        ///</summary>
-        public CheckoutBrandingColorRoles? hover { get; set; }
-        ///<summary>
-        ///The color of icons.
-        ///</summary>
-        public string? icon { get; set; }
-        ///<summary>
-        ///The color of text.
-        ///</summary>
-        public string? text { get; set; }
-    }
-
-    ///<summary>
-    ///The checkboxes customizations.
-    ///</summary>
-    public class CheckoutBrandingCheckbox : GraphQLObject<CheckoutBrandingCheckbox>
-    {
-        ///<summary>
-        ///The corner radius used for checkboxes.
-        ///</summary>
-        public CheckoutBrandingCornerRadius? cornerRadius { get; set; }
-    }
-
-    ///<summary>
-    ///The choice list customizations.
-    ///</summary>
-    public class CheckoutBrandingChoiceList : GraphQLObject<CheckoutBrandingChoiceList>
-    {
-        ///<summary>
-        ///The settings that apply to the 'group' variant of ChoiceList.
-        ///</summary>
-        public CheckoutBrandingChoiceListGroup? group { get; set; }
-    }
-
-    ///<summary>
-    ///The settings that apply to the 'group' variant of ChoiceList.
-    ///</summary>
-    public class CheckoutBrandingChoiceListGroup : GraphQLObject<CheckoutBrandingChoiceListGroup>
-    {
-        ///<summary>
-        ///The spacing between UI elements in the list.
-        ///</summary>
-        public CheckoutBrandingSpacingKeyword? spacing { get; set; }
-    }
-
-    ///<summary>
-    ///A set of colors for customizing the overall look and feel of the checkout.
-    ///</summary>
-    public class CheckoutBrandingColorGlobal : GraphQLObject<CheckoutBrandingColorGlobal>
-    {
-        ///<summary>
-        ///A color used for interaction, like links and focus states.
-        ///</summary>
-        public string? accent { get; set; }
-        ///<summary>
-        ///A color strongly associated with the merchant, currently used for elements
-        ///like primary and secondary buttons.
-        ///</summary>
-        public string? brand { get; set; }
-        ///<summary>
-        ///A semantic color used for components that communicate critical content.
-        ///</summary>
-        public string? critical { get; set; }
-        ///<summary>
-        ///A color used to highlight certain areas of the user interface.
-        ///</summary>
-        public string? decorative { get; set; }
-        ///<summary>
-        ///A semantic color used for components that communicate informative content.
-        ///</summary>
-        public string? info { get; set; }
-        ///<summary>
-        ///A semantic color used for components that communicate successful actions.
-        ///</summary>
-        public string? success { get; set; }
-        ///<summary>
-        ///A semantic color used for components that display content that requires attention.
-        ///</summary>
-        public string? warning { get; set; }
-    }
-
-    ///<summary>
-    ///A group of colors used together on a surface.
-    ///</summary>
-    public class CheckoutBrandingColorRoles : GraphQLObject<CheckoutBrandingColorRoles>
-    {
-        ///<summary>
-        ///The color of accented objects (links and focused state).
-        ///</summary>
-        public string? accent { get; set; }
-        ///<summary>
-        ///The color of the background.
-        ///</summary>
-        public string? background { get; set; }
-        ///<summary>
-        ///The color of borders.
-        ///</summary>
-        public string? border { get; set; }
-        ///<summary>
-        ///The decorative color for highlighting specific parts of the user interface.
-        ///</summary>
-        public string? decorative { get; set; }
-        ///<summary>
-        ///The color of icons.
-        ///</summary>
-        public string? icon { get; set; }
-        ///<summary>
-        ///The color of text.
-        ///</summary>
-        public string? text { get; set; }
-    }
-
-    ///<summary>
-    ///A base set of color customizations that is applied to an area of Checkout, from which every component
-    ///pulls its colors from.
-    ///</summary>
-    public class CheckoutBrandingColorScheme : GraphQLObject<CheckoutBrandingColorScheme>
-    {
-        ///<summary>
-        ///The main colors of a scheme.
-        ///</summary>
-        public CheckoutBrandingColorRoles? @base { get; set; }
-        ///<summary>
-        ///The colors of form controls.
-        ///</summary>
-        public CheckoutBrandingControlColorRoles? control { get; set; }
-        ///<summary>
-        ///The colors of the primary button.
-        ///</summary>
-        public CheckoutBrandingButtonColorRoles? primaryButton { get; set; }
-        ///<summary>
-        ///The colors of the secondary button.
-        ///</summary>
-        public CheckoutBrandingButtonColorRoles? secondaryButton { get; set; }
-    }
-
-    ///<summary>
-    ///The possible color schemes.
-    ///</summary>
-    public enum CheckoutBrandingColorSchemeSelection
-    {
-        ///<summary>
-        ///Transparent color scheme selection.
-        ///</summary>
-        TRANSPARENT,
-        ///<summary>
-        ///Color Scheme1 color scheme selection.
-        ///</summary>
-        COLOR_SCHEME1,
-        ///<summary>
-        ///Color Scheme2 color scheme selection.
-        ///</summary>
-        COLOR_SCHEME2,
-    }
-
-    ///<summary>
-    ///The color schemes.
-    ///</summary>
-    public class CheckoutBrandingColorSchemes : GraphQLObject<CheckoutBrandingColorSchemes>
-    {
-        ///<summary>
-        ///The primary scheme. By default, it’s used for the main area of the interface.
-        ///</summary>
-        public CheckoutBrandingColorScheme? scheme1 { get; set; }
-        ///<summary>
-        ///The secondary scheme. By default, it’s used for secondary areas, like Checkout’s Order Summary.
-        ///</summary>
-        public CheckoutBrandingColorScheme? scheme2 { get; set; }
-    }
-
-    ///<summary>
-    ///The possible colors.
-    ///</summary>
-    public enum CheckoutBrandingColorSelection
-    {
-        ///<summary>
-        ///Transparent color selection.
-        ///</summary>
-        TRANSPARENT,
-    }
-
-    ///<summary>
-    ///The color settings for global colors and color schemes.
-    ///</summary>
-    public class CheckoutBrandingColors : GraphQLObject<CheckoutBrandingColors>
-    {
-        ///<summary>
-        ///A group of global colors for customizing the overall look and feel of the user interface.
-        ///</summary>
-        public CheckoutBrandingColorGlobal? global { get; set; }
-        ///<summary>
-        ///A set of color schemes which apply to different areas of the user interface.
-        ///</summary>
-        public CheckoutBrandingColorSchemes? schemes { get; set; }
-    }
-
-    ///<summary>
-    ///The form controls customizations.
-    ///</summary>
-    public class CheckoutBrandingControl : GraphQLObject<CheckoutBrandingControl>
-    {
-        ///<summary>
-        ///The border used for form controls.
-        ///</summary>
-        public CheckoutBrandingSimpleBorder? border { get; set; }
-        ///<summary>
-        ///Set to TRANSPARENT to define transparent form controls. If null, form controls inherit colors from their scheme settings (for example, the main section inherits from `design_system.colors.schemes.scheme1.control` by default). Note that usage of the `customizations.control.color` setting to customize the form control color is deprecated.
-        ///</summary>
-        public CheckoutBrandingColorSelection? color { get; set; }
-        ///<summary>
-        ///The corner radius used for form controls.
-        ///</summary>
-        public CheckoutBrandingCornerRadius? cornerRadius { get; set; }
-        ///<summary>
-        ///The label position used for form controls.
-        ///</summary>
-        public CheckoutBrandingLabelPosition? labelPosition { get; set; }
-    }
-
-    ///<summary>
-    ///Colors for form controls.
-    ///</summary>
-    public class CheckoutBrandingControlColorRoles : GraphQLObject<CheckoutBrandingControlColorRoles>
-    {
-        ///<summary>
-        ///The color of accented objects (links and focused state).
-        ///</summary>
-        public string? accent { get; set; }
-        ///<summary>
-        ///The color of the background.
-        ///</summary>
-        public string? background { get; set; }
-        ///<summary>
-        ///The color of borders.
-        ///</summary>
-        public string? border { get; set; }
-        ///<summary>
-        ///The decorative color for highlighting specific parts of the user interface.
-        ///</summary>
-        public string? decorative { get; set; }
-        ///<summary>
-        ///The color of icons.
-        ///</summary>
-        public string? icon { get; set; }
-        ///<summary>
-        ///The colors of selected controls.
-        ///</summary>
-        public CheckoutBrandingColorRoles? selected { get; set; }
-        ///<summary>
-        ///The color of text.
-        ///</summary>
-        public string? text { get; set; }
-    }
-
-    ///<summary>
-    ///Possible values for the corner radius.
-    ///</summary>
-    public enum CheckoutBrandingCornerRadius
-    {
-        ///<summary>
-        ///The None corner radius.
-        ///</summary>
-        NONE,
-        ///<summary>
-        ///The Small corner radius.
-        ///</summary>
-        SMALL,
-        ///<summary>
-        ///The Base corner radius.
-        ///</summary>
-        BASE,
-        ///<summary>
-        ///The Large corner radius.
-        ///</summary>
-        LARGE,
-    }
-
-    ///<summary>
-    ///The corner radius variables.
-    ///</summary>
-    public class CheckoutBrandingCornerRadiusVariables : GraphQLObject<CheckoutBrandingCornerRadiusVariables>
-    {
-        ///<summary>
-        ///The pixel value for base corner radiuses.
-        ///</summary>
-        public int? @base { get; set; }
-        ///<summary>
-        ///The pixel value for large corner radiuses.
-        ///</summary>
-        public int? large { get; set; }
-        ///<summary>
-        ///The pixel value for small corner radiuses.
-        ///</summary>
-        public int? small { get; set; }
-    }
-
-    ///<summary>
-    ///A custom font.
-    ///</summary>
-    public class CheckoutBrandingCustomFont : GraphQLObject<CheckoutBrandingCustomFont>, ICheckoutBrandingFont
-    {
-        ///<summary>
-        ///Globally unique ID reference to the custom font file.
-        ///</summary>
-        public string? genericFileId { get; set; }
-        ///<summary>
-        ///The font sources.
-        ///</summary>
-        public string? sources { get; set; }
-        ///<summary>
-        ///The font weight.
-        ///</summary>
-        public int? weight { get; set; }
-    }
-
-    ///<summary>
-    ///The customizations that apply to specific components or areas of the user interface.
-    ///</summary>
-    public class CheckoutBrandingCustomizations : GraphQLObject<CheckoutBrandingCustomizations>
-    {
-        ///<summary>
-        ///The checkboxes customizations.
-        ///</summary>
-        public CheckoutBrandingCheckbox? checkbox { get; set; }
-        ///<summary>
-        ///The choice list customizations.
-        ///</summary>
-        public CheckoutBrandingChoiceList? choiceList { get; set; }
-        ///<summary>
-        ///The form controls customizations.
-        ///</summary>
-        public CheckoutBrandingControl? control { get; set; }
-        ///<summary>
-        ///The favicon image.
-        ///</summary>
-        public CheckoutBrandingImage? favicon { get; set; }
-        ///<summary>
-        ///The global customizations.
-        ///</summary>
-        public CheckoutBrandingGlobal? global { get; set; }
-        ///<summary>
-        ///The header customizations.
-        ///</summary>
-        public CheckoutBrandingHeader? header { get; set; }
-        ///<summary>
-        ///The Heading Level 1 customizations.
-        ///</summary>
-        public CheckoutBrandingHeadingLevel? headingLevel1 { get; set; }
-        ///<summary>
-        ///The Heading Level 2 customizations.
-        ///</summary>
-        public CheckoutBrandingHeadingLevel? headingLevel2 { get; set; }
-        ///<summary>
-        ///The Heading Level 3 customizations.
-        ///</summary>
-        public CheckoutBrandingHeadingLevel? headingLevel3 { get; set; }
-        ///<summary>
-        ///The main area customizations.
-        ///</summary>
-        public CheckoutBrandingMain? main { get; set; }
-        ///<summary>
-        ///The merchandise thumbnails customizations.
-        ///</summary>
-        public CheckoutBrandingMerchandiseThumbnail? merchandiseThumbnail { get; set; }
-        ///<summary>
-        ///The order summary customizations.
-        ///</summary>
-        public CheckoutBrandingOrderSummary? orderSummary { get; set; }
-        ///<summary>
-        ///The primary buttons customizations.
-        ///</summary>
-        public CheckoutBrandingButton? primaryButton { get; set; }
-        ///<summary>
-        ///The secondary buttons customizations.
-        ///</summary>
-        public CheckoutBrandingButton? secondaryButton { get; set; }
-        ///<summary>
-        ///The selects customizations.
-        ///</summary>
-        public CheckoutBrandingSelect? select { get; set; }
-        ///<summary>
-        ///The text fields customizations.
-        ///</summary>
-        public CheckoutBrandingTextField? textField { get; set; }
-    }
-
-    ///<summary>
-    ///The design system allows you to set values that represent specific attributes
-    ///of your brand like color and font. These attributes are used throughout the user
-    ///interface. This brings consistency and allows you to easily make broad design changes.
-    ///</summary>
-    public class CheckoutBrandingDesignSystem : GraphQLObject<CheckoutBrandingDesignSystem>
-    {
-        ///<summary>
-        ///The color settings for global colors and color schemes.
-        ///</summary>
-        public CheckoutBrandingColors? colors { get; set; }
-        ///<summary>
-        ///The corner radius variables.
-        ///</summary>
-        public CheckoutBrandingCornerRadiusVariables? cornerRadius { get; set; }
-        ///<summary>
-        ///The typography.
-        ///</summary>
-        public CheckoutBrandingTypography? typography { get; set; }
-    }
-
-    ///<summary>
-    ///A font.
-    ///</summary>
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
-    [JsonDerivedType(typeof(CheckoutBrandingCustomFont), typeDiscriminator: "CheckoutBrandingCustomFont")]
-    [JsonDerivedType(typeof(CheckoutBrandingShopifyFont), typeDiscriminator: "CheckoutBrandingShopifyFont")]
-    public interface ICheckoutBrandingFont : IGraphQLObject
-    {
-        public CheckoutBrandingCustomFont? AsCheckoutBrandingCustomFont() => this as CheckoutBrandingCustomFont;
-        public CheckoutBrandingShopifyFont? AsCheckoutBrandingShopifyFont() => this as CheckoutBrandingShopifyFont;
-        ///<summary>
-        ///The font sources.
-        ///</summary>
-        public string? sources { get; }
-        ///<summary>
-        ///The font weight.
-        ///</summary>
-        public int? weight { get; }
-    }
-
-    ///<summary>
-    ///A font group.
-    ///</summary>
-    public class CheckoutBrandingFontGroup : GraphQLObject<CheckoutBrandingFontGroup>
-    {
-        ///<summary>
-        ///The base font.
-        ///</summary>
-        public ICheckoutBrandingFont? @base { get; set; }
-        ///<summary>
-        ///The bold font.
-        ///</summary>
-        public ICheckoutBrandingFont? bold { get; set; }
-        ///<summary>
-        ///The font loading strategy.
-        ///</summary>
-        public CheckoutBrandingFontLoadingStrategy? loadingStrategy { get; set; }
-        ///<summary>
-        ///The font group name.
-        ///</summary>
-        public string? name { get; set; }
-    }
-
-    ///<summary>
-    ///The font loading strategy determines how a font face is displayed after it is loaded or failed to load.
-    ///For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display.
-    ///</summary>
-    public enum CheckoutBrandingFontLoadingStrategy
-    {
-        ///<summary>
-        ///The font display strategy is defined by the browser user agent.
-        ///</summary>
-        AUTO,
-        ///<summary>
-        ///Gives the font face a short block period and an infinite swap period.
-        ///</summary>
-        BLOCK,
-        ///<summary>
-        ///Gives the font face an extremely small block period and an infinite swap period.
-        ///</summary>
-        SWAP,
-        ///<summary>
-        ///Gives the font face an extremely small block period and a short swap period.
-        ///</summary>
-        FALLBACK,
-        ///<summary>
-        ///Gives the font face an extremely small block period and no swap period.
-        ///</summary>
-        OPTIONAL,
-    }
-
-    ///<summary>
-    ///The font size.
-    ///</summary>
-    public class CheckoutBrandingFontSize : GraphQLObject<CheckoutBrandingFontSize>
-    {
-        ///<summary>
-        ///The base font size.
-        ///</summary>
-        public float? @base { get; set; }
-        ///<summary>
-        ///The scale ratio used to derive all font sizes such as small and large.
-        ///</summary>
-        public float? ratio { get; set; }
-    }
-
-    ///<summary>
-    ///The global customizations.
-    ///</summary>
-    public class CheckoutBrandingGlobal : GraphQLObject<CheckoutBrandingGlobal>
-    {
-        ///<summary>
-        ///The global corner radius.
-        ///</summary>
-        public CheckoutBrandingGlobalCornerRadius? cornerRadius { get; set; }
-        ///<summary>
-        ///The global typography customizations.
-        ///</summary>
-        public CheckoutBrandingTypographyStyleGlobal? typography { get; set; }
-    }
-
-    ///<summary>
-    ///Possible values for the corner radius.
-    ///</summary>
-    public enum CheckoutBrandingGlobalCornerRadius
-    {
-        ///<summary>
-        ///The None corner radius.
-        ///</summary>
-        NONE,
-    }
-
-    ///<summary>
-    ///The header customizations.
-    ///</summary>
-    public class CheckoutBrandingHeader : GraphQLObject<CheckoutBrandingHeader>
-    {
-        ///<summary>
-        ///The header alignment.
-        ///</summary>
-        public CheckoutBrandingHeaderAlignment? alignment { get; set; }
-        ///<summary>
-        ///The background image of the header.
-        ///</summary>
-        public CheckoutBrandingImage? banner { get; set; }
-        ///<summary>
-        ///The store logo.
-        ///</summary>
-        public CheckoutBrandingLogo? logo { get; set; }
-        ///<summary>
-        ///The header position.
-        ///</summary>
-        public CheckoutBrandingHeaderPosition? position { get; set; }
-    }
-
-    ///<summary>
-    ///The possible header alignments.
-    ///</summary>
-    public enum CheckoutBrandingHeaderAlignment
-    {
-        ///<summary>
-        ///Start alignment.
-        ///</summary>
-        START,
-        ///<summary>
-        ///Center alignment.
-        ///</summary>
-        CENTER,
-        ///<summary>
-        ///End alignment.
-        ///</summary>
-        END,
-    }
-
-    ///<summary>
-    ///The possible header positions.
-    ///</summary>
-    public enum CheckoutBrandingHeaderPosition
-    {
-        ///<summary>
-        ///Inline position.
-        ///</summary>
-        INLINE,
-        ///<summary>
-        ///Secondary inline position.
-        ///</summary>
-        INLINE_SECONDARY,
-        ///<summary>
-        ///Start position.
-        ///</summary>
-        START,
-    }
-
-    ///<summary>
-    ///The heading level customizations.
-    ///</summary>
-    public class CheckoutBrandingHeadingLevel : GraphQLObject<CheckoutBrandingHeadingLevel>
-    {
-        ///<summary>
-        ///The typography customizations used for headings.
-        ///</summary>
-        public CheckoutBrandingTypographyStyle? typography { get; set; }
-    }
-
-    ///<summary>
-    ///A checkout branding image.
-    ///</summary>
-    public class CheckoutBrandingImage : GraphQLObject<CheckoutBrandingImage>
-    {
-        ///<summary>
-        ///The image details.
-        ///</summary>
-        public Image? image { get; set; }
-    }
-
-    ///<summary>
-    ///Possible values for the label position.
-    ///</summary>
-    public enum CheckoutBrandingLabelPosition
-    {
-        ///<summary>
-        ///The Inside label position.
-        ///</summary>
-        INSIDE,
-        ///<summary>
-        ///The Outside label position.
-        ///</summary>
-        OUTSIDE,
-    }
-
-    ///<summary>
-    ///The store logo customizations.
-    ///</summary>
-    public class CheckoutBrandingLogo : GraphQLObject<CheckoutBrandingLogo>
-    {
-        ///<summary>
-        ///The logo image.
-        ///</summary>
-        public Image? image { get; set; }
-        ///<summary>
-        ///The maximum width of the logo.
-        ///</summary>
-        public int? maxWidth { get; set; }
-    }
-
-    ///<summary>
-    ///The main container customizations.
-    ///</summary>
-    public class CheckoutBrandingMain : GraphQLObject<CheckoutBrandingMain>
-    {
-        ///<summary>
-        ///The background image of the main container.
-        ///</summary>
-        public CheckoutBrandingImage? backgroundImage { get; set; }
-        ///<summary>
-        ///The selected color scheme of the main container.
-        ///</summary>
-        public CheckoutBrandingColorSchemeSelection? colorScheme { get; set; }
-    }
-
-    ///<summary>
-    ///The merchandise thumbnails customizations.
-    ///</summary>
-    public class CheckoutBrandingMerchandiseThumbnail : GraphQLObject<CheckoutBrandingMerchandiseThumbnail>
-    {
-        ///<summary>
-        ///The border used for merchandise thumbnails.
-        ///</summary>
-        public CheckoutBrandingSimpleBorder? border { get; set; }
-        ///<summary>
-        ///The corner radius used for merchandise thumbnails.
-        ///</summary>
-        public CheckoutBrandingCornerRadius? cornerRadius { get; set; }
-    }
-
-    ///<summary>
-    ///The order summary customizations.
-    ///</summary>
-    public class CheckoutBrandingOrderSummary : GraphQLObject<CheckoutBrandingOrderSummary>
-    {
-        ///<summary>
-        ///The background image of the order summary.
-        ///</summary>
-        public CheckoutBrandingImage? backgroundImage { get; set; }
-        ///<summary>
-        ///The selected color scheme.
-        ///</summary>
-        public CheckoutBrandingColorSchemeSelection? colorScheme { get; set; }
-    }
-
-    ///<summary>
-    ///The selects customizations.
-    ///</summary>
-    public class CheckoutBrandingSelect : GraphQLObject<CheckoutBrandingSelect>
-    {
-        ///<summary>
-        ///The border used for selects.
-        ///</summary>
-        public CheckoutBrandingBorder? border { get; set; }
-        ///<summary>
-        ///The typography customizations used for selects.
-        ///</summary>
-        public CheckoutBrandingTypographyStyle? typography { get; set; }
-    }
-
-    ///<summary>
-    ///A Shopify font.
-    ///</summary>
-    public class CheckoutBrandingShopifyFont : GraphQLObject<CheckoutBrandingShopifyFont>, ICheckoutBrandingFont
-    {
-        ///<summary>
-        ///The font sources.
-        ///</summary>
-        public string? sources { get; set; }
-        ///<summary>
-        ///The font weight.
-        ///</summary>
-        public int? weight { get; set; }
-    }
-
-    ///<summary>
-    ///Possible values for the simple border.
-    ///</summary>
-    public enum CheckoutBrandingSimpleBorder
-    {
-        ///<summary>
-        ///The None simple border.
-        ///</summary>
-        NONE,
-        ///<summary>
-        ///The Full simple border.
-        ///</summary>
-        FULL,
-    }
-
-    ///<summary>
-    ///Possible values for the spacing.
-    ///</summary>
-    public enum CheckoutBrandingSpacing
-    {
-        ///<summary>
-        ///The None spacing.
-        ///</summary>
-        NONE,
-        ///<summary>
-        ///The Extra Tight spacing.
-        ///</summary>
-        EXTRA_TIGHT,
-        ///<summary>
-        ///The Tight spacing.
-        ///</summary>
-        TIGHT,
-        ///<summary>
-        ///The Base spacing.
-        ///</summary>
-        BASE,
-        ///<summary>
-        ///The Loose spacing.
-        ///</summary>
-        LOOSE,
-        ///<summary>
-        ///The Extra Loose spacing.
-        ///</summary>
-        EXTRA_LOOSE,
-    }
-
-    ///<summary>
-    ///The spacing between UI elements.
-    ///</summary>
-    public enum CheckoutBrandingSpacingKeyword
-    {
-        ///<summary>
-        ///The None spacing.
-        ///</summary>
-        NONE,
-        ///<summary>
-        ///The Base spacing.
-        ///</summary>
-        BASE,
-        ///<summary>
-        ///The Small spacing.
-        ///</summary>
-        SMALL,
-        ///<summary>
-        ///The Small 100 spacing.
-        ///</summary>
-        SMALL_100,
-        ///<summary>
-        ///The Small 200 spacing.
-        ///</summary>
-        SMALL_200,
-        ///<summary>
-        ///The Small 300 spacing.
-        ///</summary>
-        SMALL_300,
-        ///<summary>
-        ///The Small 400 spacing.
-        ///</summary>
-        SMALL_400,
-        ///<summary>
-        ///The Small 500 spacing.
-        ///</summary>
-        SMALL_500,
-        ///<summary>
-        ///The Large spacing.
-        ///</summary>
-        LARGE,
-        ///<summary>
-        ///The Large 100 spacing.
-        ///</summary>
-        LARGE_100,
-        ///<summary>
-        ///The Large 200 spacing.
-        ///</summary>
-        LARGE_200,
-        ///<summary>
-        ///The Large 300 spacing.
-        ///</summary>
-        LARGE_300,
-        ///<summary>
-        ///The Large 400 spacing.
-        ///</summary>
-        LARGE_400,
-        ///<summary>
-        ///The Large 500 spacing.
-        ///</summary>
-        LARGE_500,
-    }
-
-    ///<summary>
-    ///The text fields customizations.
-    ///</summary>
-    public class CheckoutBrandingTextField : GraphQLObject<CheckoutBrandingTextField>
-    {
-        ///<summary>
-        ///The border used for text fields.
-        ///</summary>
-        public CheckoutBrandingBorder? border { get; set; }
-        ///<summary>
-        ///The typography customizations used for text fields.
-        ///</summary>
-        public CheckoutBrandingTypographyStyle? typography { get; set; }
-    }
-
-    ///<summary>
-    ///The typography settings.
-    ///</summary>
-    public class CheckoutBrandingTypography : GraphQLObject<CheckoutBrandingTypography>
-    {
-        ///<summary>
-        ///A font group used for most components such as text, buttons and form controls.
-        ///</summary>
-        public CheckoutBrandingFontGroup? primary { get; set; }
-        ///<summary>
-        ///A font group used for heading components by default.
-        ///</summary>
-        public CheckoutBrandingFontGroup? secondary { get; set; }
-        ///<summary>
-        ///The font size.
-        ///</summary>
-        public CheckoutBrandingFontSize? size { get; set; }
-    }
-
-    ///<summary>
-    ///The font selection.
-    ///</summary>
-    public enum CheckoutBrandingTypographyFont
-    {
-        ///<summary>
-        ///The primary font.
-        ///</summary>
-        PRIMARY,
-        ///<summary>
-        ///The secondary font.
-        ///</summary>
-        SECONDARY,
-    }
-
-    ///<summary>
-    ///Possible values for the typography kerning.
-    ///</summary>
-    public enum CheckoutBrandingTypographyKerning
-    {
-        ///<summary>
-        ///Base or default kerning.
-        ///</summary>
-        BASE,
-        ///<summary>
-        ///Loose kerning, leaving more space than the default in between characters.
-        ///</summary>
-        LOOSE,
-        ///<summary>
-        ///Extra loose kerning, leaving even more space in between characters.
-        ///</summary>
-        EXTRA_LOOSE,
-    }
-
-    ///<summary>
-    ///Possible values for the typography letter case.
-    ///</summary>
-    public enum CheckoutBrandingTypographyLetterCase
-    {
-        ///<summary>
-        ///All letters are is lower case.
-        ///</summary>
-        LOWER,
-        ///<summary>
-        ///No letter casing applied.
-        ///</summary>
-        NONE,
-        ///<summary>
-        ///Capitalize the first letter of each word.
-        ///</summary>
-        TITLE,
-        ///<summary>
-        ///All letters are uppercase.
-        ///</summary>
-        UPPER,
-    }
-
-    ///<summary>
-    ///Possible values for the font size.
-    ///</summary>
-    public enum CheckoutBrandingTypographySize
-    {
-        ///<summary>
-        ///The extra small font size.
-        ///</summary>
-        EXTRA_SMALL,
-        ///<summary>
-        ///The small font size.
-        ///</summary>
-        SMALL,
-        ///<summary>
-        ///The base font size.
-        ///</summary>
-        BASE,
-        ///<summary>
-        ///The medium font size.
-        ///</summary>
-        MEDIUM,
-        ///<summary>
-        ///The large font size.
-        ///</summary>
-        LARGE,
-        ///<summary>
-        ///The extra large font size.
-        ///</summary>
-        EXTRA_LARGE,
-        ///<summary>
-        ///The extra extra large font size.
-        ///</summary>
-        EXTRA_EXTRA_LARGE,
-    }
-
-    ///<summary>
-    ///The typography customizations.
-    ///</summary>
-    public class CheckoutBrandingTypographyStyle : GraphQLObject<CheckoutBrandingTypographyStyle>
-    {
-        ///<summary>
-        ///The font.
-        ///</summary>
-        public CheckoutBrandingTypographyFont? font { get; set; }
-        ///<summary>
-        ///The kerning.
-        ///</summary>
-        public CheckoutBrandingTypographyKerning? kerning { get; set; }
-        ///<summary>
-        ///The letter case.
-        ///</summary>
-        public CheckoutBrandingTypographyLetterCase? letterCase { get; set; }
-        ///<summary>
-        ///The font size.
-        ///</summary>
-        public CheckoutBrandingTypographySize? size { get; set; }
-        ///<summary>
-        ///The font weight.
-        ///</summary>
-        public CheckoutBrandingTypographyWeight? weight { get; set; }
-    }
-
-    ///<summary>
-    ///The global typography customizations.
-    ///</summary>
-    public class CheckoutBrandingTypographyStyleGlobal : GraphQLObject<CheckoutBrandingTypographyStyleGlobal>
-    {
-        ///<summary>
-        ///The kerning.
-        ///</summary>
-        public CheckoutBrandingTypographyKerning? kerning { get; set; }
-        ///<summary>
-        ///The letter case.
-        ///</summary>
-        public CheckoutBrandingTypographyLetterCase? letterCase { get; set; }
-    }
-
-    ///<summary>
-    ///Possible values for the font weight.
-    ///</summary>
-    public enum CheckoutBrandingTypographyWeight
-    {
-        ///<summary>
-        ///The base weight.
-        ///</summary>
-        BASE,
-        ///<summary>
-        ///The bold weight.
-        ///</summary>
-        BOLD,
-    }
-
-    ///<summary>
-    ///Return type for `checkoutBrandingUpsert` mutation.
-    ///</summary>
-    public class CheckoutBrandingUpsertPayload : GraphQLObject<CheckoutBrandingUpsertPayload>
-    {
-        ///<summary>
-        ///Returns the new checkout branding settings.
-        ///</summary>
-        public CheckoutBranding? checkoutBranding { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<CheckoutBrandingUpsertUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `CheckoutBrandingUpsert`.
-    ///</summary>
-    public class CheckoutBrandingUpsertUserError : GraphQLObject<CheckoutBrandingUpsertUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public CheckoutBrandingUpsertUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `CheckoutBrandingUpsertUserError`.
-    ///</summary>
-    public enum CheckoutBrandingUpsertUserErrorCode
-    {
-        ///<summary>
-        ///Unexpected internal error happened.
-        ///</summary>
-        INTERNAL_ERROR,
     }
 
     ///<summary>
@@ -6575,10 +5286,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public DateTime? createdAt { get; set; }
         ///<summary>
-        ///The first name of the recipient.
-        ///</summary>
-        public string? firstName { get; set; }
-        ///<summary>
         ///The formatted version of the address.
         ///</summary>
         public IEnumerable<string>? formattedAddress { get; set; }
@@ -6590,10 +5297,6 @@ namespace ShopifySharp.GraphQL
         ///A globally-unique ID.
         ///</summary>
         public string? id { get; set; }
-        ///<summary>
-        ///The last name of the recipient.
-        ///</summary>
-        public string? lastName { get; set; }
         ///<summary>
         ///A unique phone number for the customer.
         ///Formatted using E.164 standard. For example, _+16135551111_.
@@ -8599,7 +7302,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         TN,
         ///<summary>
-        ///Türkiye.
+        ///Turkey.
         ///</summary>
         TR,
         ///<summary>
@@ -9508,6 +8211,17 @@ namespace ShopifySharp.GraphQL
     public class Customer : GraphQLObject<Customer>, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, ILegacyInteroperability, INode, ICommentEventEmbed, IMetafieldReferencer, IPurchasingEntity
     {
         ///<summary>
+        ///Whether the customer has agreed to receive marketing material.
+        ///</summary>
+        [Obsolete("Use `emailMarketingConsent` instead.")]
+        public bool? acceptsMarketing { get; set; }
+
+        ///<summary>
+        ///The date and time when the customer consented or objected to receiving marketing material by email.
+        ///</summary>
+        [Obsolete("Use `emailMarketingConsent` instead.")]
+        public DateTime? acceptsMarketingUpdatedAt { get; set; }
+        ///<summary>
         ///A list of addresses associated with the customer.
         ///</summary>
         public IEnumerable<MailingAddress>? addresses { get; set; }
@@ -9515,6 +8229,18 @@ namespace ShopifySharp.GraphQL
         ///The total amount that the customer has spent on orders in their lifetime.
         ///</summary>
         public MoneyV2? amountSpent { get; set; }
+
+        ///<summary>
+        ///The average amount that the customer spent per order.
+        ///</summary>
+        [Obsolete("This field is no longer supported.")]
+        public decimal? averageOrderAmount { get; set; }
+
+        ///<summary>
+        ///The average amount that the customer spent per order.
+        ///</summary>
+        [Obsolete("This field is no longer supported.")]
+        public MoneyV2? averageOrderAmountV2 { get; set; }
         ///<summary>
         ///Whether the merchant can delete the customer from their store.
         ///
@@ -9596,6 +8322,15 @@ namespace ShopifySharp.GraphQL
         ///The market that includes the customer’s default address.
         ///</summary>
         public Market? market { get; set; }
+
+        ///<summary>
+        ///The marketing subscription opt-in level, as described by the M3AAWG best practices guidelines, that the
+        ///customer gave when they consented to receive marketing material by email.
+        ///
+        ///If the customer doesn't accept email marketing, then this property is `null`.
+        ///</summary>
+        [Obsolete("Use `emailMarketingConsent` instead.")]
+        public CustomerMarketingOptInLevel? marketingOptInLevel { get; set; }
         ///<summary>
         ///Whether the customer can be merged with another customer.
         ///</summary>
@@ -9705,44 +8440,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Information about the shop's customer accounts.
-    ///</summary>
-    public class CustomerAccountsV2 : GraphQLObject<CustomerAccountsV2>
-    {
-        ///<summary>
-        ///Indicates which version of customer accounts the merchant is using in online store and checkout.
-        ///</summary>
-        public CustomerAccountsVersion? customerAccountsVersion { get; set; }
-        ///<summary>
-        ///Login links are shown in online store and checkout.
-        ///</summary>
-        public bool? loginLinksVisibleOnStorefrontAndCheckout { get; set; }
-        ///<summary>
-        ///Customers are required to log in to their account before checkout.
-        ///</summary>
-        public bool? loginRequiredAtCheckout { get; set; }
-        ///<summary>
-        ///The root url for the customer accounts pages.
-        ///</summary>
-        public string? url { get; set; }
-    }
-
-    ///<summary>
-    ///The login redirection target for customer accounts.
-    ///</summary>
-    public enum CustomerAccountsVersion
-    {
-        ///<summary>
-        ///The customer is redirected to the classic customer accounts login page.
-        ///</summary>
-        CLASSIC,
-        ///<summary>
-        ///The customer is redirected to the new customer accounts login page.
-        ///</summary>
-        NEW_CUSTOMER_ACCOUNTS,
-    }
-
-    ///<summary>
     ///Return type for `customerAddTaxExemptions` mutation.
     ///</summary>
     public class CustomerAddTaxExemptionsPayload : GraphQLObject<CustomerAddTaxExemptionsPayload>
@@ -9755,59 +8452,6 @@ namespace ShopifySharp.GraphQL
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `CustomerCancelDataErasureUserError`.
-    ///</summary>
-    public enum CustomerCancelDataErasureErrorCode
-    {
-        ///<summary>
-        ///Customer does not exist.
-        ///</summary>
-        DOES_NOT_EXIST,
-        ///<summary>
-        ///Failed to cancel customer data erasure.
-        ///</summary>
-        FAILED_TO_CANCEL,
-        ///<summary>
-        ///Customer's data is not scheduled for erasure.
-        ///</summary>
-        NOT_BEING_ERASED,
-    }
-
-    ///<summary>
-    ///Return type for `customerCancelDataErasure` mutation.
-    ///</summary>
-    public class CustomerCancelDataErasurePayload : GraphQLObject<CustomerCancelDataErasurePayload>
-    {
-        ///<summary>
-        ///The ID of the customer whose pending data erasure has been cancelled.
-        ///</summary>
-        public string? customerId { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<CustomerCancelDataErasureUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs when cancelling a customer data erasure request.
-    ///</summary>
-    public class CustomerCancelDataErasureUserError : GraphQLObject<CustomerCancelDataErasureUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public CustomerCancelDataErasureErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
     }
 
     ///<summary>
@@ -10841,10 +9485,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public CustomerPaymentMethod? customerPaymentMethod { get; set; }
         ///<summary>
-        ///If the card verification result is processing. When this is true, customer_payment_method will be null.
-        ///</summary>
-        public bool? processing { get; set; }
-        ///<summary>
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
@@ -10859,10 +9499,6 @@ namespace ShopifySharp.GraphQL
         ///The customer payment method.
         ///</summary>
         public CustomerPaymentMethod? customerPaymentMethod { get; set; }
-        ///<summary>
-        ///If the card verification result is processing. When this is true, customer_payment_method will be null.
-        ///</summary>
-        public bool? processing { get; set; }
         ///<summary>
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
@@ -11367,55 +10003,6 @@ namespace ShopifySharp.GraphQL
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `CustomerRequestDataErasureUserError`.
-    ///</summary>
-    public enum CustomerRequestDataErasureErrorCode
-    {
-        ///<summary>
-        ///Customer does not exist.
-        ///</summary>
-        DOES_NOT_EXIST,
-        ///<summary>
-        ///Failed to request customer data erasure.
-        ///</summary>
-        FAILED_TO_REQUEST,
-    }
-
-    ///<summary>
-    ///Return type for `customerRequestDataErasure` mutation.
-    ///</summary>
-    public class CustomerRequestDataErasurePayload : GraphQLObject<CustomerRequestDataErasurePayload>
-    {
-        ///<summary>
-        ///The ID of the customer that will be erased.
-        ///</summary>
-        public string? customerId { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<CustomerRequestDataErasureUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs when requesting a customer data erasure.
-    ///</summary>
-    public class CustomerRequestDataErasureUserError : GraphQLObject<CustomerRequestDataErasureUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public CustomerRequestDataErasureErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
     }
 
     ///<summary>
@@ -12909,10 +11496,6 @@ namespace ShopifySharp.GraphQL
         ///The earliest delivery date and time when the fulfillment is expected to arrive at the buyer's location.
         ///</summary>
         public DateTime? minDeliveryDateTime { get; set; }
-        ///<summary>
-        ///A reference to the shipping method.
-        ///</summary>
-        public string? serviceCode { get; set; }
     }
 
     ///<summary>
@@ -13421,7 +12004,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(DiscountAutomaticApp), typeDiscriminator: "DiscountAutomaticApp")]
     [JsonDerivedType(typeof(DiscountAutomaticBasic), typeDiscriminator: "DiscountAutomaticBasic")]
     [JsonDerivedType(typeof(DiscountAutomaticBxgy), typeDiscriminator: "DiscountAutomaticBxgy")]
-    [JsonDerivedType(typeof(DiscountAutomaticFreeShipping), typeDiscriminator: "DiscountAutomaticFreeShipping")]
     [JsonDerivedType(typeof(DiscountCodeApp), typeDiscriminator: "DiscountCodeApp")]
     [JsonDerivedType(typeof(DiscountCodeBasic), typeDiscriminator: "DiscountCodeBasic")]
     [JsonDerivedType(typeof(DiscountCodeBxgy), typeDiscriminator: "DiscountCodeBxgy")]
@@ -13431,7 +12013,6 @@ namespace ShopifySharp.GraphQL
         public DiscountAutomaticApp? AsDiscountAutomaticApp() => this as DiscountAutomaticApp;
         public DiscountAutomaticBasic? AsDiscountAutomaticBasic() => this as DiscountAutomaticBasic;
         public DiscountAutomaticBxgy? AsDiscountAutomaticBxgy() => this as DiscountAutomaticBxgy;
-        public DiscountAutomaticFreeShipping? AsDiscountAutomaticFreeShipping() => this as DiscountAutomaticFreeShipping;
         public DiscountCodeApp? AsDiscountCodeApp() => this as DiscountCodeApp;
         public DiscountCodeBasic? AsDiscountCodeBasic() => this as DiscountCodeBasic;
         public DiscountCodeBxgy? AsDiscountCodeBxgy() => this as DiscountCodeBxgy;
@@ -13493,7 +12074,7 @@ namespace ShopifySharp.GraphQL
     ///<summary>
     ///The fixed amount value of a discount, and whether the amount is applied to each entitled item or spread evenly across the entitled items.
     ///</summary>
-    public class DiscountAmount : GraphQLObject<DiscountAmount>, IDiscountCustomerGetsValue, IDiscountEffect
+    public class DiscountAmount : GraphQLObject<DiscountAmount>, IDiscountCustomerGetsValue
     {
         ///<summary>
         ///The value of the discount.
@@ -13660,13 +12241,11 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(DiscountAutomaticApp), typeDiscriminator: "DiscountAutomaticApp")]
     [JsonDerivedType(typeof(DiscountAutomaticBasic), typeDiscriminator: "DiscountAutomaticBasic")]
     [JsonDerivedType(typeof(DiscountAutomaticBxgy), typeDiscriminator: "DiscountAutomaticBxgy")]
-    [JsonDerivedType(typeof(DiscountAutomaticFreeShipping), typeDiscriminator: "DiscountAutomaticFreeShipping")]
     public interface IDiscountAutomatic : IGraphQLObject
     {
         public DiscountAutomaticApp? AsDiscountAutomaticApp() => this as DiscountAutomaticApp;
         public DiscountAutomaticBasic? AsDiscountAutomaticBasic() => this as DiscountAutomaticBasic;
         public DiscountAutomaticBxgy? AsDiscountAutomaticBxgy() => this as DiscountAutomaticBxgy;
-        public DiscountAutomaticFreeShipping? AsDiscountAutomaticFreeShipping() => this as DiscountAutomaticFreeShipping;
         ///<summary>
         ///The number of times the discount has been used. This value is updated asynchronously and can be different than the actual usage count.
         ///</summary>
@@ -13834,10 +12413,6 @@ namespace ShopifySharp.GraphQL
         ///The minimum subtotal or quantity that's required for the discount to be applied.
         ///</summary>
         public IDiscountMinimumRequirement? minimumRequirement { get; set; }
-        ///<summary>
-        ///The number of times a discount applies on recurring purchases (subscriptions).
-        ///</summary>
-        public int? recurringCycleLimit { get; set; }
         ///<summary>
         ///A short summary of the discount.
         ///</summary>
@@ -14082,119 +12657,6 @@ namespace ShopifySharp.GraphQL
         ///The item at the end of DiscountAutomaticEdge.
         ///</summary>
         public IDiscountAutomatic? node { get; set; }
-    }
-
-    ///<summary>
-    ///An automatic discount that offers customers free shipping on their order.
-    ///</summary>
-    public class DiscountAutomaticFreeShipping : GraphQLObject<DiscountAutomaticFreeShipping>, IDiscount, IDiscountAutomatic
-    {
-        ///<summary>
-        ///Whether the discount applies on regular one-time-purchase shipping lines.
-        ///</summary>
-        public bool? appliesOnOneTimePurchase { get; set; }
-        ///<summary>
-        ///Whether the discount applies on subscription shipping lines.
-        ///</summary>
-        public bool? appliesOnSubscription { get; set; }
-        ///<summary>
-        ///The number of times that the discount has been used. This value is updated asynchronously and can be different than the actual usage count.
-        ///</summary>
-        public int? asyncUsageCount { get; set; }
-        ///<summary>
-        ///Determines which discount classes the discount can combine with.
-        ///</summary>
-        public DiscountCombinesWith? combinesWith { get; set; }
-        ///<summary>
-        ///The date and time when the discount was created.
-        ///</summary>
-        public DateTime? createdAt { get; set; }
-        ///<summary>
-        ///A shipping destination that qualifies for the discount.
-        ///</summary>
-        public IDiscountShippingDestinationSelection? destinationSelection { get; set; }
-        ///<summary>
-        ///The class of the discount for combining purposes.
-        ///</summary>
-        public ShippingDiscountClass? discountClass { get; set; }
-        ///<summary>
-        ///The date and time when the discount ends. For open-ended discounts, use `null`.
-        ///</summary>
-        public DateTime? endsAt { get; set; }
-        ///<summary>
-        ///Indicates whether there are any timeline comments on the discount.
-        ///</summary>
-        public bool? hasTimelineComment { get; set; }
-        ///<summary>
-        ///The maximum shipping price amount accepted to qualify for the discount.
-        ///</summary>
-        public MoneyV2? maximumShippingPrice { get; set; }
-        ///<summary>
-        ///The minimum subtotal or quantity that's required for the discount to be applied.
-        ///</summary>
-        public IDiscountMinimumRequirement? minimumRequirement { get; set; }
-        ///<summary>
-        ///The number of times a discount applies on recurring purchases (subscriptions).
-        ///</summary>
-        public int? recurringCycleLimit { get; set; }
-        ///<summary>
-        ///A short summary of the discount.
-        ///</summary>
-        public string? shortSummary { get; set; }
-        ///<summary>
-        ///The date and time when the discount starts.
-        ///</summary>
-        public DateTime? startsAt { get; set; }
-        ///<summary>
-        ///The status of the discount.
-        ///</summary>
-        public DiscountStatus? status { get; set; }
-        ///<summary>
-        ///A detailed summary of the discount.
-        ///</summary>
-        public string? summary { get; set; }
-        ///<summary>
-        ///The title of the discount.
-        ///</summary>
-        public string? title { get; set; }
-        ///<summary>
-        ///The total sales from orders where the discount was used.
-        ///</summary>
-        public MoneyV2? totalSales { get; set; }
-        ///<summary>
-        ///The date and time when the discount was updated.
-        ///</summary>
-        public DateTime? updatedAt { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `discountAutomaticFreeShippingCreate` mutation.
-    ///</summary>
-    public class DiscountAutomaticFreeShippingCreatePayload : GraphQLObject<DiscountAutomaticFreeShippingCreatePayload>
-    {
-        ///<summary>
-        ///The created automatic discount.
-        ///</summary>
-        public DiscountAutomaticNode? automaticDiscountNode { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<DiscountUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `discountAutomaticFreeShippingUpdate` mutation.
-    ///</summary>
-    public class DiscountAutomaticFreeShippingUpdatePayload : GraphQLObject<DiscountAutomaticFreeShippingUpdatePayload>
-    {
-        ///<summary>
-        ///The updated automatic discount.
-        ///</summary>
-        public DiscountAutomaticNode? automaticDiscountNode { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<DiscountUserError>? userErrors { get; set; }
     }
 
     ///<summary>
@@ -15289,12 +13751,14 @@ namespace ShopifySharp.GraphQL
     ///The type of discount that will be applied. Currently, only a percentage discount is supported.
     ///</summary>
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
-    [JsonDerivedType(typeof(DiscountAmount), typeDiscriminator: "DiscountAmount")]
     [JsonDerivedType(typeof(DiscountPercentage), typeDiscriminator: "DiscountPercentage")]
     public interface IDiscountEffect : IGraphQLObject
     {
-        public DiscountAmount? AsDiscountAmount() => this as DiscountAmount;
         public DiscountPercentage? AsDiscountPercentage() => this as DiscountPercentage;
+        ///<summary>
+        ///The percentage value of the discount.
+        ///</summary>
+        public float? percentage { get; set; }
     }
 
     ///<summary>
@@ -15895,10 +14359,6 @@ namespace ShopifySharp.GraphQL
         ///Code discount type.
         ///</summary>
         CODE_DISCOUNT,
-        ///<summary>
-        ///Automatic discount type.
-        ///</summary>
-        AUTOMATIC_DISCOUNT,
     }
 
     ///<summary>
@@ -15930,6 +14390,8 @@ namespace ShopifySharp.GraphQL
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
     [JsonDerivedType(typeof(AbandonmentEmailStateUpdateUserError), typeDiscriminator: "AbandonmentEmailStateUpdateUserError")]
     [JsonDerivedType(typeof(AbandonmentUpdateActivitiesDeliveryStatusesUserError), typeDiscriminator: "AbandonmentUpdateActivitiesDeliveryStatusesUserError")]
+    [JsonDerivedType(typeof(AppRevenueAttributionRecordCreateUserError), typeDiscriminator: "AppRevenueAttributionRecordCreateUserError")]
+    [JsonDerivedType(typeof(AppRevenueAttributionRecordDeleteUserError), typeDiscriminator: "AppRevenueAttributionRecordDeleteUserError")]
     [JsonDerivedType(typeof(AppSubscriptionTrialExtendUserError), typeDiscriminator: "AppSubscriptionTrialExtendUserError")]
     [JsonDerivedType(typeof(BillingAttemptUserError), typeDiscriminator: "BillingAttemptUserError")]
     [JsonDerivedType(typeof(BulkMutationUserError), typeDiscriminator: "BulkMutationUserError")]
@@ -15938,9 +14400,7 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(CartTransformCreateUserError), typeDiscriminator: "CartTransformCreateUserError")]
     [JsonDerivedType(typeof(CartTransformDeleteUserError), typeDiscriminator: "CartTransformDeleteUserError")]
     [JsonDerivedType(typeof(CatalogUserError), typeDiscriminator: "CatalogUserError")]
-    [JsonDerivedType(typeof(CheckoutBrandingUpsertUserError), typeDiscriminator: "CheckoutBrandingUpsertUserError")]
     [JsonDerivedType(typeof(CollectionAddProductsV2UserError), typeDiscriminator: "CollectionAddProductsV2UserError")]
-    [JsonDerivedType(typeof(CustomerCancelDataErasureUserError), typeDiscriminator: "CustomerCancelDataErasureUserError")]
     [JsonDerivedType(typeof(CustomerEmailMarketingConsentUpdateUserError), typeDiscriminator: "CustomerEmailMarketingConsentUpdateUserError")]
     [JsonDerivedType(typeof(CustomerMergeUserError), typeDiscriminator: "CustomerMergeUserError")]
     [JsonDerivedType(typeof(CustomerPaymentMethodCreateFromDuplicationDataUserError), typeDiscriminator: "CustomerPaymentMethodCreateFromDuplicationDataUserError")]
@@ -15948,7 +14408,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(CustomerPaymentMethodGetUpdateUrlUserError), typeDiscriminator: "CustomerPaymentMethodGetUpdateUrlUserError")]
     [JsonDerivedType(typeof(CustomerPaymentMethodRemoteUserError), typeDiscriminator: "CustomerPaymentMethodRemoteUserError")]
     [JsonDerivedType(typeof(CustomerPaymentMethodUserError), typeDiscriminator: "CustomerPaymentMethodUserError")]
-    [JsonDerivedType(typeof(CustomerRequestDataErasureUserError), typeDiscriminator: "CustomerRequestDataErasureUserError")]
     [JsonDerivedType(typeof(CustomerSegmentMembersQueryUserError), typeDiscriminator: "CustomerSegmentMembersQueryUserError")]
     [JsonDerivedType(typeof(CustomerSmsMarketingConsentError), typeDiscriminator: "CustomerSmsMarketingConsentError")]
     [JsonDerivedType(typeof(DelegateAccessTokenCreateUserError), typeDiscriminator: "DelegateAccessTokenCreateUserError")]
@@ -15960,8 +14419,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(ErrorsServerPixelUserError), typeDiscriminator: "ErrorsServerPixelUserError")]
     [JsonDerivedType(typeof(ErrorsWebPixelUserError), typeDiscriminator: "ErrorsWebPixelUserError")]
     [JsonDerivedType(typeof(FilesUserError), typeDiscriminator: "FilesUserError")]
-    [JsonDerivedType(typeof(FulfillmentConstraintRuleCreateUserError), typeDiscriminator: "FulfillmentConstraintRuleCreateUserError")]
-    [JsonDerivedType(typeof(FulfillmentConstraintRuleDeleteUserError), typeDiscriminator: "FulfillmentConstraintRuleDeleteUserError")]
     [JsonDerivedType(typeof(FulfillmentOrderHoldUserError), typeDiscriminator: "FulfillmentOrderHoldUserError")]
     [JsonDerivedType(typeof(FulfillmentOrderLineItemsPreparedForPickupUserError), typeDiscriminator: "FulfillmentOrderLineItemsPreparedForPickupUserError")]
     [JsonDerivedType(typeof(FulfillmentOrderMergeUserError), typeDiscriminator: "FulfillmentOrderMergeUserError")]
@@ -15975,7 +14432,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(InventoryBulkToggleActivationUserError), typeDiscriminator: "InventoryBulkToggleActivationUserError")]
     [JsonDerivedType(typeof(InventoryMoveQuantitiesUserError), typeDiscriminator: "InventoryMoveQuantitiesUserError")]
     [JsonDerivedType(typeof(InventorySetOnHandQuantitiesUserError), typeDiscriminator: "InventorySetOnHandQuantitiesUserError")]
-    [JsonDerivedType(typeof(InventorySetScheduledChangesUserError), typeDiscriminator: "InventorySetScheduledChangesUserError")]
     [JsonDerivedType(typeof(LocationActivateUserError), typeDiscriminator: "LocationActivateUserError")]
     [JsonDerivedType(typeof(LocationAddUserError), typeDiscriminator: "LocationAddUserError")]
     [JsonDerivedType(typeof(LocationDeactivateUserError), typeDiscriminator: "LocationDeactivateUserError")]
@@ -15992,10 +14448,7 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(MetafieldDefinitionUpdateUserError), typeDiscriminator: "MetafieldDefinitionUpdateUserError")]
     [JsonDerivedType(typeof(MetafieldsSetUserError), typeDiscriminator: "MetafieldsSetUserError")]
     [JsonDerivedType(typeof(MetaobjectUserError), typeDiscriminator: "MetaobjectUserError")]
-    [JsonDerivedType(typeof(OrderCancelUserError), typeDiscriminator: "OrderCancelUserError")]
     [JsonDerivedType(typeof(OrderCreateMandatePaymentUserError), typeDiscriminator: "OrderCreateMandatePaymentUserError")]
-    [JsonDerivedType(typeof(OrderEditRemoveDiscountUserError), typeDiscriminator: "OrderEditRemoveDiscountUserError")]
-    [JsonDerivedType(typeof(OrderEditUpdateDiscountUserError), typeDiscriminator: "OrderEditUpdateDiscountUserError")]
     [JsonDerivedType(typeof(OrderInvoiceSendUserError), typeDiscriminator: "OrderInvoiceSendUserError")]
     [JsonDerivedType(typeof(PaymentCustomizationError), typeDiscriminator: "PaymentCustomizationError")]
     [JsonDerivedType(typeof(PaymentReminderSendUserError), typeDiscriminator: "PaymentReminderSendUserError")]
@@ -16021,17 +14474,13 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(PubSubWebhookSubscriptionCreateUserError), typeDiscriminator: "PubSubWebhookSubscriptionCreateUserError")]
     [JsonDerivedType(typeof(PubSubWebhookSubscriptionUpdateUserError), typeDiscriminator: "PubSubWebhookSubscriptionUpdateUserError")]
     [JsonDerivedType(typeof(PublicationUserError), typeDiscriminator: "PublicationUserError")]
-    [JsonDerivedType(typeof(QuantityPricingByVariantUserError), typeDiscriminator: "QuantityPricingByVariantUserError")]
     [JsonDerivedType(typeof(QuantityRuleUserError), typeDiscriminator: "QuantityRuleUserError")]
     [JsonDerivedType(typeof(ReturnUserError), typeDiscriminator: "ReturnUserError")]
     [JsonDerivedType(typeof(SellingPlanGroupUserError), typeDiscriminator: "SellingPlanGroupUserError")]
     [JsonDerivedType(typeof(ShopPolicyUserError), typeDiscriminator: "ShopPolicyUserError")]
     [JsonDerivedType(typeof(ShopResourceFeedbackCreateUserError), typeDiscriminator: "ShopResourceFeedbackCreateUserError")]
     [JsonDerivedType(typeof(StandardMetafieldDefinitionEnableUserError), typeDiscriminator: "StandardMetafieldDefinitionEnableUserError")]
-    [JsonDerivedType(typeof(SubscriptionBillingCycleSkipUserError), typeDiscriminator: "SubscriptionBillingCycleSkipUserError")]
-    [JsonDerivedType(typeof(SubscriptionBillingCycleUnskipUserError), typeDiscriminator: "SubscriptionBillingCycleUnskipUserError")]
     [JsonDerivedType(typeof(SubscriptionBillingCycleUserError), typeDiscriminator: "SubscriptionBillingCycleUserError")]
-    [JsonDerivedType(typeof(SubscriptionContractStatusUpdateUserError), typeDiscriminator: "SubscriptionContractStatusUpdateUserError")]
     [JsonDerivedType(typeof(SubscriptionContractUserError), typeDiscriminator: "SubscriptionContractUserError")]
     [JsonDerivedType(typeof(SubscriptionDraftUserError), typeDiscriminator: "SubscriptionDraftUserError")]
     [JsonDerivedType(typeof(TaxAppConfigureUserError), typeDiscriminator: "TaxAppConfigureUserError")]
@@ -16042,11 +14491,12 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(UrlRedirectImportUserError), typeDiscriminator: "UrlRedirectImportUserError")]
     [JsonDerivedType(typeof(UrlRedirectUserError), typeDiscriminator: "UrlRedirectUserError")]
     [JsonDerivedType(typeof(UserError), typeDiscriminator: "UserError")]
-    [JsonDerivedType(typeof(ValidationUserError), typeDiscriminator: "ValidationUserError")]
     public interface IDisplayableError : IGraphQLObject
     {
         public AbandonmentEmailStateUpdateUserError? AsAbandonmentEmailStateUpdateUserError() => this as AbandonmentEmailStateUpdateUserError;
         public AbandonmentUpdateActivitiesDeliveryStatusesUserError? AsAbandonmentUpdateActivitiesDeliveryStatusesUserError() => this as AbandonmentUpdateActivitiesDeliveryStatusesUserError;
+        public AppRevenueAttributionRecordCreateUserError? AsAppRevenueAttributionRecordCreateUserError() => this as AppRevenueAttributionRecordCreateUserError;
+        public AppRevenueAttributionRecordDeleteUserError? AsAppRevenueAttributionRecordDeleteUserError() => this as AppRevenueAttributionRecordDeleteUserError;
         public AppSubscriptionTrialExtendUserError? AsAppSubscriptionTrialExtendUserError() => this as AppSubscriptionTrialExtendUserError;
         public BillingAttemptUserError? AsBillingAttemptUserError() => this as BillingAttemptUserError;
         public BulkMutationUserError? AsBulkMutationUserError() => this as BulkMutationUserError;
@@ -16055,9 +14505,7 @@ namespace ShopifySharp.GraphQL
         public CartTransformCreateUserError? AsCartTransformCreateUserError() => this as CartTransformCreateUserError;
         public CartTransformDeleteUserError? AsCartTransformDeleteUserError() => this as CartTransformDeleteUserError;
         public CatalogUserError? AsCatalogUserError() => this as CatalogUserError;
-        public CheckoutBrandingUpsertUserError? AsCheckoutBrandingUpsertUserError() => this as CheckoutBrandingUpsertUserError;
         public CollectionAddProductsV2UserError? AsCollectionAddProductsV2UserError() => this as CollectionAddProductsV2UserError;
-        public CustomerCancelDataErasureUserError? AsCustomerCancelDataErasureUserError() => this as CustomerCancelDataErasureUserError;
         public CustomerEmailMarketingConsentUpdateUserError? AsCustomerEmailMarketingConsentUpdateUserError() => this as CustomerEmailMarketingConsentUpdateUserError;
         public CustomerMergeUserError? AsCustomerMergeUserError() => this as CustomerMergeUserError;
         public CustomerPaymentMethodCreateFromDuplicationDataUserError? AsCustomerPaymentMethodCreateFromDuplicationDataUserError() => this as CustomerPaymentMethodCreateFromDuplicationDataUserError;
@@ -16065,7 +14513,6 @@ namespace ShopifySharp.GraphQL
         public CustomerPaymentMethodGetUpdateUrlUserError? AsCustomerPaymentMethodGetUpdateUrlUserError() => this as CustomerPaymentMethodGetUpdateUrlUserError;
         public CustomerPaymentMethodRemoteUserError? AsCustomerPaymentMethodRemoteUserError() => this as CustomerPaymentMethodRemoteUserError;
         public CustomerPaymentMethodUserError? AsCustomerPaymentMethodUserError() => this as CustomerPaymentMethodUserError;
-        public CustomerRequestDataErasureUserError? AsCustomerRequestDataErasureUserError() => this as CustomerRequestDataErasureUserError;
         public CustomerSegmentMembersQueryUserError? AsCustomerSegmentMembersQueryUserError() => this as CustomerSegmentMembersQueryUserError;
         public CustomerSmsMarketingConsentError? AsCustomerSmsMarketingConsentError() => this as CustomerSmsMarketingConsentError;
         public DelegateAccessTokenCreateUserError? AsDelegateAccessTokenCreateUserError() => this as DelegateAccessTokenCreateUserError;
@@ -16077,8 +14524,6 @@ namespace ShopifySharp.GraphQL
         public ErrorsServerPixelUserError? AsErrorsServerPixelUserError() => this as ErrorsServerPixelUserError;
         public ErrorsWebPixelUserError? AsErrorsWebPixelUserError() => this as ErrorsWebPixelUserError;
         public FilesUserError? AsFilesUserError() => this as FilesUserError;
-        public FulfillmentConstraintRuleCreateUserError? AsFulfillmentConstraintRuleCreateUserError() => this as FulfillmentConstraintRuleCreateUserError;
-        public FulfillmentConstraintRuleDeleteUserError? AsFulfillmentConstraintRuleDeleteUserError() => this as FulfillmentConstraintRuleDeleteUserError;
         public FulfillmentOrderHoldUserError? AsFulfillmentOrderHoldUserError() => this as FulfillmentOrderHoldUserError;
         public FulfillmentOrderLineItemsPreparedForPickupUserError? AsFulfillmentOrderLineItemsPreparedForPickupUserError() => this as FulfillmentOrderLineItemsPreparedForPickupUserError;
         public FulfillmentOrderMergeUserError? AsFulfillmentOrderMergeUserError() => this as FulfillmentOrderMergeUserError;
@@ -16092,7 +14537,6 @@ namespace ShopifySharp.GraphQL
         public InventoryBulkToggleActivationUserError? AsInventoryBulkToggleActivationUserError() => this as InventoryBulkToggleActivationUserError;
         public InventoryMoveQuantitiesUserError? AsInventoryMoveQuantitiesUserError() => this as InventoryMoveQuantitiesUserError;
         public InventorySetOnHandQuantitiesUserError? AsInventorySetOnHandQuantitiesUserError() => this as InventorySetOnHandQuantitiesUserError;
-        public InventorySetScheduledChangesUserError? AsInventorySetScheduledChangesUserError() => this as InventorySetScheduledChangesUserError;
         public LocationActivateUserError? AsLocationActivateUserError() => this as LocationActivateUserError;
         public LocationAddUserError? AsLocationAddUserError() => this as LocationAddUserError;
         public LocationDeactivateUserError? AsLocationDeactivateUserError() => this as LocationDeactivateUserError;
@@ -16109,10 +14553,7 @@ namespace ShopifySharp.GraphQL
         public MetafieldDefinitionUpdateUserError? AsMetafieldDefinitionUpdateUserError() => this as MetafieldDefinitionUpdateUserError;
         public MetafieldsSetUserError? AsMetafieldsSetUserError() => this as MetafieldsSetUserError;
         public MetaobjectUserError? AsMetaobjectUserError() => this as MetaobjectUserError;
-        public OrderCancelUserError? AsOrderCancelUserError() => this as OrderCancelUserError;
         public OrderCreateMandatePaymentUserError? AsOrderCreateMandatePaymentUserError() => this as OrderCreateMandatePaymentUserError;
-        public OrderEditRemoveDiscountUserError? AsOrderEditRemoveDiscountUserError() => this as OrderEditRemoveDiscountUserError;
-        public OrderEditUpdateDiscountUserError? AsOrderEditUpdateDiscountUserError() => this as OrderEditUpdateDiscountUserError;
         public OrderInvoiceSendUserError? AsOrderInvoiceSendUserError() => this as OrderInvoiceSendUserError;
         public PaymentCustomizationError? AsPaymentCustomizationError() => this as PaymentCustomizationError;
         public PaymentReminderSendUserError? AsPaymentReminderSendUserError() => this as PaymentReminderSendUserError;
@@ -16137,17 +14578,13 @@ namespace ShopifySharp.GraphQL
         public PubSubWebhookSubscriptionCreateUserError? AsPubSubWebhookSubscriptionCreateUserError() => this as PubSubWebhookSubscriptionCreateUserError;
         public PubSubWebhookSubscriptionUpdateUserError? AsPubSubWebhookSubscriptionUpdateUserError() => this as PubSubWebhookSubscriptionUpdateUserError;
         public PublicationUserError? AsPublicationUserError() => this as PublicationUserError;
-        public QuantityPricingByVariantUserError? AsQuantityPricingByVariantUserError() => this as QuantityPricingByVariantUserError;
         public QuantityRuleUserError? AsQuantityRuleUserError() => this as QuantityRuleUserError;
         public ReturnUserError? AsReturnUserError() => this as ReturnUserError;
         public SellingPlanGroupUserError? AsSellingPlanGroupUserError() => this as SellingPlanGroupUserError;
         public ShopPolicyUserError? AsShopPolicyUserError() => this as ShopPolicyUserError;
         public ShopResourceFeedbackCreateUserError? AsShopResourceFeedbackCreateUserError() => this as ShopResourceFeedbackCreateUserError;
         public StandardMetafieldDefinitionEnableUserError? AsStandardMetafieldDefinitionEnableUserError() => this as StandardMetafieldDefinitionEnableUserError;
-        public SubscriptionBillingCycleSkipUserError? AsSubscriptionBillingCycleSkipUserError() => this as SubscriptionBillingCycleSkipUserError;
-        public SubscriptionBillingCycleUnskipUserError? AsSubscriptionBillingCycleUnskipUserError() => this as SubscriptionBillingCycleUnskipUserError;
         public SubscriptionBillingCycleUserError? AsSubscriptionBillingCycleUserError() => this as SubscriptionBillingCycleUserError;
-        public SubscriptionContractStatusUpdateUserError? AsSubscriptionContractStatusUpdateUserError() => this as SubscriptionContractStatusUpdateUserError;
         public SubscriptionContractUserError? AsSubscriptionContractUserError() => this as SubscriptionContractUserError;
         public SubscriptionDraftUserError? AsSubscriptionDraftUserError() => this as SubscriptionDraftUserError;
         public TaxAppConfigureUserError? AsTaxAppConfigureUserError() => this as TaxAppConfigureUserError;
@@ -16158,7 +14595,6 @@ namespace ShopifySharp.GraphQL
         public UrlRedirectImportUserError? AsUrlRedirectImportUserError() => this as UrlRedirectImportUserError;
         public UrlRedirectUserError? AsUrlRedirectUserError() => this as UrlRedirectUserError;
         public UserError? AsUserError() => this as UserError;
-        public ValidationUserError? AsValidationUserError() => this as ValidationUserError;
         ///<summary>
         ///The path to the input field that caused the error.
         ///</summary>
@@ -18244,60 +16680,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///An amount that's allocated to a line item based on an associated discount application.
-    ///</summary>
-    public class FinancialSummaryDiscountAllocation : GraphQLObject<FinancialSummaryDiscountAllocation>
-    {
-        ///<summary>
-        ///The money amount that's allocated per unit on the associated line based on the discount application in shop and presentment currencies. If the allocated amount for the line cannot be evenly divided by the quantity, then this amount will be an approximate amount, avoiding fractional pennies. For example, if the associated line had a quantity of 3 with a discount of 4 cents, then the discount distribution would be [0.01, 0.01, 0.02]. This field returns the highest number of the distribution. In this example, this would be 0.02.
-        ///</summary>
-        public MoneyBag? approximateAllocatedAmountPerItem { get; set; }
-        ///<summary>
-        ///The discount application that the allocated amount originated from.
-        ///</summary>
-        public FinancialSummaryDiscountApplication? discountApplication { get; set; }
-    }
-
-    ///<summary>
-    ///Discount applications capture the intentions of a discount source at
-    ///the time of application on an order's line items or shipping lines.
-    ///</summary>
-    public class FinancialSummaryDiscountApplication : GraphQLObject<FinancialSummaryDiscountApplication>
-    {
-        ///<summary>
-        ///The method by which the discount's value is applied to its entitled items.
-        ///</summary>
-        public DiscountApplicationAllocationMethod? allocationMethod { get; set; }
-        ///<summary>
-        ///How the discount amount is distributed on the discounted lines.
-        ///</summary>
-        public DiscountApplicationTargetSelection? targetSelection { get; set; }
-        ///<summary>
-        ///Whether the discount is applied on line items or shipping lines.
-        ///</summary>
-        public DiscountApplicationTargetType? targetType { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `flowGenerateSignature` mutation.
-    ///</summary>
-    public class FlowGenerateSignaturePayload : GraphQLObject<FlowGenerateSignaturePayload>
-    {
-        ///<summary>
-        ///The payload used to generate the signature.
-        ///</summary>
-        public string? payload { get; set; }
-        ///<summary>
-        ///The generated signature.
-        ///</summary>
-        public string? signature { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///Return type for `flowTriggerReceive` mutation.
     ///</summary>
     public class FlowTriggerReceivePayload : GraphQLObject<FlowTriggerReceivePayload>
@@ -18432,155 +16814,6 @@ namespace ShopifySharp.GraphQL
         ///Information to aid in pagination.
         ///</summary>
         public PageInfo? pageInfo { get; set; }
-    }
-
-    ///<summary>
-    ///A fulfillment constraint rule.
-    ///</summary>
-    public class FulfillmentConstraintRule : GraphQLObject<FulfillmentConstraintRule>, IHasMetafields, INode
-    {
-        ///<summary>
-        ///The ID for the fulfillment constraint function.
-        ///</summary>
-        public ShopifyFunction? function { get; set; }
-        ///<summary>
-        ///A globally-unique ID.
-        ///</summary>
-        public string? id { get; set; }
-        ///<summary>
-        ///Returns a metafield by namespace and key that belongs to the resource.
-        ///</summary>
-        public Metafield? metafield { get; set; }
-        ///<summary>
-        ///List of metafields that belong to the resource.
-        ///</summary>
-        public MetafieldConnection? metafields { get; set; }
-
-        ///<summary>
-        ///Returns a private metafield by namespace and key that belongs to the resource.
-        ///</summary>
-        [Obsolete("Metafields created using a reserved namespace are private by default. See our guide for\n[migrating private metafields](https://shopify.dev/docs/apps/custom-data/metafields/migrate-private-metafields).")]
-        public PrivateMetafield? privateMetafield { get; set; }
-
-        ///<summary>
-        ///List of private metafields that belong to the resource.
-        ///</summary>
-        [Obsolete("Metafields created using a reserved namespace are private by default. See our guide for\n[migrating private metafields](https://shopify.dev/docs/apps/custom-data/metafields/migrate-private-metafields).")]
-        public PrivateMetafieldConnection? privateMetafields { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `fulfillmentConstraintRuleCreate` mutation.
-    ///</summary>
-    public class FulfillmentConstraintRuleCreatePayload : GraphQLObject<FulfillmentConstraintRuleCreatePayload>
-    {
-        ///<summary>
-        ///The newly created fulfillment constraint rule.
-        ///</summary>
-        public FulfillmentConstraintRule? fulfillmentConstraintRule { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<FulfillmentConstraintRuleCreateUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `FulfillmentConstraintRuleCreate`.
-    ///</summary>
-    public class FulfillmentConstraintRuleCreateUserError : GraphQLObject<FulfillmentConstraintRuleCreateUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public FulfillmentConstraintRuleCreateUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `FulfillmentConstraintRuleCreateUserError`.
-    ///</summary>
-    public enum FulfillmentConstraintRuleCreateUserErrorCode
-    {
-        ///<summary>
-        ///Failed to create fulfillment constraint rule due to invalid input.
-        ///</summary>
-        INPUT_INVALID,
-        ///<summary>
-        ///No Shopify Function found for provided function_id.
-        ///</summary>
-        FUNCTION_NOT_FOUND,
-        ///<summary>
-        ///A fulfillment constraint rule already exists for the provided function_id.
-        ///</summary>
-        FUNCTION_ALREADY_REGISTERED,
-        ///<summary>
-        ///Function does not implement the required interface for this fulfillment constraint rule.
-        ///</summary>
-        FUNCTION_DOES_NOT_IMPLEMENT,
-        ///<summary>
-        ///Shop must be on a Shopify Plus plan to activate functions from a custom app.
-        ///</summary>
-        CUSTOM_APP_FUNCTION_NOT_ELIGIBLE,
-        ///<summary>
-        ///Function is pending deletion and cannot have new rules created against it.
-        ///</summary>
-        FUNCTION_PENDING_DELETION,
-    }
-
-    ///<summary>
-    ///Return type for `fulfillmentConstraintRuleDelete` mutation.
-    ///</summary>
-    public class FulfillmentConstraintRuleDeletePayload : GraphQLObject<FulfillmentConstraintRuleDeletePayload>
-    {
-        ///<summary>
-        ///Whether or not the fulfillment constraint rule was successfully deleted.
-        ///</summary>
-        public bool? success { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<FulfillmentConstraintRuleDeleteUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `FulfillmentConstraintRuleDelete`.
-    ///</summary>
-    public class FulfillmentConstraintRuleDeleteUserError : GraphQLObject<FulfillmentConstraintRuleDeleteUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public FulfillmentConstraintRuleDeleteUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `FulfillmentConstraintRuleDeleteUserError`.
-    ///</summary>
-    public enum FulfillmentConstraintRuleDeleteUserErrorCode
-    {
-        ///<summary>
-        ///Could not find fulfillment constraint rule for provided id.
-        ///</summary>
-        NOT_FOUND,
-        ///<summary>
-        ///Unauthorized app scope.
-        ///</summary>
-        UNAUTHORIZED_APP_SCOPE,
     }
 
     ///<summary>
@@ -18900,10 +17133,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         ONLINE_STORE_POST_PURCHASE_CROSS_SELL,
         ///<summary>
-        ///The fulfillment hold is applied because of return items not yet received during an exchange.
-        ///</summary>
-        AWAITING_RETURN_ITEMS,
-        ///<summary>
         ///The fulfillment hold is applied for another reason.
         ///</summary>
         OTHER,
@@ -19164,10 +17393,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public FulfillmentOrderAssignedLocation? assignedLocation { get; set; }
         ///<summary>
-        ///ID of the channel that created the order.
-        ///</summary>
-        public string? channelId { get; set; }
-        ///<summary>
         ///Date and time when the fulfillment order was created.
         ///</summary>
         public DateTime? createdAt { get; set; }
@@ -19191,10 +17416,6 @@ namespace ShopifySharp.GraphQL
         ///The fulfillment holds applied on the fulfillment order.
         ///</summary>
         public IEnumerable<FulfillmentHold>? fulfillmentHolds { get; set; }
-        ///<summary>
-        ///Fulfillment orders eligible for merging with the given fulfillment order.
-        ///</summary>
-        public FulfillmentOrderConnection? fulfillmentOrdersForMerge { get; set; }
         ///<summary>
         ///A list of fulfillments for the fulfillment order.
         ///</summary>
@@ -19223,21 +17444,6 @@ namespace ShopifySharp.GraphQL
         ///The order that's associated with the fulfillment order.
         ///</summary>
         public Order? order { get; set; }
-        ///<summary>
-        ///ID of the order that's associated with the fulfillment order.
-        ///</summary>
-        public string? orderId { get; set; }
-        ///<summary>
-        ///The unique identifier for the order that appears on the order page in the Shopify admin and the <b>Order status</b> page.
-        ///For example, "#1001", "EN1001", or "1001-A".
-        ///This value isn't unique across multiple stores.
-        ///</summary>
-        public string? orderName { get; set; }
-        ///<summary>
-        ///The date and time when the order was processed.
-        ///This date and time might not match the date and time when the order was created.
-        ///</summary>
-        public DateTime? orderProcessedAt { get; set; }
         ///<summary>
         ///The request status of the fulfillment order.
         ///</summary>
@@ -19639,10 +17845,6 @@ namespace ShopifySharp.GraphQL
     public class FulfillmentOrderLineItem : GraphQLObject<FulfillmentOrderLineItem>, INode
     {
         ///<summary>
-        ///The financial summary for the Fulfillment Order's Line Items.
-        ///</summary>
-        public IEnumerable<FulfillmentOrderLineItemFinancialSummary>? financialSummaries { get; set; }
-        ///<summary>
         ///A globally-unique ID.
         ///</summary>
         public string? id { get; set; }
@@ -19660,11 +17862,9 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         [Obsolete("          As of API version 2023-01, this field has been deprecated. The order line item associated with a `FulfillmentOrderLineItem`\n          shouldn't be used to determine what to fulfill. Use the `FulfillmentOrderLineItem` and `FulfillmentOrder` objects\n          instead. An order `LineItem` represents a single line item on an order, but it doesn't represent what should be fulfilled.")]
         public LineItem? lineItem { get; set; }
-
         ///<summary>
         ///The variant unit price without discounts applied, in shop and presentment currencies.
         ///</summary>
-        [Obsolete("Use `financialSummaries` instead.")]
         public MoneyBag? originalUnitPriceSet { get; set; }
         ///<summary>
         ///The title of the product.
@@ -19739,29 +17939,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///The financial details of a fulfillment order line item.
-    ///</summary>
-    public class FulfillmentOrderLineItemFinancialSummary : GraphQLObject<FulfillmentOrderLineItemFinancialSummary>
-    {
-        ///<summary>
-        ///The approximate split price of a line item unit, in shop and presentment currencies. This value doesn't include discounts applied to the entire order.For the full picture of applied discounts, see discountAllocations.
-        ///</summary>
-        public MoneyBag? approximateDiscountedUnitPriceSet { get; set; }
-        ///<summary>
-        ///The discounts that have been allocated onto the line item by discount applications, not including order edits and refunds.
-        ///</summary>
-        public IEnumerable<FinancialSummaryDiscountAllocation>? discountAllocations { get; set; }
-        ///<summary>
-        ///The variant unit price without discounts applied, in shop and presentment currencies.
-        ///</summary>
-        public MoneyBag? originalUnitPriceSet { get; set; }
-        ///<summary>
-        ///Number of line items that this financial summary applies to.
-        ///</summary>
-        public int? quantity { get; set; }
-    }
-
-    ///<summary>
     ///A fulfillment order line item warning. For example, a warning about why a fulfillment request was rejected.
     ///</summary>
     public class FulfillmentOrderLineItemWarning : GraphQLObject<FulfillmentOrderLineItemWarning>
@@ -19831,15 +18008,6 @@ namespace ShopifySharp.GraphQL
     public class FulfillmentOrderLocationForMove : GraphQLObject<FulfillmentOrderLocationForMove>
     {
         ///<summary>
-        ///Fulfillment order line items that can be moved from their current location to the given location.
-        ///</summary>
-        public FulfillmentOrderLineItemConnection? availableLineItems { get; set; }
-        ///<summary>
-        ///Total number of fulfillment order line items that can be moved from their current assigned location to the
-        ///given location.
-        ///</summary>
-        public ulong? availableLineItemsCount { get; set; }
-        ///<summary>
         ///The location being considered as the fulfillment order's new assigned location.
         ///</summary>
         public Location? location { get; set; }
@@ -19852,15 +18020,6 @@ namespace ShopifySharp.GraphQL
         ///Whether the fulfillment order can be moved to the location.
         ///</summary>
         public bool? movable { get; set; }
-        ///<summary>
-        ///Fulfillment order line items that cannot be moved from their current location to the given location.
-        ///</summary>
-        public FulfillmentOrderLineItemConnection? unavailableLineItems { get; set; }
-        ///<summary>
-        ///Total number of fulfillment order line items that can't be moved from their current assigned location to the
-        ///given location.
-        ///</summary>
-        public ulong? unavailableLineItemsCount { get; set; }
     }
 
     ///<summary>
@@ -20256,12 +18415,7 @@ namespace ShopifySharp.GraphQL
     public class FulfillmentOrderReschedulePayload : GraphQLObject<FulfillmentOrderReschedulePayload>
     {
         ///<summary>
-        ///A fulfillment order with the rescheduled line items.
-        ///
-        ///Fulfillment orders may be merged if they have the same `fulfillAt` datetime.
-        ///
-        ///If the fulfillment order is merged then the resulting fulfillment order will be returned.
-        ///Otherwise the original fulfillment order will be returned with an updated `fulfillAt` datetime.
+        ///The fulfillment order that was rescheduled.
         ///</summary>
         public FulfillmentOrder? fulfillmentOrder { get; set; }
         ///<summary>
@@ -20386,10 +18540,6 @@ namespace ShopifySharp.GraphQL
         ///The fulfillment order line item quantity is invalid.
         ///</summary>
         INVALID_LINE_ITEM_QUANTITY,
-        ///<summary>
-        ///The fulfillment order must have at least one line item input to split.
-        ///</summary>
-        NO_LINE_ITEMS_PROVIDED_TO_SPLIT,
     }
 
     ///<summary>
@@ -21471,7 +19621,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(PaymentCustomization), typeDiscriminator: "PaymentCustomization")]
     [JsonDerivedType(typeof(Product), typeDiscriminator: "Product")]
     [JsonDerivedType(typeof(ProductVariant), typeDiscriminator: "ProductVariant")]
-    [JsonDerivedType(typeof(Validation), typeDiscriminator: "Validation")]
     public interface IHasMetafieldDefinitions : IGraphQLObject
     {
         public Collection? AsCollection() => this as Collection;
@@ -21488,7 +19637,6 @@ namespace ShopifySharp.GraphQL
         public PaymentCustomization? AsPaymentCustomization() => this as PaymentCustomization;
         public Product? AsProduct() => this as Product;
         public ProductVariant? AsProductVariant() => this as ProductVariant;
-        public Validation? AsValidation() => this as Validation;
         ///<summary>
         ///List of metafield definitions.
         ///</summary>
@@ -21511,7 +19659,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(DiscountCodeNode), typeDiscriminator: "DiscountCodeNode")]
     [JsonDerivedType(typeof(DiscountNode), typeDiscriminator: "DiscountNode")]
     [JsonDerivedType(typeof(DraftOrder), typeDiscriminator: "DraftOrder")]
-    [JsonDerivedType(typeof(FulfillmentConstraintRule), typeDiscriminator: "FulfillmentConstraintRule")]
     [JsonDerivedType(typeof(Image), typeDiscriminator: "Image")]
     [JsonDerivedType(typeof(Location), typeDiscriminator: "Location")]
     [JsonDerivedType(typeof(Market), typeDiscriminator: "Market")]
@@ -21521,7 +19668,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(Product), typeDiscriminator: "Product")]
     [JsonDerivedType(typeof(ProductVariant), typeDiscriminator: "ProductVariant")]
     [JsonDerivedType(typeof(Shop), typeDiscriminator: "Shop")]
-    [JsonDerivedType(typeof(Validation), typeDiscriminator: "Validation")]
     public interface IHasMetafields : IGraphQLObject
     {
         public AppInstallation? AsAppInstallation() => this as AppInstallation;
@@ -21536,7 +19682,6 @@ namespace ShopifySharp.GraphQL
         public DiscountCodeNode? AsDiscountCodeNode() => this as DiscountCodeNode;
         public DiscountNode? AsDiscountNode() => this as DiscountNode;
         public DraftOrder? AsDraftOrder() => this as DraftOrder;
-        public FulfillmentConstraintRule? AsFulfillmentConstraintRule() => this as FulfillmentConstraintRule;
         public Image? AsImage() => this as Image;
         public Location? AsLocation() => this as Location;
         public Market? AsMarket() => this as Market;
@@ -21546,7 +19691,6 @@ namespace ShopifySharp.GraphQL
         public Product? AsProduct() => this as Product;
         public ProductVariant? AsProductVariant() => this as ProductVariant;
         public Shop? AsShop() => this as Shop;
-        public Validation? AsValidation() => this as Validation;
         ///<summary>
         ///Returns a metafield by namespace and key that belongs to the resource.
         ///</summary>
@@ -22262,10 +20406,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public IEnumerable<InventoryQuantity>? quantities { get; set; }
         ///<summary>
-        ///Scheduled changes for the requested quantity names.
-        ///</summary>
-        public InventoryScheduledChangeConnection? scheduledChanges { get; set; }
-        ///<summary>
         ///The date and time when the inventory level was updated.
         ///</summary>
         public DateTime? updatedAt { get; set; }
@@ -22428,12 +20568,8 @@ namespace ShopifySharp.GraphQL
     ///<summary>
     ///Represents a quantity of an inventory item at a specific location, for a specific name.
     ///</summary>
-    public class InventoryQuantity : GraphQLObject<InventoryQuantity>, INode
+    public class InventoryQuantity : GraphQLObject<InventoryQuantity>
     {
-        ///<summary>
-        ///A globally-unique ID.
-        ///</summary>
-        public string? id { get; set; }
         ///<summary>
         ///The [name](https://shopify.dev/docs/apps/fulfillment/inventory-management-apps#inventory-states)
         ///that identifies the inventory quantity.
@@ -22476,75 +20612,6 @@ namespace ShopifySharp.GraphQL
         ///[inventory queries and mutations](https://shopify.dev/docs/apps/fulfillment/inventory-management-apps#graphql-queries-and-mutations).
         ///</summary>
         public string? name { get; set; }
-    }
-
-    ///<summary>
-    ///Returns the scheduled changes to inventory states related to the ledger document.
-    ///</summary>
-    public class InventoryScheduledChange : GraphQLObject<InventoryScheduledChange>
-    {
-        ///<summary>
-        ///The date and time that the scheduled change is expected to happen.
-        ///</summary>
-        public DateTime? expectedAt { get; set; }
-        ///<summary>
-        ///The quantity
-        ///[name](https://shopify.dev/docs/apps/fulfillment/inventory-management-apps/quantities-states#move-inventory-quantities-between-states)
-        ///to transition from.
-        ///</summary>
-        public string? fromName { get; set; }
-        ///<summary>
-        ///The quantities of an inventory item that are related to a specific location.
-        ///</summary>
-        public InventoryLevel? inventoryLevel { get; set; }
-        ///<summary>
-        ///An active reference document associated with the inventory quantity. Must be a valid URI.
-        ///</summary>
-        public string? ledgerDocumentUri { get; set; }
-        ///<summary>
-        ///The quantity of the scheduled change associated with the ledger document in the `from_name` state.
-        ///</summary>
-        public int? quantity { get; set; }
-        ///<summary>
-        ///The quantity
-        ///[name](https://shopify.dev/docs/apps/fulfillment/inventory-management-apps/quantities-states#move-inventory-quantities-between-states)
-        ///to transition to.
-        ///</summary>
-        public string? toName { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type for paginating through multiple InventoryScheduledChanges.
-    ///</summary>
-    public class InventoryScheduledChangeConnection : GraphQLObject<InventoryScheduledChangeConnection>, IConnectionWithNodesAndEdges<InventoryScheduledChangeEdge, InventoryScheduledChange>
-    {
-        ///<summary>
-        ///A list of edges.
-        ///</summary>
-        public IEnumerable<InventoryScheduledChangeEdge>? edges { get; set; }
-        ///<summary>
-        ///A list of the nodes contained in InventoryScheduledChangeEdge.
-        ///</summary>
-        public IEnumerable<InventoryScheduledChange>? nodes { get; set; }
-        ///<summary>
-        ///Information to aid in pagination.
-        ///</summary>
-        public PageInfo? pageInfo { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type which holds one InventoryScheduledChange and a cursor during pagination.
-    ///</summary>
-    public class InventoryScheduledChangeEdge : GraphQLObject<InventoryScheduledChangeEdge>, IEdge<InventoryScheduledChange>
-    {
-        ///<summary>
-        ///A cursor for use in pagination.
-        ///</summary>
-        public string? cursor { get; set; }
-        ///<summary>
-        ///The item at the end of InventoryScheduledChangeEdge.
-        ///</summary>
-        public InventoryScheduledChange? node { get; set; }
     }
 
     ///<summary>
@@ -22622,95 +20689,6 @@ namespace ShopifySharp.GraphQL
         ///The total quantity can't be higher than 1,000,000,000.
         ///</summary>
         INVALID_QUANTITY_TOO_HIGH,
-    }
-
-    ///<summary>
-    ///Return type for `inventorySetScheduledChanges` mutation.
-    ///</summary>
-    public class InventorySetScheduledChangesPayload : GraphQLObject<InventorySetScheduledChangesPayload>
-    {
-        ///<summary>
-        ///The scheduled changes that were created.
-        ///</summary>
-        public IEnumerable<InventoryScheduledChange>? scheduledChanges { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<InventorySetScheduledChangesUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `InventorySetScheduledChanges`.
-    ///</summary>
-    public class InventorySetScheduledChangesUserError : GraphQLObject<InventorySetScheduledChangesUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public InventorySetScheduledChangesUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `InventorySetScheduledChangesUserError`.
-    ///</summary>
-    public enum InventorySetScheduledChangesUserErrorCode
-    {
-        ///<summary>
-        ///There was an error updating the scheduled changes.
-        ///</summary>
-        ERROR_UPDATING_SCHEDULED,
-        ///<summary>
-        ///The from_name and to_name can't be the same.
-        ///</summary>
-        SAME_FROM_TO_NAMES,
-        ///<summary>
-        ///The specified fromName is invalid.
-        ///</summary>
-        INVALID_FROM_NAME,
-        ///<summary>
-        ///The specified toName is invalid.
-        ///</summary>
-        INVALID_TO_NAME,
-        ///<summary>
-        ///The item can only have one scheduled change for %{to_name} as the to_name.
-        ///</summary>
-        DUPLICATE_TO_NAME,
-        ///<summary>
-        ///The specified reason is invalid. Valid values: %{reasons}.
-        ///</summary>
-        INVALID_REASON,
-        ///<summary>
-        ///The item can only have one scheduled change for %{from_name} as the fromName.
-        ///</summary>
-        DUPLICATE_FROM_NAME,
-        ///<summary>
-        ///The location couldn't be found.
-        ///</summary>
-        LOCATION_NOT_FOUND,
-        ///<summary>
-        ///The inventory item was not found at the location specified.
-        ///</summary>
-        INVENTORY_STATE_NOT_FOUND,
-        ///<summary>
-        ///At least 1 item must be provided.
-        ///</summary>
-        ITEMS_EMPTY,
-        ///<summary>
-        ///The inventory item was not found.
-        ///</summary>
-        INVENTORY_ITEM_NOT_FOUND,
-        ///<summary>
-        ///The specified field is invalid.
-        ///</summary>
-        INCLUSION,
     }
 
     ///<summary>
@@ -23445,10 +21423,6 @@ namespace ShopifySharp.GraphQL
         [Obsolete("Use `discountedUnitPriceSet` instead.")]
         public decimal? discountedUnitPrice { get; set; }
         ///<summary>
-        ///The approximate split price of the line item, including any discounts that apply to the entire order.
-        ///</summary>
-        public MoneyBag? discountedUnitPriceAfterAllDiscountsSet { get; set; }
-        ///<summary>
         ///The approximate split price of a line item unit, in shop and presentment currencies. This value doesn't include discounts applied to the entire order.
         ///</summary>
         public MoneyBag? discountedUnitPriceSet { get; set; }
@@ -23675,14 +21649,6 @@ namespace ShopifySharp.GraphQL
         ///Title of the line item group.
         ///</summary>
         public string? title { get; set; }
-        ///<summary>
-        ///ID of the variant of the line item group.
-        ///</summary>
-        public string? variantId { get; set; }
-        ///<summary>
-        ///SKU of the variant of the line item group.
-        ///</summary>
-        public string? variantSku { get; set; }
     }
 
     ///<summary>
@@ -24725,10 +22691,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         CANNOT_DISABLE_ONLINE_ORDER_FULFILLMENT,
         ///<summary>
-        ///Cannot modify the online order fulfillment preference for fulfillment service locations.
-        ///</summary>
-        CANNOT_MODIFY_ONLINE_ORDER_FULFILLMENT_FOR_FS_LOCATION,
-        ///<summary>
         ///The type is invalid.
         ///</summary>
         INVALID_TYPE,
@@ -25111,14 +23073,6 @@ namespace ShopifySharp.GraphQL
         ///If it's the primary market and it has multiple web presences, then this field will return the primary domain web presence.
         ///</summary>
         public MarketWebPresence? webPresence { get; set; }
-        ///<summary>
-        ///The market’s web presences, which defines its SEO strategy. This can be a different domain,
-        ///subdomain, or subfolders of the primary domain. Each web presence comprises one or more
-        ///language variants. If a market doesn't have any web presences, then the market is accessible on the
-        ///primary market's domains using [country
-        ///selectors](https://shopify.dev/themes/internationalization/multiple-currencies-languages#the-country-selector).
-        ///</summary>
-        public MarketWebPresenceConnection? webPresences { get; set; }
     }
 
     ///<summary>
@@ -25238,8 +23192,7 @@ namespace ShopifySharp.GraphQL
         ///Whether or not local currencies are enabled. If enabled, then prices will
         ///be converted to give each customer the best experience based on their
         ///region. If disabled, then all customers in this market will see prices
-        ///in the market's base currency. For single country markets this will be true when
-        ///the market's base currency is the same as the default currency for the region.
+        ///in the market's base currency.
         ///</summary>
         public bool? localCurrencies { get; set; }
     }
@@ -25420,10 +23373,6 @@ namespace ShopifySharp.GraphQL
         ///A metafield. Market localizable fields: `value`.
         ///</summary>
         METAFIELD,
-        ///<summary>
-        ///A Metaobject. Market Localizable fields are determined by the Metaobject type.
-        ///</summary>
-        METAOBJECT,
     }
 
     ///<summary>
@@ -25593,21 +23542,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `marketRegionsDelete` mutation.
-    ///</summary>
-    public class MarketRegionsDeletePayload : GraphQLObject<MarketRegionsDeletePayload>
-    {
-        ///<summary>
-        ///The ID of the deleted market region.
-        ///</summary>
-        public IEnumerable<string>? deletedIds { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<MarketUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///Return type for `marketUpdate` mutation.
     ///</summary>
     public class MarketUpdatePayload : GraphQLObject<MarketUpdatePayload>
@@ -25727,18 +23661,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         CANNOT_ADD_WEB_PRESENCE_TO_PRIMARY_MARKET,
         ///<summary>
-        ///Can't add another web presence to the market.
-        ///</summary>
-        MARKET_REACHED_WEB_PRESENCE_LIMIT,
-        ///<summary>
-        ///Can't have multiple subfolder web presences per market.
-        ///</summary>
-        CANNOT_HAVE_MULTIPLE_SUBFOLDERS_PER_MARKET,
-        ///<summary>
-        ///Can't have both subfolder and domain web presences.
-        ///</summary>
-        CANNOT_HAVE_BOTH_SUBFOLDER_AND_DOMAIN_WEB_PRESENCES,
-        ///<summary>
         ///One of `subfolderSuffix` or `domainId` is required.
         ///</summary>
         REQUIRES_DOMAIN_OR_SUBFOLDER,
@@ -25806,7 +23728,7 @@ namespace ShopifySharp.GraphQL
         ///<summary>
         ///The ISO code for the default locale. When a domain is used, this is the locale that will
         ///be used when the domain root is accessed. For example, if French is the default locale,
-        ///and `example.ca` is the market’s domain, then `example.ca` will load in French.
+        ///and `example.ca` is the market’s domian, then `example.ca` will load in French.
         ///</summary>
         public string? defaultLocale { get; set; }
         ///<summary>
@@ -25830,25 +23752,6 @@ namespace ShopifySharp.GraphQL
         ///The market-specific suffix of the subfolders defined by the web presence. Example: in `/en-us` the subfolder suffix is `us`. This field will be null if `domain` isn't null.
         ///</summary>
         public string? subfolderSuffix { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type for paginating through multiple MarketWebPresences.
-    ///</summary>
-    public class MarketWebPresenceConnection : GraphQLObject<MarketWebPresenceConnection>, IConnectionWithNodesAndEdges<MarketWebPresenceEdge, MarketWebPresence>
-    {
-        ///<summary>
-        ///A list of edges.
-        ///</summary>
-        public IEnumerable<MarketWebPresenceEdge>? edges { get; set; }
-        ///<summary>
-        ///A list of the nodes contained in MarketWebPresenceEdge.
-        ///</summary>
-        public IEnumerable<MarketWebPresence>? nodes { get; set; }
-        ///<summary>
-        ///Information to aid in pagination.
-        ///</summary>
-        public PageInfo? pageInfo { get; set; }
     }
 
     ///<summary>
@@ -25886,21 +23789,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///An auto-generated type which holds one MarketWebPresence and a cursor during pagination.
-    ///</summary>
-    public class MarketWebPresenceEdge : GraphQLObject<MarketWebPresenceEdge>, IEdge<MarketWebPresence>
-    {
-        ///<summary>
-        ///A cursor for use in pagination.
-        ///</summary>
-        public string? cursor { get; set; }
-        ///<summary>
-        ///The item at the end of MarketWebPresenceEdge.
-        ///</summary>
-        public MarketWebPresence? node { get; set; }
-    }
-
-    ///<summary>
     ///The URL for the homepage of the online store in the context of a particular market and a
     ///particular locale.
     ///</summary>
@@ -25929,21 +23817,6 @@ namespace ShopifySharp.GraphQL
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<MarketUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `marketingActivitiesDeleteAllExternal` mutation.
-    ///</summary>
-    public class MarketingActivitiesDeleteAllExternalPayload : GraphQLObject<MarketingActivitiesDeleteAllExternalPayload>
-    {
-        ///<summary>
-        ///The asynchronous job that performs the deletion. The status of the job may be used to determine when it's safe again to create new activities.
-        ///</summary>
-        public Job? job { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<MarketingActivityUserError>? userErrors { get; set; }
     }
 
     ///<summary>
@@ -25981,10 +23854,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public string? formData { get; set; }
         ///<summary>
-        ///The hierarchy level of the marketing activity.
-        ///</summary>
-        public MarketingActivityHierarchyLevel? hierarchyLevel { get; set; }
-        ///<summary>
         ///A globally-unique ID.
         ///</summary>
         public string? id { get; set; }
@@ -25992,28 +23861,14 @@ namespace ShopifySharp.GraphQL
         ///Whether the marketing activity is in the main workflow version of the marketing automation.
         ///</summary>
         public bool? inMainWorkflowVersion { get; set; }
-
         ///<summary>
-        ///The medium through which the marketing activity and event reached consumers. This is used for reporting aggregation.
+        ///The available marketing channels for a marketing activity.
         ///</summary>
-        [Obsolete("Use `marketingChannelType` instead.")]
         public MarketingChannel? marketingChannel { get; set; }
-        ///<summary>
-        ///The medium through which the marketing activity and event reached consumers. This is used for reporting aggregation.
-        ///</summary>
-        public MarketingChannel? marketingChannelType { get; set; }
         ///<summary>
         ///Associated marketing event of this marketing activity.
         ///</summary>
         public MarketingEvent? marketingEvent { get; set; }
-        ///<summary>
-        ///ID of the parent activity of this marketing activity.
-        ///</summary>
-        public string? parentActivityId { get; set; }
-        ///<summary>
-        ///ID of the parent activity of this marketing activity.
-        ///</summary>
-        public string? parentRemoteId { get; set; }
         ///<summary>
         ///A contextual description of the marketing activity based on the platform and tactic used.
         ///</summary>
@@ -26058,10 +23913,6 @@ namespace ShopifySharp.GraphQL
         ///The date and time when the marketing activity was updated.
         ///</summary>
         public DateTime? updatedAt { get; set; }
-        ///<summary>
-        ///A URL parameter value associated with this marketing activity.
-        ///</summary>
-        public string? urlParameterValue { get; set; }
         ///<summary>
         ///The set of [Urchin Tracking Module](
         ///          https://help.shopify.com/https://en.wikipedia.org/wiki/UTM_parameters
@@ -26124,21 +23975,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `marketingActivityDeleteExternal` mutation.
-    ///</summary>
-    public class MarketingActivityDeleteExternalPayload : GraphQLObject<MarketingActivityDeleteExternalPayload>
-    {
-        ///<summary>
-        ///The ID of the marketing activity that was deleted, if one was deleted.
-        ///</summary>
-        public string? deletedMarketingActivityId { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<MarketingActivityUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///An auto-generated type which holds one MarketingActivity and a cursor during pagination.
     ///</summary>
     public class MarketingActivityEdge : GraphQLObject<MarketingActivityEdge>, IEdge<MarketingActivity>
@@ -26193,56 +24029,6 @@ namespace ShopifySharp.GraphQL
         ///The list of errors returned by the app.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Set of possible statuses for an external marketing activity.
-    ///</summary>
-    public enum MarketingActivityExternalStatus
-    {
-        ///<summary>
-        ///This marketing activity is currently running.
-        ///</summary>
-        ACTIVE,
-        ///<summary>
-        ///This marketing activity has completed running.
-        ///</summary>
-        INACTIVE,
-        ///<summary>
-        ///This marketing activity is currently not running.
-        ///</summary>
-        PAUSED,
-        ///<summary>
-        ///This marketing activity is scheduled to run.
-        ///</summary>
-        SCHEDULED,
-        ///<summary>
-        ///This marketing activity was deleted and it was triggered from outside of Shopify.
-        ///</summary>
-        DELETED_EXTERNALLY,
-        ///<summary>
-        ///The marketing activity's status is unknown.
-        ///</summary>
-        UNDEFINED,
-    }
-
-    ///<summary>
-    ///Hierarchy levels for external marketing activities.
-    ///</summary>
-    public enum MarketingActivityHierarchyLevel
-    {
-        ///<summary>
-        ///An advertisement activity. Must be parented by an ad group or a campaign activity, and must be assigned tracking parameters (URL or UTM).
-        ///</summary>
-        AD,
-        ///<summary>
-        ///A group of advertisement activities. Must be parented by a campaign activity.
-        ///</summary>
-        AD_GROUP,
-        ///<summary>
-        ///A campaign activity. May contain either ad groups or ads as child activities. If childless, then the campaign activity should have tracking parameters assigned (URL or UTM) otherwise it won't appear in marketing reports.
-        ///</summary>
-        CAMPAIGN,
     }
 
     ///<summary>
@@ -26382,21 +24168,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `marketingActivityUpsertExternal` mutation.
-    ///</summary>
-    public class MarketingActivityUpsertExternalPayload : GraphQLObject<MarketingActivityUpsertExternalPayload>
-    {
-        ///<summary>
-        ///The external marketing activity that was created or updated.
-        ///</summary>
-        public MarketingActivity? marketingActivity { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<MarketingActivityUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///An error that occurs during the execution of a Shopify Marketing mutation.
     ///</summary>
     public class MarketingActivityUserError : GraphQLObject<MarketingActivityUserError>, IDisplayableError
@@ -26461,7 +24232,7 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///The medium through which the marketing activity and event reached consumers. This is used for reporting aggregation.
+    ///The available marketing channels for a marketing activity or event. A marketing channel is broad category of marketing, used for reporting aggregation.
     ///</summary>
     public enum MarketingChannel
     {
@@ -26493,43 +24264,39 @@ namespace ShopifySharp.GraphQL
     public class MarketingEngagement : GraphQLObject<MarketingEngagement>
     {
         ///<summary>
-        ///The total ad spend for the marketing content. Recurring weekly, monthly, or yearly spend needs to be divided into daily amounts.
+        ///The total ad spend for the day, if the marketing event is a paid ad with a daily spend.
         ///</summary>
         public MoneyV2? adSpend { get; set; }
         ///<summary>
-        ///The unique string identifier of the channel to which the engagement metrics are being provided. This should be set when and only when providing channel-level engagements. This should be nil when providing activity-level engagements. For the correct handle for your channel, contact your partner manager.
-        ///</summary>
-        public string? channelHandle { get; set; }
-        ///<summary>
-        ///The total number of interactions, such as a button press or a screen touch, that occurred on the marketing content.
+        ///The total number of clicks on the marketing event for the day.
         ///</summary>
         public int? clicksCount { get; set; }
         ///<summary>
-        ///The total number of comments on the marketing content.
+        ///The total number of comments on marketing content for the day.
         ///</summary>
         public int? commentsCount { get; set; }
         ///<summary>
-        ///The total number of complaints on the marketing content. For message-based platforms such as email or SMS, this represents the number of marketing emails or messages that were marked as spam. For social media platforms, this represents the number of dislikes or the number of times marketing content was reported.
+        ///The total number of complaints for the day. For message-based platforms such as email or SMS, this represents the number of marketing emails or messages that were marked as spam. For social media platforms, this represents the number of dislikes or the number of times marketing content was reported.
         ///</summary>
         public int? complaintsCount { get; set; }
         ///<summary>
-        ///The total number of fails for the marketing content. For message-based platforms such as email or SMS, this represents the number of bounced marketing emails or messages.
+        ///The total number of fails for the day. For message-based platforms such as email or SMS, this represents the number of bounced marketing emails or messages.
         ///</summary>
         public int? failsCount { get; set; }
         ///<summary>
-        ///The total number of favorites, likes, saves, or bookmarks on the marketing content.
+        ///The total number of favorites, likes, saves, or bookmarks for the day.
         ///</summary>
         public int? favoritesCount { get; set; }
         ///<summary>
-        ///The number of customers that have placed their first order. Doesn't include adjustments such as edits, exchanges, or returns.
+        ///The date time at which the data was fetched.
         ///</summary>
-        public decimal? firstTimeCustomers { get; set; }
+        public DateTime? fetchedAt { get; set; }
         ///<summary>
-        ///The total number of times marketing content was displayed to users, whether or not an interaction occurred. For message-based platforms such as email or SMS, this represents the number of marketing emails or messages that were delivered.
+        ///The total number of impressions for the day.
         ///</summary>
         public int? impressionsCount { get; set; }
         ///<summary>
-        ///Whether the engagements are reported as lifetime totals rather than daily increments.
+        ///Whether the engagements are reported as lifetime values rather than daily totals.
         ///</summary>
         public bool? isCumulative { get; set; }
         ///<summary>
@@ -26541,47 +24308,31 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public DateOnly? occurredOn { get; set; }
         ///<summary>
-        ///The number of orders generated from the marketing content.
-        ///</summary>
-        public decimal? orders { get; set; }
-        ///<summary>
-        ///The number of returning customers that have placed an order. Doesn't include adjustments such as edits, exchanges, or returns.
-        ///</summary>
-        public decimal? returningCustomers { get; set; }
-        ///<summary>
-        ///The amount of sales generated from the marketing content.
-        ///</summary>
-        public MoneyV2? sales { get; set; }
-        ///<summary>
-        ///The total number of marketing emails or messages that were sent.
+        ///The total number of marketing emails or messages that were sent for the day.
         ///</summary>
         public int? sendsCount { get; set; }
         ///<summary>
-        ///The number of online store sessions generated from the marketing content.
-        ///</summary>
-        public int? sessionsCount { get; set; }
-        ///<summary>
-        ///The total number of times marketing content was distributed or reposted to either one's own network of followers through a social media platform or other digital channels. For message-based platforms such as email or SMS, this represents the number of times marketing emails or messages were forwarded.
+        ///The total number of times marketing content was distributed or reposted to either one's own network of followers through a social media platform or other digital channels for the day. For message-based platforms such as email or SMS, this represents the number of times marketing emails or messages were forwarded.
         ///</summary>
         public int? sharesCount { get; set; }
         ///<summary>
-        ///The total number of unique clicks on the marketing content.
+        ///The total number of unique clicks on marketing content for the day.
         ///</summary>
         public int? uniqueClicksCount { get; set; }
         ///<summary>
-        ///The total number of all users who saw marketing content since it was published. For  message-based platforms such as email or SMS, this represents the number of unique users that opened a  marketing email or message. For video-based content, this represents the number of unique users that  played video content.
+        ///The total number of unique views for the day. For message-based platforms such as  email or SMS, this represents the number of unique users that opened a marketing email or message. For video-based content, this represents the number of unique users that played video content.
         ///</summary>
         public int? uniqueViewsCount { get; set; }
         ///<summary>
-        ///The total number of unsubscribes on the marketing content. For social media platforms, this represents the number of unfollows.
+        ///The total number of unsubscribes for the day. For social media platforms, this represents the number of unfollows.
         ///</summary>
         public int? unsubscribesCount { get; set; }
         ///<summary>
-        ///The time difference, in hours, between UTC and the time zone used to aggregate these metrics.
+        ///The UTC Offset that the app is using to determine which date to allocate spend to.
         ///</summary>
         public TimeSpan? utcOffset { get; set; }
         ///<summary>
-        ///The total number of views on the marketing content. For message-based platforms such as email or SMS, this represents the number of times marketing emails or messages were opened. For video-based content, this represents the number of times videos were played.
+        ///The total number of views for the day. For message-based platforms such as email or SMS, this represents the number of times marketing emails or messages were opened. For video-based content, this represents the number of times videos were played.
         ///</summary>
         public int? viewsCount { get; set; }
     }
@@ -26592,28 +24343,13 @@ namespace ShopifySharp.GraphQL
     public class MarketingEngagementCreatePayload : GraphQLObject<MarketingEngagementCreatePayload>
     {
         ///<summary>
-        ///The marketing engagement that was created. This represents customer activity taken on a marketing activity or a marketing channel.
+        ///The marketing engagement that was created.
         ///</summary>
         public MarketingEngagement? marketingEngagement { get; set; }
         ///<summary>
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `marketingEngagementsDelete` mutation.
-    ///</summary>
-    public class MarketingEngagementsDeletePayload : GraphQLObject<MarketingEngagementsDeletePayload>
-    {
-        ///<summary>
-        ///Informational message about the engagement data that has been marked for deletion.
-        ///</summary>
-        public string? result { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<MarketingActivityUserError>? userErrors { get; set; }
     }
 
     ///<summary>
@@ -26625,16 +24361,10 @@ namespace ShopifySharp.GraphQL
         ///The app that the marketing event is attributed to.
         ///</summary>
         public App? app { get; set; }
-
         ///<summary>
-        ///The medium through which the marketing activity and event reached consumers. This is used for reporting aggregation.
+        ///The marketing channel used by the marketing event.
         ///</summary>
-        [Obsolete("Use `marketingChannelType` instead.")]
         public MarketingChannel? channel { get; set; }
-        ///<summary>
-        ///The unique string identifier of the channel to which this activity belongs. For the correct handle for your channel, contact your partner manager.
-        ///</summary>
-        public string? channelHandle { get; set; }
         ///<summary>
         ///A human-readable description of the marketing event.
         ///</summary>
@@ -26655,10 +24385,6 @@ namespace ShopifySharp.GraphQL
         ///The URL where the marketing event can be managed.
         ///</summary>
         public string? manageUrl { get; set; }
-        ///<summary>
-        ///The medium through which the marketing activity and event reached consumers. This is used for reporting aggregation.
-        ///</summary>
-        public MarketingChannel? marketingChannelType { get; set; }
         ///<summary>
         ///The URL where the marketing event can be previewed.
         ///</summary>
@@ -27211,10 +24937,6 @@ namespace ShopifySharp.GraphQL
         ///The size of the original file in bytes.
         ///</summary>
         public int? fileSize { get; set; }
-        ///<summary>
-        ///The URL of the original image, valid only for a short period.
-        ///</summary>
-        public string? url { get; set; }
     }
 
     ///<summary>
@@ -27525,30 +25247,6 @@ namespace ShopifySharp.GraphQL
         ///The default admin access setting used for the metafields under this definition.
         ///</summary>
         public MetafieldAdminAccess? admin { get; set; }
-        ///<summary>
-        ///The explicit grants for this metafield definition, superseding the default admin access
-        ///for the specified grantees.
-        ///</summary>
-        public IEnumerable<MetafieldAccessGrant>? grants { get; set; }
-        ///<summary>
-        ///The storefront access setting used for the metafields under this definition.
-        ///</summary>
-        public MetafieldStorefrontAccess? storefront { get; set; }
-    }
-
-    ///<summary>
-    ///An explicit access grant for the metafields under this definition.
-    ///</summary>
-    public class MetafieldAccessGrant : GraphQLObject<MetafieldAccessGrant>
-    {
-        ///<summary>
-        ///The level of access the grantee has.
-        ///</summary>
-        public MetafieldGrantAccessLevel? access { get; set; }
-        ///<summary>
-        ///The grantee being granted access.
-        ///</summary>
-        public string? grantee { get; set; }
     }
 
     ///<summary>
@@ -27663,11 +25361,9 @@ namespace ShopifySharp.GraphQL
         ///store dates after the specified minimum.
         ///</summary>
         public IEnumerable<MetafieldDefinitionValidation>? validations { get; set; }
-
         ///<summary>
         ///Whether each of the metafields that belong to the metafield definition are visible from the Storefront API.
         ///</summary>
-        [Obsolete("Use `access.storefront` instead.")]
         public bool? visibleToStorefrontApi { get; set; }
     }
 
@@ -27793,14 +25489,6 @@ namespace ShopifySharp.GraphQL
         ///You have reached the maximum allowed definitions for automated collections.
         ///</summary>
         OWNER_TYPE_LIMIT_EXCEEDED_FOR_AUTOMATED_COLLECTIONS,
-        ///<summary>
-        ///The maximum limit of grants per definition type has been exceeded.
-        ///</summary>
-        GRANT_LIMIT_EXCEEDED,
-        ///<summary>
-        ///The input combination is invalid.
-        ///</summary>
-        INVALID_INPUT_COMBINATION,
     }
 
     ///<summary>
@@ -28171,18 +25859,6 @@ namespace ShopifySharp.GraphQL
         ///You have reached the maximum allowed definitions for automated collections.
         ///</summary>
         OWNER_TYPE_LIMIT_EXCEEDED_FOR_AUTOMATED_COLLECTIONS,
-        ///<summary>
-        ///You cannot change the metaobject definition pointed to by a metaobject reference metafield definition.
-        ///</summary>
-        METAOBJECT_DEFINITION_CHANGED,
-        ///<summary>
-        ///The maximum limit of grants per definition type has been exceeded.
-        ///</summary>
-        GRANT_LIMIT_EXCEEDED,
-        ///<summary>
-        ///The input combination is invalid.
-        ///</summary>
-        INVALID_INPUT_COMBINATION,
     }
 
     ///<summary>
@@ -28259,21 +25935,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Possible access levels for explicit metafield access grants.
-    ///</summary>
-    public enum MetafieldGrantAccessLevel
-    {
-        ///<summary>
-        ///Read metafield access.
-        ///</summary>
-        READ,
-        ///<summary>
-        ///Read and write metafield access.
-        ///</summary>
-        READ_WRITE,
-    }
-
-    ///<summary>
     ///Possible types of a metafield's owner resource.
     ///</summary>
     public enum MetafieldOwnerType
@@ -28294,10 +25955,6 @@ namespace ShopifySharp.GraphQL
         ///The Payment Customization metafield owner type.
         ///</summary>
         PAYMENT_CUSTOMIZATION,
-        ///<summary>
-        ///The Validation metafield owner type.
-        ///</summary>
-        VALIDATION,
         ///<summary>
         ///The Customer metafield owner type.
         ///</summary>
@@ -28347,14 +26004,6 @@ namespace ShopifySharp.GraphQL
         ///The Page metafield owner type.
         ///</summary>
         PAGE,
-        ///<summary>
-        ///The Fulfillment Constraint Rule metafield owner type.
-        ///</summary>
-        FULFILLMENT_CONSTRAINT_RULE,
-        ///<summary>
-        ///The Order Routing Location Rule metafield owner type.
-        ///</summary>
-        ORDER_ROUTING_LOCATION_RULE,
         ///<summary>
         ///The Discount metafield owner type.
         ///</summary>
@@ -28548,21 +26197,6 @@ namespace ShopifySharp.GraphQL
         ///The item at the end of MetafieldRelationEdge.
         ///</summary>
         public MetafieldRelation? node { get; set; }
-    }
-
-    ///<summary>
-    ///Defines how the metafields of a definition can be accessed in Storefront API surface areas, including Liquid and the GraphQL Storefront API.
-    ///</summary>
-    public enum MetafieldStorefrontAccess
-    {
-        ///<summary>
-        ///Metafields are accessible in the GraphQL Storefront API and online store Liquid templates.
-        ///</summary>
-        PUBLIC_READ,
-        ///<summary>
-        ///Metafields are not accessible in any Storefront API surface area.
-        ///</summary>
-        NONE,
     }
 
     ///<summary>
@@ -28792,10 +26426,6 @@ namespace ShopifySharp.GraphQL
         ///ApiPermission metafields can only be created or updated by the app owner.
         ///</summary>
         APP_NOT_AUTHORIZED,
-        ///<summary>
-        ///The metafield violates a capability restriction.
-        ///</summary>
-        CAPABILITY_VIOLATION,
     }
 
     ///<summary>
@@ -28811,14 +26441,6 @@ namespace ShopifySharp.GraphQL
         ///The app used to create the object.
         ///</summary>
         public App? createdBy { get; set; }
-        ///<summary>
-        ///The app used to create the object.
-        ///</summary>
-        public App? createdByApp { get; set; }
-        ///<summary>
-        ///The staff member who created the metaobject.
-        ///</summary>
-        public StaffMember? createdByStaff { get; set; }
         ///<summary>
         ///The MetaobjectDefinition that models this object type.
         ///</summary>
@@ -28853,10 +26475,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         [Obsolete("Use `createdByStaff` instead.")]
         public StaffMember? staffMember { get; set; }
-        ///<summary>
-        ///The recommended field to visually represent this metaobject. May be a file reference or color         field.
-        ///</summary>
-        public MetaobjectField? thumbnailField { get; set; }
         ///<summary>
         ///The type of the metaobject.
         ///</summary>
@@ -28933,17 +26551,9 @@ namespace ShopifySharp.GraphQL
     public class MetaobjectCapabilities : GraphQLObject<MetaobjectCapabilities>
     {
         ///<summary>
-        ///Indicates whether a metaobject definition can be displayed as a page on the Online Store.
-        ///</summary>
-        public MetaobjectCapabilitiesOnlineStore? onlineStore { get; set; }
-        ///<summary>
         ///Indicate whether a metaobject definition is publishable.
         ///</summary>
         public MetaobjectCapabilitiesPublishable? publishable { get; set; }
-        ///<summary>
-        ///Indicate whether a metaobject definition is renderable and exposes SEO data.
-        ///</summary>
-        public MetaobjectCapabilitiesRenderable? renderable { get; set; }
         ///<summary>
         ///Indicate whether a metaobject definition is translatable.
         ///</summary>
@@ -28951,40 +26561,10 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///The Online Store capability of a metaobject definition.
-    ///</summary>
-    public class MetaobjectCapabilitiesOnlineStore : GraphQLObject<MetaobjectCapabilitiesOnlineStore>
-    {
-        ///<summary>
-        ///The data associated with the Online Store capability.
-        ///</summary>
-        public MetaobjectCapabilityDefinitionDataOnlineStore? data { get; set; }
-        ///<summary>
-        ///Indicates if the capability is enabled.
-        ///</summary>
-        public bool? enabled { get; set; }
-    }
-
-    ///<summary>
     ///The publishable capability of a metaobject definition.
     ///</summary>
     public class MetaobjectCapabilitiesPublishable : GraphQLObject<MetaobjectCapabilitiesPublishable>
     {
-        ///<summary>
-        ///Indicates if the capability is enabled.
-        ///</summary>
-        public bool? enabled { get; set; }
-    }
-
-    ///<summary>
-    ///The renderable capability of a metaobject definition.
-    ///</summary>
-    public class MetaobjectCapabilitiesRenderable : GraphQLObject<MetaobjectCapabilitiesRenderable>
-    {
-        ///<summary>
-        ///The data associated with the renderable capability.
-        ///</summary>
-        public MetaobjectCapabilityDefinitionDataRenderable? data { get; set; }
         ///<summary>
         ///Indicates if the capability is enabled.
         ///</summary>
@@ -29008,24 +26588,9 @@ namespace ShopifySharp.GraphQL
     public class MetaobjectCapabilityData : GraphQLObject<MetaobjectCapabilityData>
     {
         ///<summary>
-        ///The Online Store capability for this metaobject.
-        ///</summary>
-        public MetaobjectCapabilityDataOnlineStore? onlineStore { get; set; }
-        ///<summary>
         ///The publishable capability for this metaobject.
         ///</summary>
         public MetaobjectCapabilityDataPublishable? publishable { get; set; }
-    }
-
-    ///<summary>
-    ///The Online Store capability for the parent metaobject.
-    ///</summary>
-    public class MetaobjectCapabilityDataOnlineStore : GraphQLObject<MetaobjectCapabilityDataOnlineStore>
-    {
-        ///<summary>
-        ///The theme template used when viewing the metaobject in a store.
-        ///</summary>
-        public string? templateSuffix { get; set; }
     }
 
     ///<summary>
@@ -29037,36 +26602,6 @@ namespace ShopifySharp.GraphQL
         ///The visibility status of this metaobject across all channels.
         ///</summary>
         public MetaobjectStatus? status { get; set; }
-    }
-
-    ///<summary>
-    ///The Online Store capability data for the metaobject definition.
-    ///</summary>
-    public class MetaobjectCapabilityDefinitionDataOnlineStore : GraphQLObject<MetaobjectCapabilityDefinitionDataOnlineStore>
-    {
-        ///<summary>
-        ///Flag indicating if a sufficient number of redirects are available to redirect all published entries.
-        ///</summary>
-        public bool? canCreateRedirects { get; set; }
-        ///<summary>
-        ///The URL handle for accessing pages of this metaobject type in the Online Store.
-        ///</summary>
-        public string? urlHandle { get; set; }
-    }
-
-    ///<summary>
-    ///The renderable capability data for the metaobject definition.
-    ///</summary>
-    public class MetaobjectCapabilityDefinitionDataRenderable : GraphQLObject<MetaobjectCapabilityDefinitionDataRenderable>
-    {
-        ///<summary>
-        ///The metaobject field used as an alias for the SEO page description.
-        ///</summary>
-        public string? metaDescriptionKey { get; set; }
-        ///<summary>
-        ///The metaobject field used as an alias for the SEO page title.
-        ///</summary>
-        public string? metaTitleKey { get; set; }
     }
 
     ///<summary>
@@ -29117,14 +26652,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MetaobjectCapabilities? capabilities { get; set; }
         ///<summary>
-        ///The app used to create the metaobject definition.
-        ///</summary>
-        public App? createdByApp { get; set; }
-        ///<summary>
-        ///The staff member who created the metaobject definition.
-        ///</summary>
-        public StaffMember? createdByStaff { get; set; }
-        ///<summary>
         ///The administrative description.
         ///</summary>
         public string? description { get; set; }
@@ -29136,10 +26663,6 @@ namespace ShopifySharp.GraphQL
         ///The fields defined for this object type.
         ///</summary>
         public IEnumerable<MetaobjectFieldDefinition>? fieldDefinitions { get; set; }
-        ///<summary>
-        ///Whether this metaobject definition has field whose type can visually represent a metaobject with        the `thumbnailField`.
-        ///</summary>
-        public bool? hasThumbnailField { get; set; }
         ///<summary>
         ///A globally-unique ID.
         ///</summary>
@@ -29293,10 +26816,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MetafieldReferenceConnection? references { get; set; }
         ///<summary>
-        ///For file reference or color fields, provides visual attributes for this field.
-        ///</summary>
-        public MetaobjectThumbnail? thumbnail { get; set; }
-        ///<summary>
         ///The type of the field.
         ///</summary>
         public string? type { get; set; }
@@ -29368,21 +26887,6 @@ namespace ShopifySharp.GraphQL
         ///Metaobjects are accessible in online store Liquid templates.
         ///</summary>
         PUBLIC_READ,
-    }
-
-    ///<summary>
-    ///Provides attributes for visual representation.
-    ///</summary>
-    public class MetaobjectThumbnail : GraphQLObject<MetaobjectThumbnail>
-    {
-        ///<summary>
-        ///The file to be used for visual representation of this metaobject.
-        ///</summary>
-        public IFile? file { get; set; }
-        ///<summary>
-        ///The hexadecimal color code to be used for respresenting this metaobject.
-        ///</summary>
-        public string? hex { get; set; }
     }
 
     ///<summary>
@@ -29539,26 +27043,6 @@ namespace ShopifySharp.GraphQL
         ///The capability you are using is not enabled.
         ///</summary>
         CAPABILITY_NOT_ENABLED,
-        ///<summary>
-        ///The Online Store URL handle is already taken.
-        ///</summary>
-        URL_HANDLE_TAKEN,
-        ///<summary>
-        ///The Online Store URL handle is invalid.
-        ///</summary>
-        URL_HANDLE_INVALID,
-        ///<summary>
-        ///The Online Store URL handle cannot be blank.
-        ///</summary>
-        URL_HANDLE_BLANK,
-        ///<summary>
-        ///Renderable data input is referencing an invalid field.
-        ///</summary>
-        FIELD_TYPE_INVALID,
-        ///<summary>
-        ///The input is missing required keys.
-        ///</summary>
-        MISSING_REQUIRED_KEYS,
     }
 
     ///<summary>
@@ -29723,6 +27207,18 @@ namespace ShopifySharp.GraphQL
         ///Test and demo shops aren't charged.
         ///</summary>
         public AppPurchaseOneTimeCreatePayload? appPurchaseOneTimeCreate { get; set; }
+
+        ///<summary>
+        ///Creates a record of the attributed revenue for the app. This mutation should only be used to capture transactions that are not managed by the Billing API.
+        ///</summary>
+        [Obsolete("This mutation will be removed in a future version.")]
+        public AppRevenueAttributionRecordCreatePayload? appRevenueAttributionRecordCreate { get; set; }
+
+        ///<summary>
+        ///Deletes a record of the attributed revenue for the app.
+        ///</summary>
+        [Obsolete("This mutation will be removed in a future version.")]
+        public AppRevenueAttributionRecordDeletePayload? appRevenueAttributionRecordDelete { get; set; }
         ///<summary>
         ///Cancels an app subscription on a store.
         ///</summary>
@@ -29792,10 +27288,6 @@ namespace ShopifySharp.GraphQL
         ///Updates an existing catalog.
         ///</summary>
         public CatalogUpdatePayload? catalogUpdate { get; set; }
-        ///<summary>
-        ///Updates the checkout branding settings for a [checkout profile](https://shopify.dev/api/admin-graphql/unstable/queries/checkoutProfile). If the settings don't exist, then new settings are created. The checkout branding settings applied to a published checkout profile will be immediately visible within the store's checkout. The checkout branding settings applied to a draft checkout profile could be previewed within the admin checkout editor.
-        ///</summary>
-        public CheckoutBrandingUpsertPayload? checkoutBrandingUpsert { get; set; }
         ///<summary>
         ///Adds products to a collection.
         ///</summary>
@@ -29957,12 +27449,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public CustomerAddTaxExemptionsPayload? customerAddTaxExemptions { get; set; }
         ///<summary>
-        ///Cancels a pending erasure of a customer's data.
-        ///
-        ///To request an erasure of a customer's data use the [customerRequestDataErasure mutation](https://shopify.dev/api/admin-graphql/unstable/mutations/customerRequestDataErasure).
-        ///</summary>
-        public CustomerCancelDataErasurePayload? customerCancelDataErasure { get; set; }
-        ///<summary>
         ///Create a new customer. As of API version 2022-10, apps using protected customer data must meet the protected customer data [requirements](https://shopify.dev/apps/store/data-protection/protected-customer-data).
         ///</summary>
         public CustomerCreatePayload? customerCreate { get; set; }
@@ -30046,12 +27532,6 @@ namespace ShopifySharp.GraphQL
         ///Replace tax exemptions for a customer.
         ///</summary>
         public CustomerReplaceTaxExemptionsPayload? customerReplaceTaxExemptions { get; set; }
-        ///<summary>
-        ///Enqueues a request to erase customer's data. Read more [here](https://help.shopify.com/manual/privacy-and-security/privacy/processing-customer-data-requests#erase-customer-personal-data).
-        ///
-        ///To cancel the data erasure request use the [customerCancelDataErasure mutation](https://shopify.dev/api/admin-graphql/unstable/mutations/customerCancelDataErasure).
-        ///</summary>
-        public CustomerRequestDataErasurePayload? customerRequestDataErasure { get; set; }
         ///<summary>
         ///Creates a customer segment members query.
         ///</summary>
@@ -30158,14 +27638,6 @@ namespace ShopifySharp.GraphQL
         ///Deletes an automatic discount.
         ///</summary>
         public DiscountAutomaticDeletePayload? discountAutomaticDelete { get; set; }
-        ///<summary>
-        ///Creates a free shipping automatic discount.
-        ///</summary>
-        public DiscountAutomaticFreeShippingCreatePayload? discountAutomaticFreeShippingCreate { get; set; }
-        ///<summary>
-        ///Updates a free shipping automatic discount.
-        ///</summary>
-        public DiscountAutomaticFreeShippingUpdatePayload? discountAutomaticFreeShippingUpdate { get; set; }
         ///<summary>
         ///Activates a code discount.
         ///</summary>
@@ -30328,10 +27800,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public FileUpdatePayload? fileUpdate { get; set; }
         ///<summary>
-        ///Generates a signature for a Flow action payload.
-        ///</summary>
-        public FlowGenerateSignaturePayload? flowGenerateSignature { get; set; }
-        ///<summary>
         ///Triggers any workflows that begin with the trigger specified in the request body. To learn more, refer to [_Create Shopify Flow triggers_](https://shopify.dev/apps/flow/triggers).
         ///</summary>
         public FlowTriggerReceivePayload? flowTriggerReceive { get; set; }
@@ -30339,14 +27807,6 @@ namespace ShopifySharp.GraphQL
         ///Cancels a fulfillment.
         ///</summary>
         public FulfillmentCancelPayload? fulfillmentCancel { get; set; }
-        ///<summary>
-        ///Creates a fulfillment constraint rule and its metafield.
-        ///</summary>
-        public FulfillmentConstraintRuleCreatePayload? fulfillmentConstraintRuleCreate { get; set; }
-        ///<summary>
-        ///Deletes a fulfillment constraint rule and its metafields.
-        ///</summary>
-        public FulfillmentConstraintRuleDeletePayload? fulfillmentConstraintRuleDelete { get; set; }
         ///<summary>
         ///Creates a fulfillment for one or many fulfillment orders.
         ///The fulfillment orders are associated with the same order and are assigned to the same location.
@@ -30443,10 +27903,6 @@ namespace ShopifySharp.GraphQL
         public FulfillmentOrderReleaseHoldPayload? fulfillmentOrderReleaseHold { get; set; }
         ///<summary>
         ///Reschedules a scheduled fulfillment order.
-        ///
-        ///Updates the value of the `fulfillAt` field on a scheduled fulfillment order.
-        ///
-        ///The fulfillment order will be marked as ready for fulfillment at this date and time.
         ///</summary>
         public FulfillmentOrderReschedulePayload? fulfillmentOrderReschedule { get; set; }
         ///<summary>
@@ -30557,10 +28013,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public InventorySetOnHandQuantitiesPayload? inventorySetOnHandQuantities { get; set; }
         ///<summary>
-        ///Set up scheduled changes of inventory items.
-        ///</summary>
-        public InventorySetScheduledChangesPayload? inventorySetScheduledChanges { get; set; }
-        ///<summary>
         ///Activates a location.
         ///</summary>
         public LocationActivatePayload? locationActivate { get; set; }
@@ -30619,10 +28071,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MarketRegionsCreatePayload? marketRegionsCreate { get; set; }
         ///<summary>
-        ///Deletes a list of market regions.
-        ///</summary>
-        public MarketRegionsDeletePayload? marketRegionsDelete { get; set; }
-        ///<summary>
         ///Updates the properties of a market.
         ///</summary>
         public MarketUpdatePayload? marketUpdate { get; set; }
@@ -30639,10 +28087,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MarketWebPresenceUpdatePayload? marketWebPresenceUpdate { get; set; }
         ///<summary>
-        ///Deletes all external marketing activities. Deletion is performed by a background job, as it may take a bit of time to complete if a large number of activities are to be deleted. Attempting to create or modify external activities before the job has completed will result in the create/update/upsert mutation returning an error.
-        ///</summary>
-        public MarketingActivitiesDeleteAllExternalPayload? marketingActivitiesDeleteAllExternal { get; set; }
-        ///<summary>
         ///Create new marketing activity.
         ///</summary>
         public MarketingActivityCreatePayload? marketingActivityCreate { get; set; }
@@ -30650,10 +28094,6 @@ namespace ShopifySharp.GraphQL
         ///Creates a new external marketing activity.
         ///</summary>
         public MarketingActivityCreateExternalPayload? marketingActivityCreateExternal { get; set; }
-        ///<summary>
-        ///Deletes an external marketing activity.
-        ///</summary>
-        public MarketingActivityDeleteExternalPayload? marketingActivityDeleteExternal { get; set; }
         ///<summary>
         ///Updates a marketing activity with the latest information.
         ///</summary>
@@ -30663,19 +28103,9 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MarketingActivityUpdateExternalPayload? marketingActivityUpdateExternal { get; set; }
         ///<summary>
-        ///Creates a new external marketing activity or updates an existing one. When optional fields are absent or null, associated information will be removed from an existing marketing activity.
-        ///</summary>
-        public MarketingActivityUpsertExternalPayload? marketingActivityUpsertExternal { get; set; }
-        ///<summary>
-        ///Creates a new marketing engagement for a marketing activity or a marketing channel.
+        ///Creates a new marketing event engagement for a marketing activity or a marketing channel.
         ///</summary>
         public MarketingEngagementCreatePayload? marketingEngagementCreate { get; set; }
-        ///<summary>
-        ///Marks channel-level engagement data such that it no longer appears in reports.
-        ///          Activity-level data cannot be deleted directly, instead the MarketingActivity itself should be deleted to
-        ///          hide it from reports.
-        ///</summary>
-        public MarketingEngagementsDeletePayload? marketingEngagementsDelete { get; set; }
         ///<summary>
         ///Creates a metafield definition.
         ///</summary>
@@ -30763,10 +28193,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MetaobjectUpsertPayload? metaobjectUpsert { get; set; }
         ///<summary>
-        ///Cancels an order.
-        ///</summary>
-        public OrderCancelPayload? orderCancel { get; set; }
-        ///<summary>
         ///Captures payment for an authorized transaction on an order. An order can only be captured if it has a successful authorization transaction. Capturing an order will claim the money reserved by the authorization. orderCapture can be used to capture multiple times as long as the OrderTransaction is multicapturable. To capture a partial payment, the included `amount` value should be less than the total order amount. Multicapture is available only to stores on a Shopify Plus plan.
         ///</summary>
         public OrderCapturePayload? orderCapture { get; set; }
@@ -30783,7 +28209,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public OrderEditAddCustomItemPayload? orderEditAddCustomItem { get; set; }
         ///<summary>
-        ///Adds a discount to a line item on the current order edit. For more information on how to use the GraphQL Admin API to edit an existing order, refer to [Edit existing orders](https://shopify.dev/apps/fulfillment/order-management-apps/order-editing).
+        ///Adds a discount to a newly added line item on the current order edit. More information on how to use the GraphQL Admin API to edit an existing order, refer to [Edit existing orders](https://shopify.dev/apps/fulfillment/order-management-apps/order-editing).
         ///</summary>
         public OrderEditAddLineItemDiscountPayload? orderEditAddLineItemDiscount { get; set; }
         ///<summary>
@@ -30801,21 +28227,13 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public OrderEditCommitPayload? orderEditCommit { get; set; }
         ///<summary>
-        ///Removes a discount on the current order edit. For more information on how to use the GraphQL Admin API to edit an existing order, refer to [Edit existing orders](https://shopify.dev/apps/fulfillment/order-management-apps/order-editing).
-        ///</summary>
-        public OrderEditRemoveDiscountPayload? orderEditRemoveDiscount { get; set; }
-        ///<summary>
         ///Removes a line item discount that was applied as part of an order edit.
         ///</summary>
         public OrderEditRemoveLineItemDiscountPayload? orderEditRemoveLineItemDiscount { get; set; }
         ///<summary>
-        ///Sets the quantity of a line item on an order that is being edited. For more information on how to use the GraphQL Admin API to edit an existing order, refer to [Edit existing orders](https://shopify.dev/apps/fulfillment/order-management-apps/order-editing).
+        ///Sets the quantity of a line item on an order that is being edited. More information on how to use the GraphQL Admin API to edit an existing order, refer to [Edit existing orders](https://shopify.dev/apps/fulfillment/order-management-apps/order-editing).
         ///</summary>
         public OrderEditSetQuantityPayload? orderEditSetQuantity { get; set; }
-        ///<summary>
-        ///Updates a manual line level discount on the current order edit. For more information on how to use the GraphQL Admin API to edit an existing order, refer to [Edit existing orders](https://shopify.dev/apps/fulfillment/order-management-apps/order-editing).
-        ///</summary>
-        public OrderEditUpdateDiscountPayload? orderEditUpdateDiscount { get; set; }
         ///<summary>
         ///Sends an email invoice for an order.
         ///</summary>
@@ -31201,10 +28619,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public PublishableUnpublishToCurrentChannelPayload? publishableUnpublishToCurrentChannel { get; set; }
         ///<summary>
-        ///Updates quantity pricing on a price list. You can use the `quantityPricingByVariantUpdate` mutation to set fixed prices, quantity rules, and quantity price breaks. This mutation does not allow partial successes. If any of the requested resources fail to update, none of the requested resources will be updated. Delete operations are executed before create operations.
-        ///</summary>
-        public QuantityPricingByVariantUpdatePayload? quantityPricingByVariantUpdate { get; set; }
-        ///<summary>
         ///Creates or updates existing quantity rules on a price list.
         ///You can use the `quantityRulesAdd` mutation to set order level minimums, maximumums and increments for specific product variants.
         ///</summary>
@@ -31246,7 +28660,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public ReturnDeclineRequestPayload? returnDeclineRequest { get; set; }
         ///<summary>
-        ///Refunds a return when its status is `OPEN` or `CLOSED` and associates it with the related return request.
+        ///Refunds a return and associates it with the related return request.
         ///</summary>
         public ReturnRefundPayload? returnRefund { get; set; }
         ///<summary>
@@ -31485,50 +28899,19 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public SubscriptionBillingCycleScheduleEditPayload? subscriptionBillingCycleScheduleEdit { get; set; }
         ///<summary>
-        ///Skips a Subscription Billing Cycle.
-        ///</summary>
-        public SubscriptionBillingCycleSkipPayload? subscriptionBillingCycleSkip { get; set; }
-        ///<summary>
-        ///Unskips a Subscription Billing Cycle.
-        ///</summary>
-        public SubscriptionBillingCycleUnskipPayload? subscriptionBillingCycleUnskip { get; set; }
-        ///<summary>
-        ///Activates a Subscription Contract.
-        ///</summary>
-        public SubscriptionContractActivatePayload? subscriptionContractActivate { get; set; }
-        ///<summary>
         ///Creates a Subscription Contract.
         ///</summary>
         public SubscriptionContractAtomicCreatePayload? subscriptionContractAtomicCreate { get; set; }
-        ///<summary>
-        ///Cancels a Subscription Contract.
-        ///</summary>
-        public SubscriptionContractCancelPayload? subscriptionContractCancel { get; set; }
         ///<summary>
         ///Creates a Subscription Contract.
         ///</summary>
         public SubscriptionContractCreatePayload? subscriptionContractCreate { get; set; }
         ///<summary>
-        ///Expires a Subscription Contract.
-        ///</summary>
-        public SubscriptionContractExpirePayload? subscriptionContractExpire { get; set; }
-        ///<summary>
-        ///Fails a Subscription Contract.
-        ///</summary>
-        public SubscriptionContractFailPayload? subscriptionContractFail { get; set; }
-        ///<summary>
-        ///Pauses a Subscription Contract.
-        ///</summary>
-        public SubscriptionContractPausePayload? subscriptionContractPause { get; set; }
-        ///<summary>
         ///Allows for the easy change of a Product in a Contract or a Product price change.
         ///</summary>
         public SubscriptionContractProductChangePayload? subscriptionContractProductChange { get; set; }
         ///<summary>
-        ///Sets the next billing date of a Subscription Contract. This field is managed by the apps.
-        ///        Alternatively you can utilize our
-        ///        [Billing Cycles APIs](https://shopify.dev/docs/apps/selling-strategies/subscriptions/billing-cycles),
-        ///        which provide auto-computed billing dates and additional functionalities.
+        ///Sets the next billing date of a Subscription Contract.
         ///</summary>
         public SubscriptionContractSetNextBillingDatePayload? subscriptionContractSetNextBillingDate { get; set; }
         ///<summary>
@@ -31643,18 +29026,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public UrlRedirectUpdatePayload? urlRedirectUpdate { get; set; }
         ///<summary>
-        ///Creates a validation.
-        ///</summary>
-        public ValidationCreatePayload? validationCreate { get; set; }
-        ///<summary>
-        ///Deletes a validation.
-        ///</summary>
-        public ValidationDeletePayload? validationDelete { get; set; }
-        ///<summary>
-        ///Update a validation.
-        ///</summary>
-        public ValidationUpdatePayload? validationUpdate { get; set; }
-        ///<summary>
         ///Creates a new web pixel settings.
         ///</summary>
         public WebPixelCreatePayload? webPixelCreate { get; set; }
@@ -31762,7 +29133,6 @@ namespace ShopifySharp.GraphQL
     ///</summary>
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
     [JsonDerivedType(typeof(AbandonedCheckout), typeDiscriminator: "AbandonedCheckout")]
-    [JsonDerivedType(typeof(AbandonedCheckoutLineItem), typeDiscriminator: "AbandonedCheckoutLineItem")]
     [JsonDerivedType(typeof(Abandonment), typeDiscriminator: "Abandonment")]
     [JsonDerivedType(typeof(AddAllProductsOperation), typeDiscriminator: "AddAllProductsOperation")]
     [JsonDerivedType(typeof(AdditionalFee), typeDiscriminator: "AdditionalFee")]
@@ -31822,7 +29192,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(ExchangeV2), typeDiscriminator: "ExchangeV2")]
     [JsonDerivedType(typeof(ExternalVideo), typeDiscriminator: "ExternalVideo")]
     [JsonDerivedType(typeof(Fulfillment), typeDiscriminator: "Fulfillment")]
-    [JsonDerivedType(typeof(FulfillmentConstraintRule), typeDiscriminator: "FulfillmentConstraintRule")]
     [JsonDerivedType(typeof(FulfillmentEvent), typeDiscriminator: "FulfillmentEvent")]
     [JsonDerivedType(typeof(FulfillmentLineItem), typeDiscriminator: "FulfillmentLineItem")]
     [JsonDerivedType(typeof(FulfillmentOrder), typeDiscriminator: "FulfillmentOrder")]
@@ -31834,7 +29203,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(InventoryAdjustmentGroup), typeDiscriminator: "InventoryAdjustmentGroup")]
     [JsonDerivedType(typeof(InventoryItem), typeDiscriminator: "InventoryItem")]
     [JsonDerivedType(typeof(InventoryLevel), typeDiscriminator: "InventoryLevel")]
-    [JsonDerivedType(typeof(InventoryQuantity), typeDiscriminator: "InventoryQuantity")]
     [JsonDerivedType(typeof(LineItem), typeDiscriminator: "LineItem")]
     [JsonDerivedType(typeof(LineItemMutable), typeDiscriminator: "LineItemMutable")]
     [JsonDerivedType(typeof(Location), typeDiscriminator: "Location")]
@@ -31875,7 +29243,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(ProductVariantComponent), typeDiscriminator: "ProductVariantComponent")]
     [JsonDerivedType(typeof(Publication), typeDiscriminator: "Publication")]
     [JsonDerivedType(typeof(PublicationResourceOperation), typeDiscriminator: "PublicationResourceOperation")]
-    [JsonDerivedType(typeof(QuantityPriceBreak), typeDiscriminator: "QuantityPriceBreak")]
     [JsonDerivedType(typeof(Refund), typeDiscriminator: "Refund")]
     [JsonDerivedType(typeof(Return), typeDiscriminator: "Return")]
     [JsonDerivedType(typeof(ReturnLineItem), typeDiscriminator: "ReturnLineItem")]
@@ -31896,7 +29263,6 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(ShopAddress), typeDiscriminator: "ShopAddress")]
     [JsonDerivedType(typeof(ShopPolicy), typeDiscriminator: "ShopPolicy")]
     [JsonDerivedType(typeof(ShopifyPaymentsAccount), typeDiscriminator: "ShopifyPaymentsAccount")]
-    [JsonDerivedType(typeof(ShopifyPaymentsBalanceTransaction), typeDiscriminator: "ShopifyPaymentsBalanceTransaction")]
     [JsonDerivedType(typeof(ShopifyPaymentsBankAccount), typeDiscriminator: "ShopifyPaymentsBankAccount")]
     [JsonDerivedType(typeof(ShopifyPaymentsDispute), typeDiscriminator: "ShopifyPaymentsDispute")]
     [JsonDerivedType(typeof(ShopifyPaymentsDisputeEvidence), typeDiscriminator: "ShopifyPaymentsDisputeEvidence")]
@@ -31914,14 +29280,12 @@ namespace ShopifySharp.GraphQL
     [JsonDerivedType(typeof(TransactionFee), typeDiscriminator: "TransactionFee")]
     [JsonDerivedType(typeof(UrlRedirect), typeDiscriminator: "UrlRedirect")]
     [JsonDerivedType(typeof(UrlRedirectImport), typeDiscriminator: "UrlRedirectImport")]
-    [JsonDerivedType(typeof(Validation), typeDiscriminator: "Validation")]
     [JsonDerivedType(typeof(Video), typeDiscriminator: "Video")]
     [JsonDerivedType(typeof(WebPixel), typeDiscriminator: "WebPixel")]
     [JsonDerivedType(typeof(WebhookSubscription), typeDiscriminator: "WebhookSubscription")]
     public interface INode : IGraphQLObject
     {
         public AbandonedCheckout? AsAbandonedCheckout() => this as AbandonedCheckout;
-        public AbandonedCheckoutLineItem? AsAbandonedCheckoutLineItem() => this as AbandonedCheckoutLineItem;
         public Abandonment? AsAbandonment() => this as Abandonment;
         public AddAllProductsOperation? AsAddAllProductsOperation() => this as AddAllProductsOperation;
         public AdditionalFee? AsAdditionalFee() => this as AdditionalFee;
@@ -31981,7 +29345,6 @@ namespace ShopifySharp.GraphQL
         public ExchangeV2? AsExchangeV2() => this as ExchangeV2;
         public ExternalVideo? AsExternalVideo() => this as ExternalVideo;
         public Fulfillment? AsFulfillment() => this as Fulfillment;
-        public FulfillmentConstraintRule? AsFulfillmentConstraintRule() => this as FulfillmentConstraintRule;
         public FulfillmentEvent? AsFulfillmentEvent() => this as FulfillmentEvent;
         public FulfillmentLineItem? AsFulfillmentLineItem() => this as FulfillmentLineItem;
         public FulfillmentOrder? AsFulfillmentOrder() => this as FulfillmentOrder;
@@ -31993,7 +29356,6 @@ namespace ShopifySharp.GraphQL
         public InventoryAdjustmentGroup? AsInventoryAdjustmentGroup() => this as InventoryAdjustmentGroup;
         public InventoryItem? AsInventoryItem() => this as InventoryItem;
         public InventoryLevel? AsInventoryLevel() => this as InventoryLevel;
-        public InventoryQuantity? AsInventoryQuantity() => this as InventoryQuantity;
         public LineItem? AsLineItem() => this as LineItem;
         public LineItemMutable? AsLineItemMutable() => this as LineItemMutable;
         public Location? AsLocation() => this as Location;
@@ -32034,7 +29396,6 @@ namespace ShopifySharp.GraphQL
         public ProductVariantComponent? AsProductVariantComponent() => this as ProductVariantComponent;
         public Publication? AsPublication() => this as Publication;
         public PublicationResourceOperation? AsPublicationResourceOperation() => this as PublicationResourceOperation;
-        public QuantityPriceBreak? AsQuantityPriceBreak() => this as QuantityPriceBreak;
         public Refund? AsRefund() => this as Refund;
         public Return? AsReturn() => this as Return;
         public ReturnLineItem? AsReturnLineItem() => this as ReturnLineItem;
@@ -32055,7 +29416,6 @@ namespace ShopifySharp.GraphQL
         public ShopAddress? AsShopAddress() => this as ShopAddress;
         public ShopPolicy? AsShopPolicy() => this as ShopPolicy;
         public ShopifyPaymentsAccount? AsShopifyPaymentsAccount() => this as ShopifyPaymentsAccount;
-        public ShopifyPaymentsBalanceTransaction? AsShopifyPaymentsBalanceTransaction() => this as ShopifyPaymentsBalanceTransaction;
         public ShopifyPaymentsBankAccount? AsShopifyPaymentsBankAccount() => this as ShopifyPaymentsBankAccount;
         public ShopifyPaymentsDispute? AsShopifyPaymentsDispute() => this as ShopifyPaymentsDispute;
         public ShopifyPaymentsDisputeEvidence? AsShopifyPaymentsDisputeEvidence() => this as ShopifyPaymentsDisputeEvidence;
@@ -32073,7 +29433,6 @@ namespace ShopifySharp.GraphQL
         public TransactionFee? AsTransactionFee() => this as TransactionFee;
         public UrlRedirect? AsUrlRedirect() => this as UrlRedirect;
         public UrlRedirectImport? AsUrlRedirectImport() => this as UrlRedirectImport;
-        public Validation? AsValidation() => this as Validation;
         public Video? AsVideo() => this as Video;
         public WebPixel? AsWebPixel() => this as WebPixel;
         public WebhookSubscription? AsWebhookSubscription() => this as WebhookSubscription;
@@ -32206,10 +29565,6 @@ namespace ShopifySharp.GraphQL
         ///Returns `null` if the order wasn't canceled.
         ///</summary>
         public OrderCancelReason? cancelReason { get; set; }
-        ///<summary>
-        ///Cancellation details for the order.
-        ///</summary>
-        public OrderCancellation? cancellation { get; set; }
         ///<summary>
         ///The date and time when the order was canceled.
         ///Returns `null` if the order wasn't canceled.
@@ -32661,10 +30016,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public ShippingLineConnection? shippingLines { get; set; }
         ///<summary>
-        ///The Shopify Protect details for the order. If Shopify Protect is disabled for the shop, then this will be null.
-        ///</summary>
-        public ShopifyProtectOrderSummary? shopifyProtect { get; set; }
-        ///<summary>
         ///A unique POS or third party order identifier.
         ///For example, "1234-12-1000" or "111-98567-54". The `receipt_number` field is derived from this value for POS orders.
         ///</summary>
@@ -32907,27 +30258,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `orderCancel` mutation.
-    ///</summary>
-    public class OrderCancelPayload : GraphQLObject<OrderCancelPayload>
-    {
-        ///<summary>
-        ///The job that asynchronously cancels the order.
-        ///</summary>
-        public Job? job { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<OrderCancelUserError>? orderCancelUserErrors { get; set; }
-
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        [Obsolete("Use `orderCancelUserErrors` instead.")]
-        public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///Represents the reason for the order's cancellation.
     ///</summary>
     public enum OrderCancelReason
@@ -32949,62 +30279,9 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         INVENTORY,
         ///<summary>
-        ///Staff made an error.
-        ///</summary>
-        STAFF,
-        ///<summary>
         ///The order was canceled for an unlisted reason.
         ///</summary>
         OTHER,
-    }
-
-    ///<summary>
-    ///Errors related to order cancellation.
-    ///</summary>
-    public class OrderCancelUserError : GraphQLObject<OrderCancelUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public OrderCancelUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `OrderCancelUserError`.
-    ///</summary>
-    public enum OrderCancelUserErrorCode
-    {
-        ///<summary>
-        ///An order refund was requested but the user does not have the refund_orders permission.
-        ///</summary>
-        NO_REFUND_PERMISSION,
-        ///<summary>
-        ///The record with the ID used as the input value couldn't be found.
-        ///</summary>
-        NOT_FOUND,
-        ///<summary>
-        ///The input value is invalid.
-        ///</summary>
-        INVALID,
-    }
-
-    ///<summary>
-    ///Details about the order cancellation.
-    ///</summary>
-    public class OrderCancellation : GraphQLObject<OrderCancellation>
-    {
-        ///<summary>
-        ///Staff provided note for the order cancellation.
-        ///</summary>
-        public string? staffNote { get; set; }
     }
 
     ///<summary>
@@ -33346,51 +30623,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `orderEditRemoveDiscount` mutation.
-    ///</summary>
-    public class OrderEditRemoveDiscountPayload : GraphQLObject<OrderEditRemoveDiscountPayload>
-    {
-        ///<summary>
-        ///An order with the edits applied but not saved.
-        ///</summary>
-        public CalculatedOrder? calculatedOrder { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<OrderEditRemoveDiscountUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `OrderEditRemoveDiscount`.
-    ///</summary>
-    public class OrderEditRemoveDiscountUserError : GraphQLObject<OrderEditRemoveDiscountUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public OrderEditRemoveDiscountUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `OrderEditRemoveDiscountUserError`.
-    ///</summary>
-    public enum OrderEditRemoveDiscountUserErrorCode
-    {
-        ///<summary>
-        ///The input value is invalid.
-        ///</summary>
-        INVALID,
-    }
-
-    ///<summary>
     ///Return type for `orderEditRemoveLineItemDiscount` mutation.
     ///</summary>
     public class OrderEditRemoveLineItemDiscountPayload : GraphQLObject<OrderEditRemoveLineItemDiscountPayload>
@@ -33426,51 +30658,6 @@ namespace ShopifySharp.GraphQL
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `orderEditUpdateDiscount` mutation.
-    ///</summary>
-    public class OrderEditUpdateDiscountPayload : GraphQLObject<OrderEditUpdateDiscountPayload>
-    {
-        ///<summary>
-        ///An order with the edits applied but not saved.
-        ///</summary>
-        public CalculatedOrder? calculatedOrder { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<OrderEditUpdateDiscountUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `OrderEditUpdateDiscount`.
-    ///</summary>
-    public class OrderEditUpdateDiscountUserError : GraphQLObject<OrderEditUpdateDiscountUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public OrderEditUpdateDiscountUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `OrderEditUpdateDiscountUserError`.
-    ///</summary>
-    public enum OrderEditUpdateDiscountUserErrorCode
-    {
-        ///<summary>
-        ///The input value is invalid.
-        ///</summary>
-        INVALID,
     }
 
     ///<summary>
@@ -33635,14 +30822,6 @@ namespace ShopifySharp.GraphQL
         ///Status is unknown.
         ///</summary>
         UNKNOWN,
-        ///<summary>
-        ///The payment is awaiting processing.
-        ///</summary>
-        INITIATED,
-        ///<summary>
-        ///The payment is pending with the provider, and may take a while.
-        ///</summary>
-        PENDING,
     }
 
     ///<summary>
@@ -34022,10 +31201,6 @@ namespace ShopifySharp.GraphQL
         ///This value is only available for transactions of type `SuggestedRefund`.
         ///</summary>
         public MoneyV2? maximumRefundableV2 { get; set; }
-        ///<summary>
-        ///Whether the transaction can be captured multiple times.
-        ///</summary>
-        public bool? multiCapturable { get; set; }
         ///<summary>
         ///The associated order.
         ///</summary>
@@ -34828,15 +32003,45 @@ namespace ShopifySharp.GraphQL
     ///</summary>
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
     [JsonDerivedType(typeof(CardPaymentDetails), typeDiscriminator: "CardPaymentDetails")]
-    [JsonDerivedType(typeof(ShopPayInstallmentsPaymentDetails), typeDiscriminator: "ShopPayInstallmentsPaymentDetails")]
     public interface IPaymentDetails : IGraphQLObject
     {
         public CardPaymentDetails? AsCardPaymentDetails() => this as CardPaymentDetails;
-        public ShopPayInstallmentsPaymentDetails? AsShopPayInstallmentsPaymentDetails() => this as ShopPayInstallmentsPaymentDetails;
         ///<summary>
-        ///The name of payment method used by the buyer.
+        ///The response code from the address verification system (AVS). The code is always a single letter.
         ///</summary>
-        public string? paymentMethodName { get; set; }
+        public string? avsResultCode { get; set; }
+        ///<summary>
+        ///The issuer identification number (IIN), formerly known as bank identification number (BIN) of the customer's credit card. This is made up of the first few digits of the credit card number.
+        ///</summary>
+        public string? bin { get; set; }
+        ///<summary>
+        ///The name of the company that issued the customer's credit card.
+        ///</summary>
+        public string? company { get; set; }
+        ///<summary>
+        ///The response code from the credit card company indicating whether the customer entered the card security code, or card verification value, correctly. The code is a single letter or empty string.
+        ///</summary>
+        public string? cvvResultCode { get; set; }
+        ///<summary>
+        ///The month in which the used credit card expires.
+        ///</summary>
+        public int? expirationMonth { get; set; }
+        ///<summary>
+        ///The year in which the used credit card expires.
+        ///</summary>
+        public int? expirationYear { get; set; }
+        ///<summary>
+        ///The holder of the credit card.
+        ///</summary>
+        public string? name { get; set; }
+        ///<summary>
+        ///The customer's credit card number, with most of the leading digits redacted.
+        ///</summary>
+        public string? number { get; set; }
+        ///<summary>
+        ///Digital wallet used for the payment.
+        ///</summary>
+        public DigitalWallet? wallet { get; set; }
     }
 
     ///<summary>
@@ -35699,10 +32904,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MoneyV2? price { get; set; }
         ///<summary>
-        ///A list of quantity breaks for the product variant.
-        ///</summary>
-        public QuantityPriceBreakConnection? quantityPriceBreaks { get; set; }
-        ///<summary>
         ///The product variant associated with this price.
         ///</summary>
         public ProductVariant? variant { get; set; }
@@ -35931,10 +33132,6 @@ namespace ShopifySharp.GraphQL
         ///Quantity rules can be associated only with company location catalogs.
         ///</summary>
         CATALOG_CONTEXT_DOES_NOT_SUPPORT_QUANTITY_RULES,
-        ///<summary>
-        ///Quantity price breaks can be associated only with company location catalogs.
-        ///</summary>
-        CATALOG_CONTEXT_DOES_NOT_SUPPORT_QUANTITY_PRICE_BREAKS,
         ///<summary>
         ///Only one context rule option may be specified.
         ///</summary>
@@ -37287,10 +34484,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public CollectionConnection? collections { get; set; }
         ///<summary>
-        ///The compare-at price range of the product in the default shop currency.
-        ///</summary>
-        public ProductCompareAtPriceRange? compareAtPriceRange { get; set; }
-        ///<summary>
         ///The pricing that applies for a customer in a given context.
         ///</summary>
         public ProductContextualPricing? contextualPricing { get; set; }
@@ -37351,10 +34544,6 @@ namespace ShopifySharp.GraphQL
         ///Whether the product has out of stock variants.
         ///</summary>
         public bool? hasOutOfStockVariants { get; set; }
-        ///<summary>
-        ///Determines if at least one of the product variant requires components. The default value is `false`.
-        ///</summary>
-        public bool? hasVariantsThatRequiresComponents { get; set; }
         ///<summary>
         ///A globally-unique ID.
         ///</summary>
@@ -37699,21 +34888,6 @@ namespace ShopifySharp.GraphQL
         ///Don't use this sort key when no search query is specified.
         ///</summary>
         RELEVANCE,
-    }
-
-    ///<summary>
-    ///The compare-at price range of the product.
-    ///</summary>
-    public class ProductCompareAtPriceRange : GraphQLObject<ProductCompareAtPriceRange>
-    {
-        ///<summary>
-        ///The highest variant's compare-at price.
-        ///</summary>
-        public MoneyV2? maxVariantCompareAtPrice { get; set; }
-        ///<summary>
-        ///The lowest variant's compare-at price.
-        ///</summary>
-        public MoneyV2? minVariantCompareAtPrice { get; set; }
     }
 
     ///<summary>
@@ -39083,10 +36257,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public MoneyV2? price { get; set; }
         ///<summary>
-        ///A list of quantity breaks for the product variant.
-        ///</summary>
-        public QuantityPriceBreakConnection? quantityPriceBreaks { get; set; }
-        ///<summary>
         ///The quantity rule applied for a given context.
         ///</summary>
         public QuantityRule? quantityRule { get; set; }
@@ -40393,273 +37563,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Quantity price breaks lets you offer different rates that are based on the
-    ///amount of a specific variant being ordered.
-    ///</summary>
-    public class QuantityPriceBreak : GraphQLObject<QuantityPriceBreak>, INode
-    {
-        ///<summary>
-        ///A globally-unique ID.
-        ///</summary>
-        public string? id { get; set; }
-        ///<summary>
-        ///Minimum quantity required to reach new quantity break price.
-        ///</summary>
-        public int? minimumQuantity { get; set; }
-        ///<summary>
-        ///The price of variant after reaching the minimum quanity.
-        ///</summary>
-        public MoneyV2? price { get; set; }
-        ///<summary>
-        ///The price list associated with this quantity break.
-        ///</summary>
-        public PriceList? priceList { get; set; }
-        ///<summary>
-        ///The product variant associated with this quantity break.
-        ///</summary>
-        public ProductVariant? variant { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type for paginating through multiple QuantityPriceBreaks.
-    ///</summary>
-    public class QuantityPriceBreakConnection : GraphQLObject<QuantityPriceBreakConnection>, IConnectionWithNodesAndEdges<QuantityPriceBreakEdge, QuantityPriceBreak>
-    {
-        ///<summary>
-        ///A list of edges.
-        ///</summary>
-        public IEnumerable<QuantityPriceBreakEdge>? edges { get; set; }
-        ///<summary>
-        ///A list of the nodes contained in QuantityPriceBreakEdge.
-        ///</summary>
-        public IEnumerable<QuantityPriceBreak>? nodes { get; set; }
-        ///<summary>
-        ///Information to aid in pagination.
-        ///</summary>
-        public PageInfo? pageInfo { get; set; }
-        ///<summary>
-        ///The total count of QuantityPriceBreaks.
-        ///</summary>
-        public ulong? totalCount { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type which holds one QuantityPriceBreak and a cursor during pagination.
-    ///</summary>
-    public class QuantityPriceBreakEdge : GraphQLObject<QuantityPriceBreakEdge>, IEdge<QuantityPriceBreak>
-    {
-        ///<summary>
-        ///A cursor for use in pagination.
-        ///</summary>
-        public string? cursor { get; set; }
-        ///<summary>
-        ///The item at the end of QuantityPriceBreakEdge.
-        ///</summary>
-        public QuantityPriceBreak? node { get; set; }
-    }
-
-    ///<summary>
-    ///The set of valid sort keys for the QuantityPriceBreak query.
-    ///</summary>
-    public enum QuantityPriceBreakSortKeys
-    {
-        ///<summary>
-        ///Sort by the `minimum_quantity` value.
-        ///</summary>
-        MINIMUM_QUANTITY,
-        ///<summary>
-        ///Sort by the `id` value.
-        ///</summary>
-        ID,
-        ///<summary>
-        ///Sort by relevance to the search terms when the `query` parameter is specified on the connection.
-        ///Don't use this sort key when no search query is specified.
-        ///</summary>
-        RELEVANCE,
-    }
-
-    ///<summary>
-    ///Return type for `quantityPricingByVariantUpdate` mutation.
-    ///</summary>
-    public class QuantityPricingByVariantUpdatePayload : GraphQLObject<QuantityPricingByVariantUpdatePayload>
-    {
-        ///<summary>
-        ///The variants for which quantity pricing was created successfully in the price list.
-        ///</summary>
-        public IEnumerable<ProductVariant>? productVariants { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<QuantityPricingByVariantUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Error codes for failed volume pricing operations.
-    ///</summary>
-    public class QuantityPricingByVariantUserError : GraphQLObject<QuantityPricingByVariantUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public QuantityPricingByVariantUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `QuantityPricingByVariantUserError`.
-    ///</summary>
-    public enum QuantityPricingByVariantUserErrorCode
-    {
-        ///<summary>
-        ///The input value is blank.
-        ///</summary>
-        BLANK,
-        ///<summary>
-        ///Price List does not exist.
-        ///</summary>
-        PRICE_LIST_NOT_FOUND,
-        ///<summary>
-        ///Something went wrong when trying to update quantity pricing. Please try again later.
-        ///</summary>
-        GENERIC_ERROR,
-        ///<summary>
-        ///Invalid quantity price break.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_INVALID,
-        ///<summary>
-        ///Quantity price break's fixed price not found.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_PRICE_LIST_PRICE_NOT_FOUND,
-        ///<summary>
-        ///Exceeded the allowed number of quantity price breaks per variant.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_LIMIT_EXCEEDED,
-        ///<summary>
-        ///Price list and quantity price break currency mismatch.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_CURRENCY_MISMATCH,
-        ///<summary>
-        ///Failed to save quantity price break.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_FAILED_TO_SAVE,
-        ///<summary>
-        ///Quantity price break miniumum is less than the quantity rule minimum.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_MIN_LOWER_THAN_QUANTITY_RULES_MIN,
-        ///<summary>
-        ///Quantity price break miniumum is higher than the quantity rule maximum.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_MIN_HIGHER_THAN_QUANTITY_RULES_MAX,
-        ///<summary>
-        ///Quantity price break miniumum is not multiple of the quantity rule increment.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_MIN_NOT_A_MULTIPLE_OF_QUANTITY_RULES_INCREMENT,
-        ///<summary>
-        ///Quantity price break variant not found.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_VARIANT_NOT_FOUND,
-        ///<summary>
-        ///Quantity price breaks to add inputs must be unique by variant id and minimum quantity.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_ADD_DUPLICATE_INPUT_FOR_VARIANT_AND_MIN,
-        ///<summary>
-        ///Quantity price break not found.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_DELETE_NOT_FOUND,
-        ///<summary>
-        ///Failed to delete quantity price break.
-        ///</summary>
-        QUANTITY_PRICE_BREAK_DELETE_FAILED,
-        ///<summary>
-        ///Quantity rule variant not found.
-        ///</summary>
-        QUANTITY_RULE_ADD_VARIANT_NOT_FOUND,
-        ///<summary>
-        ///Quantity rule minimum is higher than the quantity price break minimum.
-        ///</summary>
-        QUANTITY_RULE_ADD_MIN_HIGHER_THAN_QUANTITY_PRICE_BREAK_MIN,
-        ///<summary>
-        ///Quantity rule maximum is less than the quantity price break minimum.
-        ///</summary>
-        QUANTITY_RULE_ADD_MAX_LOWER_THAN_QUANTITY_PRICE_BREAK_MIN,
-        ///<summary>
-        ///Quantity rule increment must be a multiple of the quantity price break minimum.
-        ///</summary>
-        QUANTITY_RULE_ADD_INCREMENT_NOT_A_MULTIPLE_OF_QUANTITY_PRICE_BREAK_MIN,
-        ///<summary>
-        ///Quantity rule catalog context not supported.
-        ///</summary>
-        QUANTITY_RULE_ADD_CATALOG_CONTEXT_NOT_SUPPORTED,
-        ///<summary>
-        ///Quantity rule increment is greater than minimum.
-        ///</summary>
-        QUANTITY_RULE_ADD_INCREMENT_IS_GREATER_THAN_MINIMUM,
-        ///<summary>
-        ///Quantity rule minimum is not a multiple of increment.
-        ///</summary>
-        QUANTITY_RULE_ADD_MINIMUM_NOT_A_MULTIPLE_OF_INCREMENT,
-        ///<summary>
-        ///Quantity rule maximum is not a multiple of increment.
-        ///</summary>
-        QUANTITY_RULE_ADD_MAXIMUM_NOT_A_MULTIPLE_OF_INCREMENT,
-        ///<summary>
-        ///Quantity rule minimum is greater than maximum.
-        ///</summary>
-        QUANTITY_RULE_ADD_MINIMUM_GREATER_THAN_MAXIMUM,
-        ///<summary>
-        ///Quantity rule increment is less than one.
-        ///</summary>
-        QUANTITY_RULE_ADD_INCREMENT_IS_LESS_THAN_ONE,
-        ///<summary>
-        ///Quantity rule minimum is less than one.
-        ///</summary>
-        QUANTITY_RULE_ADD_MINIMUM_IS_LESS_THAN_ONE,
-        ///<summary>
-        ///Quantity rule maximum is less than one.
-        ///</summary>
-        QUANTITY_RULE_ADD_MAXIMUM_IS_LESS_THAN_ONE,
-        ///<summary>
-        ///Quantity rules to add inputs must be unique by variant id.
-        ///</summary>
-        QUANTITY_RULE_ADD_DUPLICATE_INPUT_FOR_VARIANT,
-        ///<summary>
-        ///Quantity rule not found.
-        ///</summary>
-        QUANTITY_RULE_DELETE_RULE_NOT_FOUND,
-        ///<summary>
-        ///Quantity rule variant not found.
-        ///</summary>
-        QUANTITY_RULE_DELETE_VARIANT_NOT_FOUND,
-        ///<summary>
-        ///Price list and fixed price currency mismatch.
-        ///</summary>
-        PRICE_ADD_CURRENCY_MISMATCH,
-        ///<summary>
-        ///Fixed price's variant not found.
-        ///</summary>
-        PRICE_ADD_VARIANT_NOT_FOUND,
-        ///<summary>
-        ///Prices to add inputs must be unique by variant id.
-        ///</summary>
-        PRICE_ADD_DUPLICATE_INPUT_FOR_VARIANT,
-        ///<summary>
-        ///Price is not fixed.
-        ///</summary>
-        PRICE_DELETE_PRICE_NOT_FIXED,
-        ///<summary>
-        ///Fixed price's variant not found.
-        ///</summary>
-        PRICE_DELETE_VARIANT_NOT_FOUND,
-    }
-
-    ///<summary>
     ///The quantity rule for the product variant in a given context.
     ///</summary>
     public class QuantityRule : GraphQLObject<QuantityRule>
@@ -40714,7 +37617,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public PageInfo? pageInfo { get; set; }
         ///<summary>
-        ///The total count of QuantityRules.
+        ///The total count of QuantityRules. Note: The maximum count limit is 10000.
         ///</summary>
         public ulong? totalCount { get; set; }
     }
@@ -40794,18 +37697,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         MINIMUM_IS_GREATER_THAN_MAXIMUM,
         ///<summary>
-        ///Minimum must be less than or equal to all quantity price break minimums associated with this variant in the specified price list.
-        ///</summary>
-        MINIMUM_IS_HIGHER_THAN_QUANTITY_PRICE_BREAK_MINIMUM,
-        ///<summary>
-        ///Maximum must be greater than or equal to all quantity price break minimums associated with this variant in the specified price list.
-        ///</summary>
-        MAXIMUM_IS_LOWER_THAN_QUANTITY_PRICE_BREAK_MINIMUM,
-        ///<summary>
-        ///Increment must be a multiple of all quantity price break minimums associated with this variant in the specified price list.
-        ///</summary>
-        INCREMENT_NOT_A_MULTIPLE_OF_QUANTITY_PRICE_BREAK_MINIMUM,
-        ///<summary>
         ///Increment must be lower than or equal to the minimum.
         ///</summary>
         INCREMENT_IS_GREATER_THAN_MINIMUM,
@@ -40825,10 +37716,6 @@ namespace ShopifySharp.GraphQL
         ///Quantity rules can be associated only with company location catalogs.
         ///</summary>
         CATALOG_CONTEXT_DOES_NOT_SUPPORT_QUANTITY_RULES,
-        ///<summary>
-        ///Quantity rule inputs must be unique by variant id.
-        ///</summary>
-        DUPLICATE_INPUT_FOR_VARIANT,
         ///<summary>
         ///Something went wrong when trying to save the quantity rule. Please try again later.
         ///</summary>
@@ -40972,10 +37859,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         [Obsolete("Use `publications` instead.")]
         public ChannelConnection? channels { get; set; }
-        ///<summary>
-        ///Returns the checkout branding settings for a checkout profile.
-        ///</summary>
-        public CheckoutBranding? checkoutBranding { get; set; }
         ///<summary>
         ///A checkout profile on a shop.
         ///</summary>
@@ -41175,10 +38058,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public Fulfillment? fulfillment { get; set; }
         ///<summary>
-        ///The fulfillment constraint rules that belong to a shop.
-        ///</summary>
-        public IEnumerable<FulfillmentConstraintRule>? fulfillmentConstraintRules { get; set; }
-        ///<summary>
         ///Returns a Fulfillment order resource by ID.
         ///</summary>
         public FulfillmentOrder? fulfillmentOrder { get; set; }
@@ -41298,6 +38177,10 @@ namespace ShopifySharp.GraphQL
         ///The markets configured for the shop.
         ///</summary>
         public MarketConnection? markets { get; set; }
+        ///<summary>
+        ///Returns a metafield by ID.
+        ///</summary>
+        public Metafield? metafield { get; set; }
         ///<summary>
         ///Returns a metafield definition by ID.
         ///</summary>
@@ -41671,14 +38554,6 @@ namespace ShopifySharp.GraphQL
         ///A list of redirects for a shop.
         ///</summary>
         public UrlRedirectConnection? urlRedirects { get; set; }
-        ///<summary>
-        ///Validation available on the shop.
-        ///</summary>
-        public Validation? validation { get; set; }
-        ///<summary>
-        ///Validations available on the shop.
-        ///</summary>
-        public ValidationConnection? validations { get; set; }
         ///<summary>
         ///The web pixel configured by the app.
         ///</summary>
@@ -42123,6 +38998,29 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
+    ///A resource limit represents the limits that the resource has.
+    ///</summary>
+    public class ResourceLimit : GraphQLObject<ResourceLimit>
+    {
+        ///<summary>
+        ///Whether the resource is available.
+        ///</summary>
+        public bool? available { get; set; }
+        ///<summary>
+        ///Quantity available. If null the quantity available is unlimited.
+        ///</summary>
+        public int? quantityAvailable { get; set; }
+        ///<summary>
+        ///Quantity limit of the resource. If null the quantity is unlimited.
+        ///</summary>
+        public int? quantityLimit { get; set; }
+        ///<summary>
+        ///Quantity used of the resource. If null the quantity used can't be retrieved.
+        ///</summary>
+        public int? quantityUsed { get; set; }
+    }
+
+    ///<summary>
     ///Represents a merchandising background operation interface.
     ///</summary>
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "__typename")]
@@ -42341,7 +39239,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public SuggestedReturnRefund? suggestedRefund { get; set; }
         ///<summary>
-        ///The sum of all return line item quantities for the return.
+        ///The sum of all line item quantities for the return. Includes the total quantity of both return line items and exchange line items.
         ///</summary>
         public int? totalQuantity { get; set; }
     }
@@ -43813,26 +40711,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///The set of valid sort keys for the ScheduledChange query.
-    ///</summary>
-    public enum ScheduledChangeSortKeys
-    {
-        ///<summary>
-        ///Sort by the `expected_at` value.
-        ///</summary>
-        EXPECTED_AT,
-        ///<summary>
-        ///Sort by the `id` value.
-        ///</summary>
-        ID,
-        ///<summary>
-        ///Sort by relevance to the search terms when the `query` parameter is specified on the connection.
-        ///Don't use this sort key when no search query is specified.
-        ///</summary>
-        RELEVANCE,
-    }
-
-    ///<summary>
     ///Script discount applications capture the intentions of a discount that
     ///was created by a Shopify Script for an order's line item or shipping line.
     ///
@@ -44131,10 +41009,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         DISCOUNT_REDEEM_CODE,
         ORDER,
-        ///<summary>
-        ///A balance transaction.
-        ///</summary>
-        BALANCE_TRANSACTION,
     }
 
     ///<summary>
@@ -45616,14 +42490,6 @@ namespace ShopifySharp.GraphQL
         ///A selling plan can't have both fixed and recurring delivery policies.
         ///</summary>
         ONLY_ONE_OF_FIXED_OR_RECURRING_DELIVERY,
-        ///<summary>
-        ///Billing policy's interval is too large.
-        ///</summary>
-        BILLING_POLICY_INTERVAL_TOO_LARGE,
-        ///<summary>
-        ///Delivery policy's interval is too large.
-        ///</summary>
-        DELIVERY_POLICY_INTERVAL_TOO_LARGE,
     }
 
     ///<summary>
@@ -45848,7 +42714,7 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Represents a recurring selling plan pricing policy. It applies after the fixed pricing policy. By using the afterCycle parameter, you can specify the cycle when the recurring pricing policy comes into effect. Recurring pricing policies are not available for deferred purchase options.
+    ///Represents a recurring selling plan pricing policy.
     ///</summary>
     public class SellingPlanRecurringPricingPolicy : GraphQLObject<SellingPlanRecurringPricingPolicy>, ISellingPlanPricingPolicyBase, ISellingPlanPricingPolicy
     {
@@ -46390,10 +43256,6 @@ namespace ShopifySharp.GraphQL
         ///Whether customer accounts are required, optional, or disabled for the shop.
         ///</summary>
         public ShopCustomerAccountsSetting? customerAccounts { get; set; }
-        ///<summary>
-        ///Information about the shop's customer accounts.
-        ///</summary>
-        public CustomerAccountsV2? customerAccountsV2 { get; set; }
 
         ///<summary>
         ///List of the shop's customer saved searches.
@@ -46652,6 +43514,12 @@ namespace ShopifySharp.GraphQL
         ///The list of all legal policies associated with a shop.
         ///</summary>
         public IEnumerable<ShopPolicy>? shopPolicies { get; set; }
+
+        ///<summary>
+        ///Shopify Payments account information, including balances and payouts.
+        ///</summary>
+        [Obsolete("Use `QueryRoot.shopifyPaymentsAccount` instead.")]
+        public ShopifyPaymentsAccount? shopifyPaymentsAccount { get; set; }
         ///<summary>
         ///The paginated list of the shop's staff members.
         ///</summary>
@@ -46917,10 +43785,6 @@ namespace ShopifySharp.GraphQL
         ///Whether a shop's online store can have CAPTCHA protection for domains not managed by Shopify.
         ///</summary>
         public bool? captchaExternalDomains { get; set; }
-        ///<summary>
-        ///Represents the cart transform feature configuration for the shop.
-        ///</summary>
-        public CartTransformFeature? cartTransform { get; set; }
 
         ///<summary>
         ///Whether the delivery profiles functionality is enabled for this shop.
@@ -46948,11 +43812,9 @@ namespace ShopifySharp.GraphQL
         ///internationally.
         ///</summary>
         public bool? harmonizedSystemCode { get; set; }
-
         ///<summary>
         ///Whether a shop can enable international domains.
         ///</summary>
-        [Obsolete("All shops have international domains through Shopify Markets.")]
         public bool? internationalDomains { get; set; }
         ///<summary>
         ///Whether a shop can enable international price overrides.
@@ -47083,17 +43945,6 @@ namespace ShopifySharp.GraphQL
         ///The list of errors that occurred from executing the mutation.
         ///</summary>
         public IEnumerable<UserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Shop Pay Installments payment details related to a transaction.
-    ///</summary>
-    public class ShopPayInstallmentsPaymentDetails : GraphQLObject<ShopPayInstallmentsPaymentDetails>, IBasePaymentDetails, IPaymentDetails
-    {
-        ///<summary>
-        ///The name of payment method used by the buyer.
-        ///</summary>
-        public string? paymentMethodName { get; set; }
     }
 
     ///<summary>
@@ -47304,6 +44155,12 @@ namespace ShopifySharp.GraphQL
         ///Whether the shop has reached the limit of the number of URL redirects it can make for resources.
         ///</summary>
         public bool? redirectLimitReached { get; set; }
+
+        ///<summary>
+        ///The maximum number of variants allowed per shop. If the shop has unlimited SKUs, then the quantity used can't be retrieved.
+        ///</summary>
+        [Obsolete("This field is deprecated. After the 2023-10 version, we no longer set limits on number of SKUs per shop. Use `maxProductVariants` instead.")]
+        public ResourceLimit? skuResourceLimits { get; set; }
     }
 
     ///<summary>
@@ -47419,10 +44276,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public IEnumerable<MoneyV2>? balance { get; set; }
         ///<summary>
-        ///A list of balance transactions associated with the shop.
-        ///</summary>
-        public ShopifyPaymentsBalanceTransactionConnection? balanceTransactions { get; set; }
-        ///<summary>
         ///All bank accounts configured for the Shopify Payments account.
         ///</summary>
         public ShopifyPaymentsBankAccountConnection? bankAccounts { get; set; }
@@ -47490,82 +44343,6 @@ namespace ShopifySharp.GraphQL
         ///The verifications necessary for this account.
         ///</summary>
         public IEnumerable<ShopifyPaymentsVerification>? verifications { get; set; }
-    }
-
-    ///<summary>
-    ///The adjustment order object.
-    ///</summary>
-    public class ShopifyPaymentsAdjustmentOrder : GraphQLObject<ShopifyPaymentsAdjustmentOrder>
-    {
-        ///<summary>
-        ///The amount of the adjustment order.
-        ///</summary>
-        public MoneyV2? amount { get; set; }
-        ///<summary>
-        ///The link to the adjustment order.
-        ///</summary>
-        public string? link { get; set; }
-        ///<summary>
-        ///The name of the adjustment order.
-        ///</summary>
-        public string? name { get; set; }
-    }
-
-    ///<summary>
-    ///A transaction that contributes to a Shopify Payments account balance.
-    ///</summary>
-    public class ShopifyPaymentsBalanceTransaction : GraphQLObject<ShopifyPaymentsBalanceTransaction>, INode
-    {
-        ///<summary>
-        ///The adjustment orders associated to the transaction.
-        ///</summary>
-        public IEnumerable<ShopifyPaymentsAdjustmentOrder>? adjustmentsOrders { get; set; }
-        ///<summary>
-        ///A globally-unique ID.
-        ///</summary>
-        public string? id { get; set; }
-        ///<summary>
-        ///The net amount contributing to the merchant's balance.
-        ///</summary>
-        public MoneyV2? net { get; set; }
-        ///<summary>
-        ///The date and time when the balance transaction was processed.
-        ///</summary>
-        public DateTime? transactionDate { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type for paginating through multiple ShopifyPaymentsBalanceTransactions.
-    ///</summary>
-    public class ShopifyPaymentsBalanceTransactionConnection : GraphQLObject<ShopifyPaymentsBalanceTransactionConnection>, IConnectionWithNodesAndEdges<ShopifyPaymentsBalanceTransactionEdge, ShopifyPaymentsBalanceTransaction>
-    {
-        ///<summary>
-        ///A list of edges.
-        ///</summary>
-        public IEnumerable<ShopifyPaymentsBalanceTransactionEdge>? edges { get; set; }
-        ///<summary>
-        ///A list of the nodes contained in ShopifyPaymentsBalanceTransactionEdge.
-        ///</summary>
-        public IEnumerable<ShopifyPaymentsBalanceTransaction>? nodes { get; set; }
-        ///<summary>
-        ///Information to aid in pagination.
-        ///</summary>
-        public PageInfo? pageInfo { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type which holds one ShopifyPaymentsBalanceTransaction and a cursor during pagination.
-    ///</summary>
-    public class ShopifyPaymentsBalanceTransactionEdge : GraphQLObject<ShopifyPaymentsBalanceTransactionEdge>, IEdge<ShopifyPaymentsBalanceTransaction>
-    {
-        ///<summary>
-        ///A cursor for use in pagination.
-        ///</summary>
-        public string? cursor { get; set; }
-        ///<summary>
-        ///The item at the end of ShopifyPaymentsBalanceTransactionEdge.
-        ///</summary>
-        public ShopifyPaymentsBalanceTransaction? node { get; set; }
     }
 
     ///<summary>
@@ -48455,80 +45232,6 @@ namespace ShopifySharp.GraphQL
         ///The given name of the individual to verify.
         ///</summary>
         public string? givenName { get; set; }
-    }
-
-    ///<summary>
-    ///The status of an order's eligibility for protection against fraudulent chargebacks by Shopify Protect.
-    ///</summary>
-    public enum ShopifyProtectEligibilityStatus
-    {
-        ///<summary>
-        ///The eligibility of the order is pending and has not yet been determined.
-        ///</summary>
-        PENDING,
-        ///<summary>
-        ///The order is eligible for protection against fraudulent chargebacks.
-        ///If an order is updated, the order's eligibility may change and protection could be removed.
-        ///</summary>
-        ELIGIBLE,
-        ///<summary>
-        ///The order isn't eligible for protection against fraudulent chargebacks.
-        ///</summary>
-        NOT_ELIGIBLE,
-    }
-
-    ///<summary>
-    ///The eligibility details of an order's protection against fraudulent chargebacks by Shopify Protect.
-    ///</summary>
-    public class ShopifyProtectOrderEligibility : GraphQLObject<ShopifyProtectOrderEligibility>
-    {
-        ///<summary>
-        ///The status of whether an order is eligible for protection against fraudulent chargebacks.
-        ///</summary>
-        public ShopifyProtectEligibilityStatus? status { get; set; }
-    }
-
-    ///<summary>
-    ///A summary of Shopify Protect details for an order.
-    ///</summary>
-    public class ShopifyProtectOrderSummary : GraphQLObject<ShopifyProtectOrderSummary>
-    {
-        ///<summary>
-        ///The eligibility details of an order's protection against fraudulent chargebacks.
-        ///</summary>
-        public ShopifyProtectOrderEligibility? eligibility { get; set; }
-        ///<summary>
-        ///The status of the order's protection against fraudulent chargebacks.
-        ///</summary>
-        public ShopifyProtectStatus? status { get; set; }
-    }
-
-    ///<summary>
-    ///The status of an order's protection with Shopify Protect.
-    ///</summary>
-    public enum ShopifyProtectStatus
-    {
-        ///<summary>
-        ///The protection for the order is pending and has not yet been determined.
-        ///</summary>
-        PENDING,
-        ///<summary>
-        ///The protection for the order is active and eligible for reimbursement against fraudulent chargebacks.
-        ///If an order is updated, the order's eligibility may change and protection could become inactive.
-        ///</summary>
-        ACTIVE,
-        ///<summary>
-        ///The protection for an order isn't active because the order didn't meet eligibility requirements.
-        ///</summary>
-        INACTIVE,
-        ///<summary>
-        ///The order received a fraudulent chargeback and it was protected.
-        ///</summary>
-        PROTECTED,
-        ///<summary>
-        ///The order received a chargeback but the order wasn't protected because it didn't meet coverage requirements.
-        ///</summary>
-        NOT_PROTECTED,
     }
 
     ///<summary>
@@ -49859,96 +46562,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `subscriptionBillingCycleSkip` mutation.
-    ///</summary>
-    public class SubscriptionBillingCycleSkipPayload : GraphQLObject<SubscriptionBillingCycleSkipPayload>
-    {
-        ///<summary>
-        ///The updated billing cycle.
-        ///</summary>
-        public SubscriptionBillingCycle? billingCycle { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionBillingCycleSkipUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `SubscriptionBillingCycleSkip`.
-    ///</summary>
-    public class SubscriptionBillingCycleSkipUserError : GraphQLObject<SubscriptionBillingCycleSkipUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public SubscriptionBillingCycleSkipUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `SubscriptionBillingCycleSkipUserError`.
-    ///</summary>
-    public enum SubscriptionBillingCycleSkipUserErrorCode
-    {
-        ///<summary>
-        ///The input value is invalid.
-        ///</summary>
-        INVALID,
-    }
-
-    ///<summary>
-    ///Return type for `subscriptionBillingCycleUnskip` mutation.
-    ///</summary>
-    public class SubscriptionBillingCycleUnskipPayload : GraphQLObject<SubscriptionBillingCycleUnskipPayload>
-    {
-        ///<summary>
-        ///The updated billing cycle.
-        ///</summary>
-        public SubscriptionBillingCycle? billingCycle { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionBillingCycleUnskipUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of `SubscriptionBillingCycleUnskip`.
-    ///</summary>
-    public class SubscriptionBillingCycleUnskipUserError : GraphQLObject<SubscriptionBillingCycleUnskipUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public SubscriptionBillingCycleUnskipUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `SubscriptionBillingCycleUnskipUserError`.
-    ///</summary>
-    public enum SubscriptionBillingCycleUnskipUserErrorCode
-    {
-        ///<summary>
-        ///The input value is invalid.
-        ///</summary>
-        INVALID,
-    }
-
-    ///<summary>
     ///The possible errors for a subscription billing cycle.
     ///</summary>
     public class SubscriptionBillingCycleUserError : GraphQLObject<SubscriptionBillingCycleUserError>, IDisplayableError
@@ -50099,10 +46712,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         public SubscriptionLineConnection? lines { get; set; }
         ///<summary>
-        ///The next billing date for the subscription contract. This field is managed by the apps.
-        ///        Alternatively you can utilize our
-        ///        [Billing Cycles APIs](https://shopify.dev/docs/apps/selling-strategies/subscriptions/billing-cycles),
-        ///        which provide auto-computed billing dates and additional functionalities.
+        ///The next billing date for the subscription contract.
         ///</summary>
         public DateTime? nextBillingDate { get; set; }
         ///<summary>
@@ -50129,21 +46739,6 @@ namespace ShopifySharp.GraphQL
         ///The date and time when the subscription contract was updated.
         ///</summary>
         public DateTime? updatedAt { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `subscriptionContractActivate` mutation.
-    ///</summary>
-    public class SubscriptionContractActivatePayload : GraphQLObject<SubscriptionContractActivatePayload>
-    {
-        ///<summary>
-        ///The new Subscription Contract object.
-        ///</summary>
-        public SubscriptionContract? contract { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionContractStatusUpdateUserError>? userErrors { get; set; }
     }
 
     ///<summary>
@@ -50230,21 +46825,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `subscriptionContractCancel` mutation.
-    ///</summary>
-    public class SubscriptionContractCancelPayload : GraphQLObject<SubscriptionContractCancelPayload>
-    {
-        ///<summary>
-        ///The new Subscription Contract object.
-        ///</summary>
-        public SubscriptionContract? contract { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionContractStatusUpdateUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///An auto-generated type for paginating through multiple SubscriptionContracts.
     ///</summary>
     public class SubscriptionContractConnection : GraphQLObject<SubscriptionContractConnection>, IConnectionWithNodesAndEdges<SubscriptionContractEdge, SubscriptionContract>
@@ -50305,36 +46885,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Return type for `subscriptionContractExpire` mutation.
-    ///</summary>
-    public class SubscriptionContractExpirePayload : GraphQLObject<SubscriptionContractExpirePayload>
-    {
-        ///<summary>
-        ///The new Subscription Contract object.
-        ///</summary>
-        public SubscriptionContract? contract { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionContractStatusUpdateUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `subscriptionContractFail` mutation.
-    ///</summary>
-    public class SubscriptionContractFailPayload : GraphQLObject<SubscriptionContractFailPayload>
-    {
-        ///<summary>
-        ///The new Subscription Contract object.
-        ///</summary>
-        public SubscriptionContract? contract { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionContractStatusUpdateUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
     ///The possible status values of the last payment on a subscription contract.
     ///</summary>
     public enum SubscriptionContractLastPaymentStatus
@@ -50347,21 +46897,6 @@ namespace ShopifySharp.GraphQL
         ///Failed subscription billing attempt.
         ///</summary>
         FAILED,
-    }
-
-    ///<summary>
-    ///Return type for `subscriptionContractPause` mutation.
-    ///</summary>
-    public class SubscriptionContractPausePayload : GraphQLObject<SubscriptionContractPausePayload>
-    {
-        ///<summary>
-        ///The new Subscription Contract object.
-        ///</summary>
-        public SubscriptionContract? contract { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<SubscriptionContractStatusUpdateUserError>? userErrors { get; set; }
     }
 
     ///<summary>
@@ -50399,40 +46934,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///Possible error codes that can be returned by `SubscriptionContractStatusUpdateUserError`.
-    ///</summary>
-    public enum SubscriptionContractStatusUpdateErrorCode
-    {
-        ///<summary>
-        ///The input value is invalid.
-        ///</summary>
-        INVALID,
-        ///<summary>
-        ///Subscription contract status cannot be changed once terminated.
-        ///</summary>
-        CONTRACT_TERMINATED,
-    }
-
-    ///<summary>
-    ///Represents a subscription contract status update error.
-    ///</summary>
-    public class SubscriptionContractStatusUpdateUserError : GraphQLObject<SubscriptionContractStatusUpdateUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public SubscriptionContractStatusUpdateErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
     ///The possible status values of a subscription.
     ///</summary>
     public enum SubscriptionContractSubscriptionStatus
@@ -50457,6 +46958,10 @@ namespace ShopifySharp.GraphQL
         ///The contract ended because billing failed and no further billing attempts are expected.
         ///</summary>
         FAILED,
+        ///<summary>
+        ///The contract has expired due to inactivity.
+        ///</summary>
+        STALE,
     }
 
     ///<summary>
@@ -51885,10 +48390,6 @@ namespace ShopifySharp.GraphQL
         ///The associated parent transaction, for example the authorization of a capture.
         ///</summary>
         public OrderTransaction? parentTransaction { get; set; }
-        ///<summary>
-        ///The associated payment details related to the transaction.
-        ///</summary>
-        public IPaymentDetails? paymentDetails { get; set; }
     }
 
     ///<summary>
@@ -52857,7 +49358,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         PAYMENT_GATEWAY,
         ///<summary>
-        ///An online store product. Translatable fields: `title`, `body_html`, `handle`, `product_type`, `meta_title`, `meta_description`.
+        ///An online store product. Translatable fields: `title`, `body_html`, `handle`, `meta_title`, `meta_description`.
         ///</summary>
         PRODUCT,
         ///<summary>
@@ -52866,7 +49367,7 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         PRODUCT_OPTION,
         ///<summary>
-        ///An online store product variant. Translatable fields: `option1`, `option2`, `option3`.
+        ///An online store product variant. Translatable fields: `title`, `option1`, `option2`, `option3`. The field `title` has been deprecated.
         ///</summary>
         PRODUCT_VARIANT,
         ///<summary>
@@ -53608,250 +50109,6 @@ namespace ShopifySharp.GraphQL
     }
 
     ///<summary>
-    ///A checkout server side validation installed on the shop.
-    ///</summary>
-    public class Validation : GraphQLObject<Validation>, IHasMetafieldDefinitions, IHasMetafields, INode
-    {
-        ///<summary>
-        ///Whether the validation should block on failures other than expected violations.
-        ///</summary>
-        public bool? blockOnFailure { get; set; }
-        ///<summary>
-        ///Whether the validation is enabled on the merchant checkout.
-        ///</summary>
-        public bool? enabled { get; set; }
-        ///<summary>
-        ///The error history on the most recent version of the validation function.
-        ///</summary>
-        public FunctionsErrorHistory? errorHistory { get; set; }
-        ///<summary>
-        ///Global ID for the validation.
-        ///</summary>
-        public string? id { get; set; }
-        ///<summary>
-        ///Returns a metafield by namespace and key that belongs to the resource.
-        ///</summary>
-        public Metafield? metafield { get; set; }
-        ///<summary>
-        ///List of metafield definitions.
-        ///</summary>
-        public MetafieldDefinitionConnection? metafieldDefinitions { get; set; }
-        ///<summary>
-        ///List of metafields that belong to the resource.
-        ///</summary>
-        public MetafieldConnection? metafields { get; set; }
-
-        ///<summary>
-        ///Returns a private metafield by namespace and key that belongs to the resource.
-        ///</summary>
-        [Obsolete("Metafields created using a reserved namespace are private by default. See our guide for\n[migrating private metafields](https://shopify.dev/docs/apps/custom-data/metafields/migrate-private-metafields).")]
-        public PrivateMetafield? privateMetafield { get; set; }
-
-        ///<summary>
-        ///List of private metafields that belong to the resource.
-        ///</summary>
-        [Obsolete("Metafields created using a reserved namespace are private by default. See our guide for\n[migrating private metafields](https://shopify.dev/docs/apps/custom-data/metafields/migrate-private-metafields).")]
-        public PrivateMetafieldConnection? privateMetafields { get; set; }
-        ///<summary>
-        ///The Shopify Function implementing the validation.
-        ///</summary>
-        public ShopifyFunction? shopifyFunction { get; set; }
-        ///<summary>
-        ///The merchant-facing validation name.
-        ///</summary>
-        public string? title { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type for paginating through multiple Validations.
-    ///</summary>
-    public class ValidationConnection : GraphQLObject<ValidationConnection>, IConnectionWithNodesAndEdges<ValidationEdge, Validation>
-    {
-        ///<summary>
-        ///A list of edges.
-        ///</summary>
-        public IEnumerable<ValidationEdge>? edges { get; set; }
-        ///<summary>
-        ///A list of the nodes contained in ValidationEdge.
-        ///</summary>
-        public IEnumerable<Validation>? nodes { get; set; }
-        ///<summary>
-        ///Information to aid in pagination.
-        ///</summary>
-        public PageInfo? pageInfo { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `validationCreate` mutation.
-    ///</summary>
-    public class ValidationCreatePayload : GraphQLObject<ValidationCreatePayload>
-    {
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<ValidationUserError>? userErrors { get; set; }
-        ///<summary>
-        ///The created validation.
-        ///</summary>
-        public Validation? validation { get; set; }
-    }
-
-    ///<summary>
-    ///Return type for `validationDelete` mutation.
-    ///</summary>
-    public class ValidationDeletePayload : GraphQLObject<ValidationDeletePayload>
-    {
-        ///<summary>
-        ///Returns the deleted validation ID.
-        ///</summary>
-        public string? deletedId { get; set; }
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<ValidationUserError>? userErrors { get; set; }
-    }
-
-    ///<summary>
-    ///An auto-generated type which holds one Validation and a cursor during pagination.
-    ///</summary>
-    public class ValidationEdge : GraphQLObject<ValidationEdge>, IEdge<Validation>
-    {
-        ///<summary>
-        ///A cursor for use in pagination.
-        ///</summary>
-        public string? cursor { get; set; }
-        ///<summary>
-        ///The item at the end of ValidationEdge.
-        ///</summary>
-        public Validation? node { get; set; }
-    }
-
-    ///<summary>
-    ///The set of valid sort keys for the Validation query.
-    ///</summary>
-    public enum ValidationSortKeys
-    {
-        ///<summary>
-        ///Sort by the `id` value.
-        ///</summary>
-        ID,
-        ///<summary>
-        ///Sort by relevance to the search terms when the `query` parameter is specified on the connection.
-        ///Don't use this sort key when no search query is specified.
-        ///</summary>
-        RELEVANCE,
-    }
-
-    ///<summary>
-    ///Return type for `validationUpdate` mutation.
-    ///</summary>
-    public class ValidationUpdatePayload : GraphQLObject<ValidationUpdatePayload>
-    {
-        ///<summary>
-        ///The list of errors that occurred from executing the mutation.
-        ///</summary>
-        public IEnumerable<ValidationUserError>? userErrors { get; set; }
-        ///<summary>
-        ///The updated validation.
-        ///</summary>
-        public Validation? validation { get; set; }
-    }
-
-    ///<summary>
-    ///An error that occurs during the execution of a validation mutation.
-    ///</summary>
-    public class ValidationUserError : GraphQLObject<ValidationUserError>, IDisplayableError
-    {
-        ///<summary>
-        ///The error code.
-        ///</summary>
-        public ValidationUserErrorCode? code { get; set; }
-        ///<summary>
-        ///The path to the input field that caused the error.
-        ///</summary>
-        public IEnumerable<string>? field { get; set; }
-        ///<summary>
-        ///The error message.
-        ///</summary>
-        public string? message { get; set; }
-    }
-
-    ///<summary>
-    ///Possible error codes that can be returned by `ValidationUserError`.
-    ///</summary>
-    public enum ValidationUserErrorCode
-    {
-        ///<summary>
-        ///Validation not found.
-        ///</summary>
-        NOT_FOUND,
-        ///<summary>
-        ///Function not found.
-        ///</summary>
-        FUNCTION_NOT_FOUND,
-        ///<summary>
-        ///Shop must be on a Shopify Plus plan to activate functions from a custom app.
-        ///</summary>
-        CUSTOM_APP_FUNCTION_NOT_ELIGIBLE,
-        ///<summary>
-        ///Function does not implement the required interface for this cart & checkout validation.
-        ///</summary>
-        FUNCTION_DOES_NOT_IMPLEMENT,
-        ///<summary>
-        ///Only unlisted apps can be used for this cart & checkout validation.
-        ///</summary>
-        PUBLIC_APP_NOT_ALLOWED,
-        ///<summary>
-        ///Function is pending deletion.
-        ///</summary>
-        FUNCTION_PENDING_DELETION,
-        ///<summary>
-        ///The type is invalid.
-        ///</summary>
-        INVALID_TYPE,
-        ///<summary>
-        ///The value is invalid for the metafield type or for the definition options.
-        ///</summary>
-        INVALID_VALUE,
-        ///<summary>
-        ///ApiPermission metafields can only be created or updated by the app owner.
-        ///</summary>
-        APP_NOT_AUTHORIZED,
-        ///<summary>
-        ///Unstructured reserved namespace.
-        ///</summary>
-        UNSTRUCTURED_RESERVED_NAMESPACE,
-        ///<summary>
-        ///Owner type can't be used in this mutation.
-        ///</summary>
-        DISALLOWED_OWNER_TYPE,
-        ///<summary>
-        ///The input value isn't included in the list.
-        ///</summary>
-        INCLUSION,
-        ///<summary>
-        ///The input value is already taken.
-        ///</summary>
-        TAKEN,
-        ///<summary>
-        ///The input value needs to be blank.
-        ///</summary>
-        PRESENT,
-        ///<summary>
-        ///The input value is blank.
-        ///</summary>
-        BLANK,
-        ///<summary>
-        ///The input value is too long.
-        ///</summary>
-        TOO_LONG,
-        ///<summary>
-        ///The input value is too short.
-        ///</summary>
-        TOO_SHORT,
-    }
-
-    ///<summary>
     ///Represents a credit card payment instrument.
     ///</summary>
     public class VaultCreditCard : GraphQLObject<VaultCreditCard>, IPaymentInstrument
@@ -54197,10 +50454,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         [Obsolete("Metafields created using a reserved namespace are private by default. See our guide for\n[migrating private metafields](https://shopify.dev/docs/apps/custom-data/metafields/migrate-private-metafields).")]
         public IEnumerable<string>? privateMetafieldNamespaces { get; set; }
-        ///<summary>
-        ///An additional constraint to refine the type of event that triggers the webhook. Only supported on certain topics. See our guide to [sub-topics](https://shopify.dev/docs/apps/webhooks/sub-topics) for more.
-        ///</summary>
-        public string? subTopic { get; set; }
         ///<summary>
         ///The type of event that triggers the webhook. The topic determines when the webhook subscription sends a webhook, as well as what class of data object that webhook contains.
         ///</summary>
@@ -54601,14 +50854,6 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         FULFILLMENT_ORDERS_PLACED_ON_HOLD,
         ///<summary>
-        ///The webhook topic for `fulfillment_orders/merged` events. Occurs when multiple fulfillment orders are merged into a single fulfillment order. Requires at least one of the following scopes: read_merchant_managed_fulfillment_orders, read_assigned_fulfillment_orders, read_third_party_fulfillment_orders.
-        ///</summary>
-        FULFILLMENT_ORDERS_MERGED,
-        ///<summary>
-        ///The webhook topic for `fulfillment_orders/split` events. Occurs when a fulfillment order is split into multiple fulfillment orders. Requires at least one of the following scopes: read_merchant_managed_fulfillment_orders, read_assigned_fulfillment_orders, read_third_party_fulfillment_orders.
-        ///</summary>
-        FULFILLMENT_ORDERS_SPLIT,
-        ///<summary>
         ///The webhook topic for `product_listings/add` events. Occurs whenever an active product is listed on a channel. Requires the `read_product_listings` scope.
         ///</summary>
         PRODUCT_LISTINGS_ADD,
@@ -54942,22 +51187,9 @@ namespace ShopifySharp.GraphQL
         ///</summary>
         MARKETS_DELETE,
         ///<summary>
-        ///The webhook topic for `orders/shopify_protect_eligibility_changed` events. Occurs whenever Shopify Protect's eligibility for an order is changed. Requires the `read_orders` scope.
-        ///</summary>
-        ORDERS_SHOPIFY_PROTECT_ELIGIBILITY_CHANGED,
-        ///<summary>
-        ///The webhook topic for `fulfillment_orders/rescheduled` events. Triggers when a fulfillment order is rescheduled.
-        ///
-        ///Fulfillment orders may be merged if they have the same `fulfillAt` datetime.
-        ///If the fulfillment order is merged then the resulting fulfillment order will be indicated in the webhook body.
-        ///Otherwise it will be the original fulfillment order with an updated `fulfill_at` datetime.
-        /// Requires at least one of the following scopes: read_merchant_managed_fulfillment_orders, read_assigned_fulfillment_orders, read_third_party_fulfillment_orders.
+        ///The webhook topic for `fulfillment_orders/rescheduled` events. Triggers when a fulfillment order is rescheduled Requires at least one of the following scopes: read_merchant_managed_fulfillment_orders, read_assigned_fulfillment_orders, read_third_party_fulfillment_orders.
         ///</summary>
         FULFILLMENT_ORDERS_RESCHEDULED,
-        ///<summary>
-        ///The webhook topic for `publications/delete` events. Occurs whenever a publication is deleted. Requires the `read_publications` scope.
-        ///</summary>
-        PUBLICATIONS_DELETE,
         ///<summary>
         ///The webhook topic for `audit_events/admin_api_activity` events. Triggers for each auditable Admin API request. This topic is limited to one active subscription per Plus store and requires the use of Google Cloud Pub/Sub or AWS EventBridge. Requires the `read_audit_events` scope.
         ///</summary>
@@ -55014,66 +51246,6 @@ namespace ShopifySharp.GraphQL
         ///The webhook topic for `company_contact_roles/revoke` events. Occurs whenever a role is revoked from a contact at a location. Requires the `read_customers` scope.
         ///</summary>
         COMPANY_CONTACT_ROLES_REVOKE,
-        ///<summary>
-        ///The webhook topic for `subscription_contracts/activate` events. Occurs when a subscription contract is activated. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_CONTRACTS_ACTIVATE,
-        ///<summary>
-        ///The webhook topic for `subscription_contracts/pause` events. Occurs when a subscription contract is paused. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_CONTRACTS_PAUSE,
-        ///<summary>
-        ///The webhook topic for `subscription_contracts/cancel` events. Occurs when a subscription contract is canceled. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_CONTRACTS_CANCEL,
-        ///<summary>
-        ///The webhook topic for `subscription_contracts/fail` events. Occurs when a subscription contract is failed. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_CONTRACTS_FAIL,
-        ///<summary>
-        ///The webhook topic for `subscription_contracts/expire` events. Occurs when a subscription contract expires. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_CONTRACTS_EXPIRE,
-        ///<summary>
-        ///The webhook topic for `subscription_billing_cycles/skip` events. Occurs whenever a subscription contract billing cycle is skipped. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_BILLING_CYCLES_SKIP,
-        ///<summary>
-        ///The webhook topic for `subscription_billing_cycles/unskip` events. Occurs whenever a subscription contract billing cycle is unskipped. Requires the `read_own_subscription_contracts` scope.
-        ///</summary>
-        SUBSCRIPTION_BILLING_CYCLES_UNSKIP,
-        ///<summary>
-        ///The webhook topic for `metaobjects/create` events. Occurs when a metaobject is created. Requires the `read_metaobjects` scope.
-        ///</summary>
-        METAOBJECTS_CREATE,
-        ///<summary>
-        ///The webhook topic for `metaobjects/update` events. Occurs when a metaobject is updated. Requires the `read_metaobjects` scope.
-        ///</summary>
-        METAOBJECTS_UPDATE,
-        ///<summary>
-        ///The webhook topic for `metaobjects/delete` events. Occurs when a metaobject is deleted. Requires the `read_metaobjects` scope.
-        ///</summary>
-        METAOBJECTS_DELETE,
-        ///<summary>
-        ///The webhook topic for `discounts/create` events. Occurs whenever a discount is created. Requires the `read_discounts` scope.
-        ///</summary>
-        DISCOUNTS_CREATE,
-        ///<summary>
-        ///The webhook topic for `discounts/update` events. Occurs whenever a discount is updated. Requires the `read_discounts` scope.
-        ///</summary>
-        DISCOUNTS_UPDATE,
-        ///<summary>
-        ///The webhook topic for `discounts/delete` events. Occurs whenever a discount is deleted. Requires the `read_discounts` scope.
-        ///</summary>
-        DISCOUNTS_DELETE,
-        ///<summary>
-        ///The webhook topic for `discounts/redeemcode_added` events. Occurs whenever a redeem code is added to a code discount. Requires the `read_discounts` scope.
-        ///</summary>
-        DISCOUNTS_REDEEMCODE_ADDED,
-        ///<summary>
-        ///The webhook topic for `discounts/redeemcode_removed` events. Occurs whenever a redeem code on a code discount is deleted. Requires the `read_discounts` scope.
-        ///</summary>
-        DISCOUNTS_REDEEMCODE_REMOVED,
     }
 
     ///<summary>

--- a/ShopifySharp/Factories/ShopPlanServiceFactory.cs
+++ b/ShopifySharp/Factories/ShopPlanServiceFactory.cs
@@ -4,7 +4,6 @@
 
 using ShopifySharp.Credentials;
 using ShopifySharp.Utilities;
-using ShopifySharp.Services;
 
 namespace ShopifySharp.Factories;
 

--- a/ShopifySharp/Infrastructure/BucketStates/RestBucketState.cs
+++ b/ShopifySharp/Infrastructure/BucketStates/RestBucketState.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace ShopifySharp
 {
@@ -11,9 +11,9 @@ namespace ShopifySharp
 
         public const string RESPONSE_HEADER_API_CALL_LIMIT = "X-Shopify-Shop-Api-Call-Limit";
 
-        public static RestBucketState Get(HttpResponseMessage response)
+        public static RestBucketState Get(HttpResponseHeaders responseHeaders)
         {
-            string headerValue = response.Headers.FirstOrDefault(kvp => kvp.Key == RESPONSE_HEADER_API_CALL_LIMIT)
+            string headerValue = responseHeaders.FirstOrDefault(kvp => kvp.Key == RESPONSE_HEADER_API_CALL_LIMIT)
                                        .Value
                                        ?.FirstOrDefault();
 

--- a/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
+++ b/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
@@ -14,6 +14,7 @@ namespace ShopifySharp.Infrastructure
             }
         }
 
+        [Obsolete("This method has been replaced with " + nameof(CloneAsync) + ", it will be removed in a future version of ShopifySharp.")]
         public CloneableRequestMessage Clone()
         {
             var newContent = Content;

--- a/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
+++ b/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -22,6 +23,14 @@ namespace ShopifySharp.Infrastructure
             if (newContent is JsonContent c)
             {
                 newContent = c.Clone();
+
+                foreach (var header in Content.Headers)
+                {
+                    if (!newContent.Headers.Contains(header.Key))
+                    {
+                        newContent.Headers.Add(header.Key, header.Value);
+                    }
+                }
             }
 
             var cloned = new CloneableRequestMessage(RequestUri, Method, newContent);

--- a/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
+++ b/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
@@ -1,26 +1,51 @@
 using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace ShopifySharp.Infrastructure
 {
-    public class CloneableRequestMessage : HttpRequestMessage
+    public class CloneableRequestMessage: HttpRequestMessage
     {
         public CloneableRequestMessage(Uri url, HttpMethod method, HttpContent content = null) : base(method, url)
         {
             if (content != null)
             {
-                this.Content = content;
+                Content = content;
             }
         }
 
         public CloneableRequestMessage Clone()
         {
-            HttpContent newContent = Content;
+            var newContent = Content;
 
-            if (newContent != null && newContent is JsonContent c)
+            if (newContent is JsonContent c)
             {
                 newContent = c.Clone();
             }
+
+            var cloned = new CloneableRequestMessage(RequestUri, Method, newContent);
+
+            // Copy over the request's headers which includes the access token if set
+            foreach (var header in Headers)
+            {
+                cloned.Headers.Add(header.Key, header.Value);
+            }
+
+            return cloned;
+        }
+
+        public async Task<CloneableRequestMessage> CloneAsync()
+        {
+            HttpContent newContent = Content switch
+            {
+                JsonContent c => c.Clone(),
+                // TODO: use new ReadOnlyMemoryContent(bytes) when cloning. Can import System.Memory from Nuget for netstandard2.0 targets
+                StringContent s => new StreamContent(await s.ReadAsStreamAsync()),
+                StreamContent s => new StreamContent(await s.ReadAsStreamAsync()),
+                ByteArrayContent b => new ByteArrayContent(await b.ReadAsByteArrayAsync()),
+                null => null,
+                _ => throw new ArgumentOutOfRangeException(nameof(Content), Content.GetType().FullName, "Unhandled HttpContent type, ")
+            };
 
             var cloned = new CloneableRequestMessage(RequestUri, Method, newContent);
 

--- a/ShopifySharp/Infrastructure/DefaultHttpClientFactory.cs
+++ b/ShopifySharp/Infrastructure/DefaultHttpClientFactory.cs
@@ -4,21 +4,6 @@ using System.Net.Http;
 namespace ShopifySharp.Infrastructure
 {
     /// <summary>
-    /// ShopifySharp's default <see cref="IHttpClientFactory" />, which uses a static <see cref="HttpClient" />.
-    /// </summary>
-    // TODO: remove this class in a future release (6.4+)
-    [Obsolete("This class will be removed in a future version of ShopifySharp. It ignores all configurations and therefore has the potential to introduce subtle bugs when used outside of ShopifySharp.")]
-    public class DefaultHttpClientFactory : IHttpClientFactory
-    {
-        private static readonly HttpClient _Client = new HttpClient();
-
-        public HttpClient CreateClient(string name)
-        {
-            return _Client;
-        }
-    }
-
-    /// <summary>
     /// ShopifySharp's internal <see cref="IHttpClientFactory" />, which uses a static <see cref="HttpClient" />.
     /// </summary>
     internal class InternalHttpClientFactory : IHttpClientFactory

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
@@ -118,7 +118,7 @@ namespace ShopifySharp
             while (true)
             {
                 // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-                request = request.Clone();
+                request = await request.CloneAsync();
 
                 if (bucket != null)
                 {
@@ -155,7 +155,7 @@ namespace ShopifySharp
             while (true)
             {
                 // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-                request = request.Clone();
+                request = await request.CloneAsync();
 
                 if (bucket != null)
                 {
@@ -229,7 +229,7 @@ namespace ShopifySharp
             while (true)
             {
                 // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-                request = request.Clone();
+                request = await request.CloneAsync();
 
                 if (bucket != null)
                 {

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
@@ -110,7 +110,7 @@ namespace ShopifySharp
             ExecuteRequestAsync<T> executeRequestAsync,
             CancellationToken cancellationToken,
             MultiShopifyAPIBucket bucket,
-            CloneableRequestMessage request
+            CloneableRequestMessage baseRequest
         )
         {
             var totalRetriesDueToServiceUnavailableResponse = 0;
@@ -118,7 +118,7 @@ namespace ShopifySharp
             while (true)
             {
                 // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-                request = await request.CloneAsync();
+                using var request = await baseRequest.CloneAsync();
 
                 if (bucket != null)
                 {
@@ -147,7 +147,7 @@ namespace ShopifySharp
             CancellationToken cancellationToken,
             int graphqlQueryCost,
             MultiShopifyAPIBucket bucket,
-            CloneableRequestMessage request
+            CloneableRequestMessage baseRequest
         )
         {
             var totalRetriesDueToServiceUnavailableResponse = 0;
@@ -155,7 +155,7 @@ namespace ShopifySharp
             while (true)
             {
                 // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-                request = await request.CloneAsync();
+                var request = await baseRequest.CloneAsync();
 
                 if (bucket != null)
                 {
@@ -221,7 +221,7 @@ namespace ShopifySharp
             ExecuteRequestAsync<T> executeRequestAsync,
             CancellationToken cancellationToken,
             MultiShopifyAPIBucket bucket,
-            CloneableRequestMessage request
+            CloneableRequestMessage baseRequest
         )
         {
             var totalRetriesDueToServiceUnavailableResponse = 0;
@@ -229,7 +229,7 @@ namespace ShopifySharp
             while (true)
             {
                 // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-                request = await request.CloneAsync();
+                using var request = await baseRequest.CloneAsync();
 
                 if (bucket != null)
                 {

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucketPolicy/LeakyBucketExecutionPolicy.cs
@@ -184,7 +184,7 @@ namespace ShopifySharp
                 {
                     System.Text.Json.JsonDocument systemTextJsonDoc => systemTextJsonDoc,
                     JToken jsonNetDoc => System.Text.Json.JsonDocument.Parse(jsonNetDoc.ToString(Newtonsoft.Json.Formatting.None)),
-                    _ => throw new Exception($"Unexpected non json result of type {result.Response.GetType().Name} for GraphQL Admin API")
+                    _ => throw new ShopifyException("Unexpected json result for GraphQL Admin API", new ArgumentException("Unexpected json result for GraphQL Admin API", nameof(result.Result)))
                 };
 
                 if (bucket != null)

--- a/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
@@ -52,7 +52,7 @@ namespace ShopifySharp
 
             while (true)
             {
-                request = request.Clone();
+                var request = await request.CloneAsync();
 
                 try
                 {

--- a/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/RetryExecutionPolicy.cs
@@ -41,7 +41,7 @@ namespace ShopifySharp
         }
 
         public async Task<RequestResult<T>> Run<T>(
-            CloneableRequestMessage request,
+            CloneableRequestMessage baseRequest,
             ExecuteRequestAsync<T> executeRequestAsync,
             CancellationToken cancellationToken,
             int? graphqlQueryCost = null
@@ -52,7 +52,7 @@ namespace ShopifySharp
 
             while (true)
             {
-                var request = await request.CloneAsync();
+                using var request = await baseRequest.CloneAsync();
 
                 try
                 {

--- a/ShopifySharp/Infrastructure/RequestResult.cs
+++ b/ShopifySharp/Infrastructure/RequestResult.cs
@@ -6,6 +6,7 @@ namespace ShopifySharp
 {
     public class RequestResult<T>
     {
+        [Obsolete("This property is obsolete and will be removed in a future version of ShopifySharp. If you need to use the response headers, please use the " + nameof(ResponseHeaders) + " property instead.")]
         public HttpResponseMessage Response { get; }
 
         public HttpResponseHeaders ResponseHeaders { get; }
@@ -19,6 +20,7 @@ namespace ShopifySharp
         /// </summary>
         public string RawLinkHeaderValue { get; }
 
+        [Obsolete("This constructor is obsolete and will be removed in a future version of ShopifySharp.")]
         public RequestResult(HttpResponseMessage response, T result, string rawResult, string rawLinkHeaderValue)
         {
             this.Response = response;

--- a/ShopifySharp/Infrastructure/RequestResult.cs
+++ b/ShopifySharp/Infrastructure/RequestResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace ShopifySharp
 {
@@ -6,10 +8,12 @@ namespace ShopifySharp
     {
         public HttpResponseMessage Response { get; }
 
+        public HttpResponseHeaders ResponseHeaders { get; }
+
         public T Result { get; }
 
         public string RawResult { get; }
-        
+
         /// <summary>
         /// Only exists for list requests, will be null or empty for all others. 
         /// </summary>
@@ -18,14 +22,29 @@ namespace ShopifySharp
         public RequestResult(HttpResponseMessage response, T result, string rawResult, string rawLinkHeaderValue)
         {
             this.Response = response;
+            this.ResponseHeaders = response.Headers;
             this.Result = result;
             this.RawResult = rawResult;
             this.RawLinkHeaderValue = rawLinkHeaderValue;
         }
 
+        public RequestResult(
+            HttpResponseMessage httpResponseMessage,
+            HttpResponseHeaders httpResponseHeaders,
+            T result,
+            string rawResult,
+            string rawLinkHeaderValue)
+        {
+            Response = httpResponseMessage;
+            ResponseHeaders = httpResponseHeaders;
+            Result = result;
+            RawResult = rawResult;
+            RawLinkHeaderValue = rawLinkHeaderValue;
+        }
+
         public RestBucketState GetRestBucketState()
         {
-            return RestBucketState.Get(this.Response);
+            return RestBucketState.Get(ResponseHeaders);
         }
 
         public GraphQLBucketState GetGraphQLBucketState(System.Text.Json.JsonDocument response)

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -135,7 +135,7 @@ namespace ShopifySharp
                 }
 
                 var message = errorList.FirstOrDefault() ?? "Unable to parse Shopify's error response, please inspect exception's RawBody property and report this issue to the ShopifySharp maintainers.";
-                var requestId = ParseRequestIdResponseHeader(requestResult.Response.Headers);
+                var requestId = ParseRequestIdResponseHeader(requestResult.ResponseHeaders);
 
                 throw new ShopifyHttpException(HttpStatusCode.OK, errorList, message, requestResult.RawResult, requestId);
             }

--- a/ShopifySharp/Services/Partner/PartnerService.cs
+++ b/ShopifySharp/Services/Partner/PartnerService.cs
@@ -58,7 +58,7 @@ namespace ShopifySharp
                 return;
             }
 
-            var requestId = ParseRequestIdResponseHeader(requestResult.Response.Headers);
+            var requestId = ParseRequestIdResponseHeader(requestResult.ResponseHeaders);
             var errorList = new List<string>();
 
             foreach (var error in requestResult.Result["errors"])

--- a/ShopifySharp/Services/ShopPlan/ShopPlanService.cs
+++ b/ShopifySharp/Services/ShopPlan/ShopPlanService.cs
@@ -1,9 +1,8 @@
 using System.Threading.Tasks;
 using System.Threading;
 using ShopifySharp.Utilities;
-using Newtonsoft.Json.Linq;
 
-namespace ShopifySharp.Services;
+namespace ShopifySharp;
 
 /// A service for getting the shop's current Shopify subscription plan. This is a convenience wrapper around the Shopify GraphQL API.
 public class ShopPlanService : GraphService, IShopPlanService

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using System.Threading;
+using ShopifySharp.Infrastructure;
 using ShopifySharp.Utilities;
 
 namespace ShopifySharp
@@ -30,7 +31,7 @@ namespace ShopifySharp
                 await this.GetBalanceAsync(cancellationToken);
                 return true;
             }
-            catch (ShopifyException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
+            catch (ShopifyHttpException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
                 return false;
             }

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -204,9 +204,8 @@ namespace ShopifySharp
             using var baseRequestMessage = PrepareRequestMessage(uri, method, content, headers);
             var policyResult = await _ExecutionPolicy.Run(baseRequestMessage, async (requestMessage) =>
             {
-                var request = _Client.SendAsync(requestMessage, cancellationToken);
+                using var response = await _Client.SendAsync(requestMessage, cancellationToken);
 
-                using var response = await request;
                 #if NETSTANDARD2_0
                 var rawResult = await response.Content.ReadAsStringAsync();
                 #else

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -181,9 +181,9 @@ namespace ShopifySharp
         /// <remarks>
         /// The Link header only exists on list requests.
         /// </remarks>
-        private string ReadLinkHeader(HttpResponseMessage response)
+        private string ReadLinkHeader(HttpResponseHeaders responseHeaders)
         {
-            var linkHeaderValues = response.Headers
+            var linkHeaderValues = responseHeaders
                 .FirstOrDefault(h => h.Key.Equals("link", StringComparison.OrdinalIgnoreCase))
                 .Value;
 
@@ -218,7 +218,7 @@ namespace ShopifySharp
 
                 var result = method == HttpMethod.Delete ? default : Serializer.Deserialize<T>(rawResult, rootElement, dateParseHandlingOverride);
 
-                return new RequestResult<T>(response, result, rawResult, ReadLinkHeader(response));
+                return new RequestResult<T>(response, response.Headers, result, rawResult, ReadLinkHeader(response.Headers));
             }, cancellationToken, graphqlQueryCost);
 
             return policyResult;

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -20,7 +20,7 @@ namespace ShopifySharp
     {
         #nullable enable
 
-        public virtual string APIVersion => "2024-01";
+        public virtual string APIVersion => "2023-07";
         public virtual bool SupportsAPIVersioning => true;
 
         protected Uri _ShopUri { get; set; }

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net6.0;net7.0;netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>ShopifySharp</AssemblyName>
     <RootNamespace>ShopifySharp</RootNamespace>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>6.12.0</VersionPrefix>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>Latest</LangVersion>


### PR DESCRIPTION
This pull request fixes a bug where the CloneableRequestMessage underlying the LeakyBucketExecutionPolicy and the RetryExecutionPolicy classes would fail to clone the request's content if the request wasn't using `JsonContent`. It also fixes a bug that caused the original request to be disposed before the leaky bucket got a succesful response, thereby throwing an ObjectDisposedException.

---

@clement911 I've temporarily reverted your changes for the 7.0 release so I could publish this (the action only publishes from one branch at the moment). I have some refactors and breaking changes I want to do for 7.0, so I've moved it to the branch `7.0-dev` and will open an issue tomorrow or Tuesday explaining my goals for 7.0! 

I'll get the action set up to publish from both branches as well so we can start publishing the 7.0 prereleases without merging them into master.