### PR TITLE
Fix disposal of InternalHttpClientFactory's static HttpClient

### DIFF
--- a/ShopifySharp.Tests/Utilities/ShopifyOauthUtilityTests.cs
+++ b/ShopifySharp.Tests/Utilities/ShopifyOauthUtilityTests.cs
@@ -186,7 +186,7 @@ public class ShopifyOauthUtilityTests
         });
         var send = async () =>
         {
-            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://127.0.0.1"));
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, shopDomain));
             response.EnsureSuccessStatusCode();
         };
 

--- a/ShopifySharp.Tests/Utilities/ShopifyOauthUtilityTests.cs
+++ b/ShopifySharp.Tests/Utilities/ShopifyOauthUtilityTests.cs
@@ -1,12 +1,15 @@
 #nullable enable
 using System;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using ShopifySharp.Enums;
+using ShopifySharp.Infrastructure;
 using ShopifySharp.Tests.TestClasses;
 using ShopifySharp.Utilities;
 using Xunit;
@@ -159,4 +162,37 @@ public class ShopifyOauthUtilityTests
         // Assert
         act.Should().Throw<TestException>();
     }
+
+    #if NET8_0_OR_GREATER
+    [Fact]
+    public async Task RefreshAccessTokenAsync_ShouldNotDisposeHttpClient()
+    {
+        // This is testing the fix for the issue described in #1005 and #1006
+
+        // Setup
+        const string shopDomain = "some-shop-domain";
+        _utility = new ShopifyOauthUtility();
+        var factory = new InternalHttpClientFactory();
+        var client = factory.CreateClient("some-name");
+
+        // Act
+        var refresh = async () => await _utility.RefreshAccessTokenAsync(new RefreshAccessTokenOptions
+        {
+            ClientId = "some-client-id",
+            ClientSecret = "some-client-secret",
+            ExistingStoreAccessToken = "some-existing-store-access-token",
+            RefreshToken = "some-refresh-token",
+            ShopDomain = shopDomain
+        });
+        var send = async () =>
+        {
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://127.0.0.1"));
+            response.EnsureSuccessStatusCode();
+        };
+
+        // Assert
+        await refresh.Should().ThrowAsync<HttpRequestException>();
+        await send.Should().NotThrowAsync<ObjectDisposedException>();
+    }
+    #endif
 }

--- a/ShopifySharp/Utilities/ShopifyOauthUtility.cs
+++ b/ShopifySharp/Utilities/ShopifyOauthUtility.cs
@@ -281,10 +281,9 @@ public class ShopifyOauthUtility(IShopifyDomainUtility? domainUtility = null) : 
             access_token = existingStoreAccessToken
         });
 
-        using var client = _httpClientFactory.CreateClient();
-        using var msg = new CloneableRequestMessage(ub.Uri, HttpMethod.Post, content);
-        var request = client.SendAsync(msg);
-        var response = await request;
+        var client = _httpClientFactory.CreateClient();
+        using var request = new CloneableRequestMessage(ub.Uri, HttpMethod.Post, content);
+        using var response = await client.SendAsync(request);
         var rawDataString = await response.Content.ReadAsStringAsync();
 
         ShopifyService.CheckResponseExceptions(response, rawDataString);

--- a/ShopifySharp/Utilities/ShopifyOauthUtility.cs
+++ b/ShopifySharp/Utilities/ShopifyOauthUtility.cs
@@ -237,10 +237,9 @@ public class ShopifyOauthUtility(IShopifyDomainUtility? domainUtility = null) : 
             code,
         });
 
-        using var client = new HttpClient();
-        using var msg = new CloneableRequestMessage(ub.Uri, HttpMethod.Post, content);
-        var request = client.SendAsync(msg);
-        var response = await request;
+        var client = _httpClientFactory.CreateClient();
+        using var request = new CloneableRequestMessage(ub.Uri, HttpMethod.Post, content);
+        using var response = await client.SendAsync(request);
         var rawDataString = await response.Content.ReadAsStringAsync();
 
         ShopifyService.CheckResponseExceptions(response, rawDataString);

--- a/ShopifySharp/Utilities/ShopifyOauthUtility.cs
+++ b/ShopifySharp/Utilities/ShopifyOauthUtility.cs
@@ -288,6 +288,7 @@ public class ShopifyOauthUtility(IShopifyDomainUtility? domainUtility = null) : 
         ShopifyService.CheckResponseExceptions(response, rawDataString);
 
         var json = JToken.Parse(rawDataString);
+        // TODO: throw a ShopifyJsonParseException if value is null. Exception should have a RawBody property.
         return new AuthorizationResult(json.Value<string>("access_token"), json.Value<string>("scope")?.Split(','));
     }
 


### PR DESCRIPTION
This pull request fixes a bug with the `ShopifyOauthUtility.RefreshAccessTokenAsync` method, which was erroneously disposing the static HttpClient in ShopifySharp's InternalHttpClientFactory. If the developer did not supply their own IHttpClientFactory to the ShopifyService via `ShopifyService.SetHttpClientFactory`, then any service that attempted to call the Shopify API after the disposal would throw an `ObjectDisposedException` for the lifetime of the application.

See #1005 for more info.