### PR TITLE
Update AssignedFulfillmentOrderService to produce ListResult

### DIFF
--- a/ShopifySharp.Tests/AssignedFulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/AssignedFulfillmentOrder_Tests.cs
@@ -1,7 +1,6 @@
 using ShopifySharp.Filters;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -20,8 +19,8 @@ namespace ShopifySharp.Tests
         [Fact]
         public async Task ListsCancellationRequests_AssignedFulfillmentOrders()
         {
-            var result = await Fixture.Service.ListAsync(new AssignedFulfillmentOrderFilter(){AssignmentStatus = "cancellation_requested" });
-            
+            var result = await Fixture.Service.ListAsync(new AssignedFulfillmentOrderFilter() { AssignmentStatus = "cancellation_requested" });
+
             Assert.NotNull(result);
         }
 
@@ -32,10 +31,19 @@ namespace ShopifySharp.Tests
 
             Assert.NotNull(result);
         }
+
         [Fact]
         public async Task ListsAcceptedRequests_AssignedFulfillmentOrders()
         {
             var result = await Fixture.Service.ListAsync(new AssignedFulfillmentOrderFilter() { AssignmentStatus = "fulfillment_accepted" });
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task ListsUnsubmittedFulfillmentOrders_AssignedFulfillmentOrders()
+        {
+            var result = await Fixture.Service.ListAsync(new AssignedFulfillmentOrderFilter() { AssignmentStatus = "fulfillment_unsubmitted", Limit = 1 });
 
             Assert.NotNull(result);
         }
@@ -44,7 +52,7 @@ namespace ShopifySharp.Tests
     public class AssignedFulfillmentOrder_Tests_Fixture : IAsyncLifetime
     {
         public AssignedFulfillmentOrderService Service { get; } = new AssignedFulfillmentOrderService(Utils.MyShopifyUrl, Utils.AccessToken);
-        
+
         public FulfillmentService FulfillmentService { get; } = new FulfillmentService(Utils.MyShopifyUrl, Utils.AccessToken);
 
         public OrderService OrderService { get; } = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);

--- a/ShopifySharp/Entities/AssignedFulfillmentOrder.cs
+++ b/ShopifySharp/Entities/AssignedFulfillmentOrder.cs
@@ -1,0 +1,66 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ShopifySharp
+{
+    /// <summary>
+    /// An object representing a Shopify assigned fulfillment order.
+    /// </summary>
+    public class AssignedFulfillmentOrder : ShopifyObject
+    {
+        /// <summary>
+        /// The ID of the fulfillment order's assigned location. This is the location from which the order is expected to be fulfilled.
+        /// </summary>
+        [JsonProperty("assigned_location_id")]
+        public long? AssignedLocationId { get; set; }
+
+        /// <summary>
+        /// The destination where the items should be sent upon fulfillment.
+        /// </summary>
+        [JsonProperty("destination")]
+        public FulfillmentOrderDestination Destination { get; set; }
+
+        /// <summary>
+        /// Represents line items belonging to a fulfillment order:
+        /// </summary>
+        [JsonProperty("line_items")]
+        public IEnumerable<AssignedFulfillmentOrderLineItem> LineItems { get; set; }
+
+        /// <summary>
+        /// The ID of the order that's associated with the fulfillment order.
+        /// </summary>
+        [JsonProperty("order_id")]
+        public long? OrderId { get; set; }
+
+        /// <summary>
+        /// The status of the fulfillment order.
+        ///     unsubmitted: The initial request status for the newly-created fulfillment orders. This is the only valid request status for fulfillment orders that aren't assigned to a fulfillment service.
+        ///     submitted: The merchant requested fulfillment for this fulfillment order.
+        ///     accepted: The fulfillment service accepted the merchant's fulfillment request.
+        ///     rejected: The fulfillment service rejected the merchant's fulfillment request.
+        ///     cancellation_requested: The merchant requested a cancellation of the fulfillment request for this fulfillment order.
+        ///     cancellation_accepted: The fulfillment service accepted the merchant's fulfillment cancellation request.
+        ///     cancellation_rejected: The fulfillment service rejected the merchant's fulfillment cancellation request.
+        ///     closed: The fulfillment service closed the fulfillment order without completing it.
+        /// </summary>
+        [JsonProperty("request_status")]
+        public string RequestStatus { get; set; }
+
+        /// <summary>
+        /// The ID of the shop that's associated with the fulfillment order.
+        /// </summary>
+        [JsonProperty("shop_id")]
+        public long? ShopId { get; set; }
+
+        /// <summary>
+        /// The status of the fulfillment order. Valid values:
+        ///     open: Default state for newly created fulfillment orders.
+        ///     in_progress: The fulfillment order is being processed.
+        ///     cancelled: The fulfillment order has been cancelled by the merchant.
+        ///     incomplete: The fulfillment order cannot be completed as requested.
+        ///     closed: The fulfillment order has been completed and closed.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/ShopifySharp/Entities/AssignedFulfillmentOrderLineItem.cs
+++ b/ShopifySharp/Entities/AssignedFulfillmentOrderLineItem.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+
+namespace ShopifySharp
+{
+    public class AssignedFulfillmentOrderLineItem : ShopifyObject
+    {
+        /// <summary>
+        /// The ID of the shop associated with the fulfillment order line item.
+        /// </summary>
+        [JsonProperty("shop_id")]
+        public long? ShopId { get; set; }
+
+        /// <summary>
+        /// The ID of the fulfillment order associated with this line item.
+        /// </summary>
+        [JsonProperty("fulfillment_order_id")]
+        public long? FulfillmentOrderId { get; set; }
+
+        /// <summary>
+        /// The ID of the line item associated with this fulfillment order line item.
+        /// </summary>
+        [JsonProperty("line_item_id")]
+        public long? LineItemId { get; set; }
+
+        /// <summary>
+        /// The ID of the inventory item associated with this fulfillment order line item.
+        /// </summary>
+        [JsonProperty("inventory_item_id")]
+        public long? InventoryItemId { get; set; }
+
+        /// <summary>
+        /// The total number of units to be fulfilled.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public long? Quantity { get; set; }
+
+        /// <summary>
+        /// The number of units remaining to be fulfilled.
+        /// </summary>
+        [JsonProperty("fulfillable_quantity")]
+        public long? FulfillableQuantity { get; set; }
+    }
+}

--- a/ShopifySharp/Filters/AssignedFulfillmentOrderFilter.cs
+++ b/ShopifySharp/Filters/AssignedFulfillmentOrderFilter.cs
@@ -3,13 +3,14 @@ using Newtonsoft.Json;
 
 namespace ShopifySharp.Filters
 {
-    public class AssignedFulfillmentOrderFilter : Parameterizable
+    public class AssignedFulfillmentOrderFilter : ListFilter<AssignedFulfillmentOrder>
     {
         /// <summary>
         /// <para>
         /// The assignment status of the fulfillment orders that should be returned:
         /// </para>
         /// <para>
+        /// <c>"fulfillment_unsubmitted"</c>: Fulfillment orders for which the merchant hasn't yet requested fulfillment. Filtering by this value is supported as of the 2023-04 API version.
         /// <c>"cancellation_requested"</c>: Fulfillment orders for which the merchant has requested cancellation of the previously accepted fulfillment request.
         /// </para>
         /// <para>

--- a/ShopifySharp/Services/AssignedFulfillmentOrder/AssignedFulfillmentOrderService.cs
+++ b/ShopifySharp/Services/AssignedFulfillmentOrder/AssignedFulfillmentOrderService.cs
@@ -1,5 +1,5 @@
 ﻿using ShopifySharp.Filters;
-using System.Collections.Generic;
+using ShopifySharp.Lists;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,9 +16,14 @@ namespace ShopifySharp
         {
         }
 
-        public virtual async Task<IEnumerable<FulfillmentOrder>> ListAsync(AssignedFulfillmentOrderFilter filter, CancellationToken cancellationToken = default)
+        public virtual async Task<ListResult<AssignedFulfillmentOrder>> ListAsync(ListFilter<AssignedFulfillmentOrder> filter, CancellationToken cancellationToken = default)
         {
-            return await ExecuteGetAsync<List<FulfillmentOrder>>("assigned_fulfillment_orders.json", "fulfillment_orders", filter, cancellationToken);
+            return await ExecuteGetListAsync("assigned_fulfillment_orders.json", "fulfillment_orders", filter, cancellationToken);
+        }
+
+        public virtual async Task<ListResult<AssignedFulfillmentOrder>> ListAsync(AssignedFulfillmentOrderFilter filter = null, CancellationToken cancellationToken = default)
+        {
+            return await ListAsync(filter?.AsListFilter(), cancellationToken);
         }
     }
 }

--- a/ShopifySharp/Services/AssignedFulfillmentOrder/IAssignedFulfillmentOrderService.cs
+++ b/ShopifySharp/Services/AssignedFulfillmentOrder/IAssignedFulfillmentOrderService.cs
@@ -1,5 +1,5 @@
 ﻿using ShopifySharp.Filters;
-using System.Collections.Generic;
+using ShopifySharp.Lists;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,14 +7,26 @@ namespace ShopifySharp
 {
     public interface IAssignedFulfillmentOrderService
     {
+        /// <summary>
+        /// <para>The AssignedFulfillmentOrder resource allows you to retrieve all the fulfillment orders that are assigned to an app at the shop level.
+        /// The list of fulfillment orders can be filtered by location and assignment status such as cancellation_requested and fulfillment_requested.</para>
+        /// <see href="https://shopify.dev/api/admin/rest/reference/shipping-and-fulfillment/assignedfulfillmentorder#index-2021-07 ">API Reference</see>
+        /// </summary>
+        /// <param name="filter">The filter object.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Retrieves a list of fulfillment orders on a shop for a specific app.</returns>
+        /// <exception cref="ShopifyException"></exception>
+        Task<ListResult<AssignedFulfillmentOrder>> ListAsync(ListFilter<AssignedFulfillmentOrder> filter, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>The AssignedFulfillmentOrder resource allows you to retrieve all the fulfillment orders that are assigned to an app at the shop level.
         /// The list of fulfillment orders can be filtered by location and assignment status such as cancellation_requested and fulfillment_requested.</para>
         /// <see href="https://shopify.dev/api/admin/rest/reference/shipping-and-fulfillment/assignedfulfillmentorder#index-2021-07 ">API Reference</see>
         /// </summary>
+        /// <param name="filter">The filter object.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Retrieves a list of fulfillment orders on a shop for a specific app.</returns>
         /// <exception cref="ShopifyException"></exception>
-        Task<IEnumerable<FulfillmentOrder>> ListAsync(AssignedFulfillmentOrderFilter filter, CancellationToken cancellationToken = default);
+        Task<ListResult<AssignedFulfillmentOrder>> ListAsync(AssignedFulfillmentOrderFilter filter = null, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
The current version (master) does not return ListResults for the [assigned_fulfillment_orders](https://shopify.dev/docs/api/admin-rest/2024-01/resources/assignedfulfillmentorder) endpoint. 

With the default [limit](https://shopify.dev/docs/api/usage/pagination-rest) of 50 items per response this behavior cause an error if more than 50 items exists as always the same items will be returned.