### PR TITLE
Feature/dispute evidence

### DIFF
--- a/ShopifySharp.Tests/ShopifyPayments_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyPayments_Tests.cs
@@ -13,93 +13,93 @@ namespace ShopifySharp.Tests;
 [Trait("Category", "Shopify payments")]
 public class ShopifyPayments_Tests
 {
-	ShopifyPaymentsService Service { get; } = new ShopifyPaymentsService(Utils.MyShopifyUrl, Utils.AccessToken);
-	private readonly ITestOutputHelper _testOutputHelper;
+    ShopifyPaymentsService Service { get; } = new ShopifyPaymentsService(Utils.MyShopifyUrl, Utils.AccessToken);
+    private readonly ITestOutputHelper _testOutputHelper;
 
 
-	public ShopifyPayments_Tests(ITestOutputHelper testOutputHelper)
-	{
-		Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
-		_testOutputHelper = testOutputHelper;
-	}
+    public ShopifyPayments_Tests(ITestOutputHelper testOutputHelper)
+    {
+        Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
+        _testOutputHelper = testOutputHelper;
+    }
 
-	[Fact]
-	public async Task GetBalance()
-	{
-		if (await Service.IsShopifyPaymentApiEnabledAsync())
-		{
-			var balances = await Service.GetBalanceAsync();
-			Assert.NotNull(balances);
-		}
-	}
+    [Fact]
+    public async Task GetBalance()
+    {
+        if (await Service.IsShopifyPaymentApiEnabledAsync())
+        {
+            var balances = await Service.GetBalanceAsync();
+            Assert.NotNull(balances);
+        }
+    }
 
-	[Fact]
-	public async Task GetPayouts()
-	{
-		if (await Service.IsShopifyPaymentApiEnabledAsync())
-		{
-			var payouts = await Service.ListPayoutsAsync();
-			Assert.NotNull(payouts);
-		}
-	}
+    [Fact]
+    public async Task GetPayouts()
+    {
+        if (await Service.IsShopifyPaymentApiEnabledAsync())
+        {
+            var payouts = await Service.ListPayoutsAsync();
+            Assert.NotNull(payouts);
+        }
+    }
 
-	[Fact]
-	public async Task GetDisputes()
-	{
-		if (await Service.IsShopifyPaymentApiEnabledAsync())
-		{
-			var disputes = await Service.ListDisputesAsync();
-			Assert.NotNull(disputes);
-		}
-	}
-	[Fact]
-	public async Task GetDisputedEvidence()
-	{
-		if (await Service.IsShopifyPaymentApiEnabledAsync())
-		{
-			var disputes = await Service.ListDisputesAsync();
-			
-			Assert.True((disputes?.Items?.Count() > 0),"There are no disputes to get dispute evidence from.");
-			
-			_testOutputHelper.WriteLine($"Getting evidence for dispute id '{disputes.Items.First().Id.Value}'.");
+    [Fact]
+    public async Task GetDisputes()
+    {
+        if (await Service.IsShopifyPaymentApiEnabledAsync())
+        {
+            var disputes = await Service.ListDisputesAsync();
+            Assert.NotNull(disputes);
+        }
+    }
+    [Fact]
+    public async Task GetDisputedEvidence()
+    {
+        if (await Service.IsShopifyPaymentApiEnabledAsync())
+        {
+            var disputes = await Service.ListDisputesAsync();
 
-			var disputedEvidence = await Service.GetDisputeEvidenceAsync(disputes.Items.First().Id.Value);
-			
-			Assert.NotNull(disputedEvidence);
-		}
-	}
+            Assert.True((disputes?.Items?.Count() > 0), "There are no disputes to get dispute evidence from.");
 
-	[Fact]
-	public async Task PutDisputedEvidence()
-	{
-		if (await Service.IsShopifyPaymentApiEnabledAsync())
-		{
-			var disputes = await Service.ListDisputesAsync();
-			Assert.True((disputes?.Items?.Count() > 0),"There are no disputes available to add evidence to.");
+            _testOutputHelper.WriteLine($"Getting evidence for dispute id '{disputes.Items.First().Id.Value}'.");
 
-			_testOutputHelper.WriteLine($"Updating evidence for dispute Id: '{disputes.Items.First().Id.Value}'.");
+            var disputedEvidence = await Service.GetDisputeEvidenceAsync(disputes.Items.First().Id.Value);
 
-			ShopifyPaymentsDisputeEvidenceUpdate update = new();
-			update.CustomerFirstName = "Tom";
-			update.CustomerLastName = "Thumb";
-			update.CancellationRebuttal = "You can't cancel past the return period.";
-			update.RefundRefusalExplanation = "You are past the return period.";
-			update.RefundPolicyDisclosure = "Refund policy is displayed on the checkout page.";
-			update.AccessActivityLog = "Email sent detailing return policy.";
-			update.UncategorizedText = "You are trying to do something not allowed.";
+            Assert.NotNull(disputedEvidence);
+        }
+    }
 
-			var disputedEvidence = await Service.UpdateDisputeEvidenceAsync(disputes.Items.First().Id.Value, update);
-			Assert.NotNull(disputedEvidence);
-		}
-	}
+    [Fact]
+    public async Task PutDisputedEvidence()
+    {
+        if (await Service.IsShopifyPaymentApiEnabledAsync())
+        {
+            var disputes = await Service.ListDisputesAsync();
+            Assert.True((disputes?.Items?.Count() > 0), "There are no disputes available to add evidence to.");
 
-	[Fact]
-	public async Task GetTransactions()
-	{
-		if (await Service.IsShopifyPaymentApiEnabledAsync())
-		{
-			var transactions = await Service.ListTransactionsAsync();
-			Assert.NotNull(transactions);
-		}
-	}
+            _testOutputHelper.WriteLine($"Updating evidence for dispute Id: '{disputes.Items.First().Id.Value}'.");
+
+            ShopifyPaymentsDisputeEvidenceUpdate update = new();
+            update.CustomerFirstName = "Tom";
+            update.CustomerLastName = "Thumb";
+            update.CancellationRebuttal = "You can't cancel past the return period.";
+            update.RefundRefusalExplanation = "You are past the return period.";
+            update.RefundPolicyDisclosure = "Refund policy is displayed on the checkout page.";
+            update.AccessActivityLog = "Email sent detailing return policy.";
+            update.UncategorizedText = "You are trying to do something not allowed.";
+
+            var disputedEvidence = await Service.UpdateDisputeEvidenceAsync(disputes.Items.First().Id.Value, update);
+            Assert.NotNull(disputedEvidence);
+        }
+    }
+
+    [Fact]
+    public async Task GetTransactions()
+    {
+        if (await Service.IsShopifyPaymentApiEnabledAsync())
+        {
+            var transactions = await Service.ListTransactionsAsync();
+            Assert.NotNull(transactions);
+        }
+    }
 }

--- a/ShopifySharp.Tests/ShopifyPayments_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyPayments_Tests.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ShopifySharp.Tests;
 
@@ -9,50 +13,93 @@ namespace ShopifySharp.Tests;
 [Trait("Category", "Shopify payments")]
 public class ShopifyPayments_Tests
 {
-    ShopifyPaymentsService Service { get; } = new ShopifyPaymentsService(Utils.MyShopifyUrl, Utils.AccessToken);
+	ShopifyPaymentsService Service { get; } = new ShopifyPaymentsService(Utils.MyShopifyUrl, Utils.AccessToken);
+	private readonly ITestOutputHelper _testOutputHelper;
 
-    public ShopifyPayments_Tests()
-    {
-        Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
-    }
 
-    [Fact]
-    public async Task GetBalance()
-    {
-        if (await Service.IsShopifyPaymentApiEnabledAsync())
-        {
-            var balances = await Service.GetBalanceAsync();
-            Assert.NotNull(balances);
-        }
-    }
+	public ShopifyPayments_Tests(ITestOutputHelper testOutputHelper)
+	{
+		Service.SetExecutionPolicy(new LeakyBucketExecutionPolicy());
+		_testOutputHelper = testOutputHelper;
+	}
 
-    [Fact]
-    public async Task GetPayouts()
-    {
-        if (await Service.IsShopifyPaymentApiEnabledAsync())
-        {
-            var payouts = await Service.ListPayoutsAsync();
-            Assert.NotNull(payouts);
-        }
-    }
+	[Fact]
+	public async Task GetBalance()
+	{
+		if (await Service.IsShopifyPaymentApiEnabledAsync())
+		{
+			var balances = await Service.GetBalanceAsync();
+			Assert.NotNull(balances);
+		}
+	}
 
-    [Fact]
-    public async Task GetDisputes()
-    {
-        if (await Service.IsShopifyPaymentApiEnabledAsync())
-        {
-            var disputes = await Service.ListDisputesAsync();
-            Assert.NotNull(disputes);
-        }
-    }
+	[Fact]
+	public async Task GetPayouts()
+	{
+		if (await Service.IsShopifyPaymentApiEnabledAsync())
+		{
+			var payouts = await Service.ListPayoutsAsync();
+			Assert.NotNull(payouts);
+		}
+	}
 
-    [Fact]
-    public async Task GetTransactions()
-    {
-        if (await Service.IsShopifyPaymentApiEnabledAsync())
-        {
-            var transactions = await Service.ListTransactionsAsync();
-            Assert.NotNull(transactions);
-        }
-    }
+	[Fact]
+	public async Task GetDisputes()
+	{
+		if (await Service.IsShopifyPaymentApiEnabledAsync())
+		{
+			var disputes = await Service.ListDisputesAsync();
+			Assert.NotNull(disputes);
+		}
+	}
+	[Fact]
+	public async Task GetDisputedEvidence()
+	{
+		if (await Service.IsShopifyPaymentApiEnabledAsync())
+		{
+			var disputes = await Service.ListDisputesAsync();
+			
+			Assert.True((disputes?.Items?.Count() > 0),"There are no disputes to get dispute evidence from.");
+			
+			_testOutputHelper.WriteLine($"Getting evidence for dispute id '{disputes.Items.First().Id.Value}'.");
+
+			var disputedEvidence = await Service.GetDisputeEvidenceAsync(disputes.Items.First().Id.Value);
+			
+			Assert.NotNull(disputedEvidence);
+		}
+	}
+
+	[Fact]
+	public async Task PutDisputedEvidence()
+	{
+		if (await Service.IsShopifyPaymentApiEnabledAsync())
+		{
+			var disputes = await Service.ListDisputesAsync();
+			Assert.True((disputes?.Items?.Count() > 0),"There are no disputes available to add evidence to.");
+
+			_testOutputHelper.WriteLine($"Updating evidence for dispute Id: '{disputes.Items.First().Id.Value}'.");
+
+			ShopifyPaymentsDisputeEvidenceUpdate update = new();
+			update.CustomerFirstName = "Tom";
+			update.CustomerLastName = "Thumb";
+			update.CancellationRebuttal = "You can't cancel past the return period.";
+			update.RefundRefusalExplanation = "You are past the return period.";
+			update.RefundPolicyDisclosure = "Refund policy is displayed on the checkout page.";
+			update.AccessActivityLog = "Email sent detailing return policy.";
+			update.UncategorizedText = "You are trying to do something not allowed.";
+
+			var disputedEvidence = await Service.UpdateDisputeEvidenceAsync(disputes.Items.First().Id.Value, update);
+			Assert.NotNull(disputedEvidence);
+		}
+	}
+
+	[Fact]
+	public async Task GetTransactions()
+	{
+		if (await Service.IsShopifyPaymentApiEnabledAsync())
+		{
+			var transactions = await Service.ListTransactionsAsync();
+			Assert.NotNull(transactions);
+		}
+	}
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidence.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidence.cs
@@ -7,63 +7,63 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	/// <summary>
-	/// An object representing a Shopify payment dispute evidence.
-	/// </summary>
-	public class ShopifyPaymentsDisputeEvidence : ShopifyObject
-	{
-		[JsonProperty("payments_dispute_id")]
-		public long? PaymentsDisputeId { get; set; }
+    /// <summary>
+    /// An object representing a Shopify payment dispute evidence.
+    /// </summary>
+    public class ShopifyPaymentsDisputeEvidence : ShopifyObject
+    {
+        [JsonProperty("payments_dispute_id")]
+        public long? PaymentsDisputeId { get; set; }
 
-		[JsonProperty("access_activity_log")]
-		public string AccessActivityLog { get; set; }
+        [JsonProperty("access_activity_log")]
+        public string AccessActivityLog { get; set; }
 
-		[JsonProperty("customer_email_address")]
-		public string CustomerEmailAddress { get; set; }
+        [JsonProperty("customer_email_address")]
+        public string CustomerEmailAddress { get; set; }
 
-		[JsonProperty("customer_first_name")]
-		public string CustomerFirstName { get; set; }
+        [JsonProperty("customer_first_name")]
+        public string CustomerFirstName { get; set; }
 
-		[JsonProperty("customer_last_name")]
-		public string CustomerLastName { get; set; }
+        [JsonProperty("customer_last_name")]
+        public string CustomerLastName { get; set; }
 
-		[JsonProperty("uncategorized_text")]
-		public string UncategorizedText { get; set; }
+        [JsonProperty("uncategorized_text")]
+        public string UncategorizedText { get; set; }
 
-		[JsonProperty("shipping_address")]
-		public ShopifyPaymentsDisputeEvidenceAddress ShippingAddress { get; set; }
+        [JsonProperty("shipping_address")]
+        public ShopifyPaymentsDisputeEvidenceAddress ShippingAddress { get; set; }
 
-		[JsonProperty("cancellation_policy_disclosure")]
-		public string CancellationPolicyDisclosure { get; set; }
+        [JsonProperty("cancellation_policy_disclosure")]
+        public string CancellationPolicyDisclosure { get; set; }
 
-		[JsonProperty("cancellation_rebuttal")]
-		public string CancellationRebuttal { get; set; }
+        [JsonProperty("cancellation_rebuttal")]
+        public string CancellationRebuttal { get; set; }
 
-		[JsonProperty("refund_policy_disclosure")]
-		public string RefundPolicyDisclosure { get; set; }
+        [JsonProperty("refund_policy_disclosure")]
+        public string RefundPolicyDisclosure { get; set; }
 
-		[JsonProperty("refund_refusal_explanation")]
-		public string RefundRefusalExplanation { get; set; }
+        [JsonProperty("refund_refusal_explanation")]
+        public string RefundRefusalExplanation { get; set; }
 
-		[JsonProperty("submitted")]
-		public bool? Submitted { get; set; }
+        [JsonProperty("submitted")]
+        public bool? Submitted { get; set; }
 
-		[JsonProperty("product_description")]
-		public ShopifyPaymentsDisputeEvidenceProductDescription ProductDescription { get; set; }
+        [JsonProperty("product_description")]
+        public ShopifyPaymentsDisputeEvidenceProductDescription ProductDescription { get; set; }
 
-		[JsonProperty("created_at")]
-		public DateTimeOffset? CreatedAt { get; set; }
+        [JsonProperty("created_at")]
+        public DateTimeOffset? CreatedAt { get; set; }
 
-		[JsonProperty("updated_on")]
-		public DateTimeOffset? UpdatedOn { get; set; }
+        [JsonProperty("updated_on")]
+        public DateTimeOffset? UpdatedOn { get; set; }
 
-		[JsonProperty("dispute_evidence_files")]
-		public ShopifyPaymentsDisputeEvidenceFiles DisputeEvidenceFiles { get; set; }
+        [JsonProperty("dispute_evidence_files")]
+        public ShopifyPaymentsDisputeEvidenceFiles DisputeEvidenceFiles { get; set; }
 
-		[JsonProperty("billing_address")]
-		public ShopifyPaymentsDisputeEvidenceAddress BillingAddress { get; set; }
+        [JsonProperty("billing_address")]
+        public ShopifyPaymentsDisputeEvidenceAddress BillingAddress { get; set; }
 
-		[JsonProperty("fulfillments")]
-		public ShopifyPaymentsDisputeEvidenceFulfillment[] Fulfillments { get; set; }
-	}
+        [JsonProperty("fulfillments")]
+        public ShopifyPaymentsDisputeEvidenceFulfillment[] Fulfillments { get; set; }
+    }
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidence.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidence.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+	/// <summary>
+	/// An object representing a Shopify payment dispute evidence.
+	/// </summary>
+	public class ShopifyPaymentsDisputeEvidence : ShopifyObject
+	{
+		[JsonProperty("payments_dispute_id")]
+		public long? PaymentsDisputeId { get; set; }
+
+		[JsonProperty("access_activity_log")]
+		public string AccessActivityLog { get; set; }
+
+		[JsonProperty("customer_email_address")]
+		public string CustomerEmailAddress { get; set; }
+
+		[JsonProperty("customer_first_name")]
+		public string CustomerFirstName { get; set; }
+
+		[JsonProperty("customer_last_name")]
+		public string CustomerLastName { get; set; }
+
+		[JsonProperty("uncategorized_text")]
+		public string UncategorizedText { get; set; }
+
+		[JsonProperty("shipping_address")]
+		public ShopifyPaymentsDisputeEvidenceAddress ShippingAddress { get; set; }
+
+		[JsonProperty("cancellation_policy_disclosure")]
+		public string CancellationPolicyDisclosure { get; set; }
+
+		[JsonProperty("cancellation_rebuttal")]
+		public string CancellationRebuttal { get; set; }
+
+		[JsonProperty("refund_policy_disclosure")]
+		public string RefundPolicyDisclosure { get; set; }
+
+		[JsonProperty("refund_refusal_explanation")]
+		public string RefundRefusalExplanation { get; set; }
+
+		[JsonProperty("submitted")]
+		public bool? Submitted { get; set; }
+
+		[JsonProperty("product_description")]
+		public ShopifyPaymentsDisputeEvidenceProductDescription ProductDescription { get; set; }
+
+		[JsonProperty("created_at")]
+		public DateTimeOffset? CreatedAt { get; set; }
+
+		[JsonProperty("updated_on")]
+		public DateTimeOffset? UpdatedOn { get; set; }
+
+		[JsonProperty("dispute_evidence_files")]
+		public ShopifyPaymentsDisputeEvidenceFiles DisputeEvidenceFiles { get; set; }
+
+		[JsonProperty("billing_address")]
+		public ShopifyPaymentsDisputeEvidenceAddress BillingAddress { get; set; }
+
+		[JsonProperty("fulfillments")]
+		public ShopifyPaymentsDisputeEvidenceFulfillment[] Fulfillments { get; set; }
+	}
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidence.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidence.cs
@@ -64,6 +64,6 @@ namespace ShopifySharp
         public ShopifyPaymentsDisputeEvidenceAddress BillingAddress { get; set; }
 
         [JsonProperty("fulfillments")]
-        public ShopifyPaymentsDisputeEvidenceFulfillment[] Fulfillments { get; set; }
+        public IEnumerable<ShopifyPaymentsDisputeEvidenceFulfillment> Fulfillments { get; set; }
     }
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceBillingAddress.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceBillingAddress.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+	public class ShopifyPaymentsDisputeEvidenceAddress : ShopifyObject
+	{
+		/// <summary>
+		/// The street address of the shipping / billing location.
+		/// </summary>
+		[JsonProperty("address1")]
+		public string Address1 { get; set; }
+
+		/// <summary>
+		/// The second line of the address. Typically the number of the apartment, suite, or unit.
+		/// </summary>
+		[JsonProperty("address2")]
+		public string Address2 { get; set; }
+
+		/// <summary>
+		/// The city of the shipping / billing location.
+		/// </summary>
+		[JsonProperty("city")]
+		public string City { get; set; }
+
+		/// <summary>
+		/// The zip code of the shipping / billing location.
+		/// </summary>
+		[JsonProperty("zip")]
+		public string Zip { get; set; }
+
+		/// <summary>
+		/// (Required) The two-letter country code (ISO 3166-1 alpha-2 format) of the shipping / billing location.
+		/// </summary>
+		[JsonProperty("country_code")]
+		public string CountryCode { get; set; }
+
+		/// <summary>
+		/// The province of the shipping / billing location.
+		/// </summary>
+		[JsonProperty("province")]
+		public string Province { get; set; }
+
+		/// <summary>
+		/// The province code of the shipping / billing location.
+		/// </summary>
+		[JsonProperty("province_code")]
+		public string ProvinceCode { get; set; }
+	}
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceBillingAddress.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceBillingAddress.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	public class ShopifyPaymentsDisputeEvidenceAddress : ShopifyObject
+	public class ShopifyPaymentsDisputeEvidenceAddress
 	{
 		/// <summary>
 		/// The street address of the shipping / billing location.

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceBillingAddress.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceBillingAddress.cs
@@ -7,48 +7,48 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	public class ShopifyPaymentsDisputeEvidenceAddress
-	{
-		/// <summary>
-		/// The street address of the shipping / billing location.
-		/// </summary>
-		[JsonProperty("address1")]
-		public string Address1 { get; set; }
+    public class ShopifyPaymentsDisputeEvidenceAddress
+    {
+        /// <summary>
+        /// The street address of the shipping / billing location.
+        /// </summary>
+        [JsonProperty("address1")]
+        public string Address1 { get; set; }
 
-		/// <summary>
-		/// The second line of the address. Typically the number of the apartment, suite, or unit.
-		/// </summary>
-		[JsonProperty("address2")]
-		public string Address2 { get; set; }
+        /// <summary>
+        /// The second line of the address. Typically the number of the apartment, suite, or unit.
+        /// </summary>
+        [JsonProperty("address2")]
+        public string Address2 { get; set; }
 
-		/// <summary>
-		/// The city of the shipping / billing location.
-		/// </summary>
-		[JsonProperty("city")]
-		public string City { get; set; }
+        /// <summary>
+        /// The city of the shipping / billing location.
+        /// </summary>
+        [JsonProperty("city")]
+        public string City { get; set; }
 
-		/// <summary>
-		/// The zip code of the shipping / billing location.
-		/// </summary>
-		[JsonProperty("zip")]
-		public string Zip { get; set; }
+        /// <summary>
+        /// The zip code of the shipping / billing location.
+        /// </summary>
+        [JsonProperty("zip")]
+        public string Zip { get; set; }
 
-		/// <summary>
-		/// (Required) The two-letter country code (ISO 3166-1 alpha-2 format) of the shipping / billing location.
-		/// </summary>
-		[JsonProperty("country_code")]
-		public string CountryCode { get; set; }
+        /// <summary>
+        /// (Required) The two-letter country code (ISO 3166-1 alpha-2 format) of the shipping / billing location.
+        /// </summary>
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
 
-		/// <summary>
-		/// The province of the shipping / billing location.
-		/// </summary>
-		[JsonProperty("province")]
-		public string Province { get; set; }
+        /// <summary>
+        /// The province of the shipping / billing location.
+        /// </summary>
+        [JsonProperty("province")]
+        public string Province { get; set; }
 
-		/// <summary>
-		/// The province code of the shipping / billing location.
-		/// </summary>
-		[JsonProperty("province_code")]
-		public string ProvinceCode { get; set; }
-	}
+        /// <summary>
+        /// The province code of the shipping / billing location.
+        /// </summary>
+        [JsonProperty("province_code")]
+        public string ProvinceCode { get; set; }
+    }
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFiles.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFiles.cs
@@ -7,27 +7,27 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	public class ShopifyPaymentsDisputeEvidenceFiles
-	{
-		[JsonProperty("cancellation_policy_file_id")]
-		public long? CancellationPolicyFileId { get; set; }
+    public class ShopifyPaymentsDisputeEvidenceFiles
+    {
+        [JsonProperty("cancellation_policy_file_id")]
+        public long? CancellationPolicyFileId { get; set; }
 
-		[JsonProperty("customer_communication_file_id")]
-		public long? CustomerCommunicationFileId { get; set; }
+        [JsonProperty("customer_communication_file_id")]
+        public long? CustomerCommunicationFileId { get; set; }
 
-		[JsonProperty("customer_signature_file_id")]
-		public long? CustomerSignatureFileId { get; set; }
+        [JsonProperty("customer_signature_file_id")]
+        public long? CustomerSignatureFileId { get; set; }
 
-		[JsonProperty("refund_policy_file_id")]
-		public long? RefundPolicyFileId { get; set; }
+        [JsonProperty("refund_policy_file_id")]
+        public long? RefundPolicyFileId { get; set; }
 
-		[JsonProperty("service_documentation_file_id")]
-		public long? ServiceDocumentationFileId { get; set; }
+        [JsonProperty("service_documentation_file_id")]
+        public long? ServiceDocumentationFileId { get; set; }
 
-		[JsonProperty("shipping_documentation_file_id")]
-		public long? ShippingDocumentationFileId { get; set; }
+        [JsonProperty("shipping_documentation_file_id")]
+        public long? ShippingDocumentationFileId { get; set; }
 
-		[JsonProperty("uncategorized_file_id")]
-		public long? UncategorizedFileId { get; set; }
-	}
+        [JsonProperty("uncategorized_file_id")]
+        public long? UncategorizedFileId { get; set; }
+    }
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFiles.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFiles.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+	public class ShopifyPaymentsDisputeEvidenceFiles
+	{
+		[JsonProperty("cancellation_policy_file_id")]
+		public long? CancellationPolicyFileId { get; set; }
+
+		[JsonProperty("customer_communication_file_id")]
+		public long? CustomerCommunicationFileId { get; set; }
+
+		[JsonProperty("customer_signature_file_id")]
+		public long? CustomerSignatureFileId { get; set; }
+
+		[JsonProperty("refund_policy_file_id")]
+		public long? RefundPolicyFileId { get; set; }
+
+		[JsonProperty("service_documentation_file_id")]
+		public long? ServiceDocumentationFileId { get; set; }
+
+		[JsonProperty("shipping_documentation_file_id")]
+		public long? ShippingDocumentationFileId { get; set; }
+
+		[JsonProperty("uncategorized_file_id")]
+		public long? UncategorizedFileId { get; set; }
+	}
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFulfillment.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFulfillment.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+	public class ShopifyPaymentsDisputeEvidenceFulfillment 
+	{
+		[JsonProperty("shipping_carrier")]
+		public string ShippingCarrier { get; set; }
+
+		[JsonProperty("shipping_tracking_number")]
+		public long? ShippingTrackingNumber { get; set; }
+
+		[JsonProperty("shipping_date")]
+		public DateTimeOffset? ShippingDate { get; set; }
+	}
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFulfillment.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceFulfillment.cs
@@ -7,15 +7,15 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	public class ShopifyPaymentsDisputeEvidenceFulfillment 
-	{
-		[JsonProperty("shipping_carrier")]
-		public string ShippingCarrier { get; set; }
+    public class ShopifyPaymentsDisputeEvidenceFulfillment
+    {
+        [JsonProperty("shipping_carrier")]
+        public string ShippingCarrier { get; set; }
 
-		[JsonProperty("shipping_tracking_number")]
-		public long? ShippingTrackingNumber { get; set; }
+        [JsonProperty("shipping_tracking_number")]
+        public long? ShippingTrackingNumber { get; set; }
 
-		[JsonProperty("shipping_date")]
-		public DateTimeOffset? ShippingDate { get; set; }
-	}
+        [JsonProperty("shipping_date")]
+        public DateTimeOffset? ShippingDate { get; set; }
+    }
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceProductDescription.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceProductDescription.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+	public class ShopifyPaymentsDisputeEvidenceProductDescription
+	{
+		[JsonProperty("Product name")]
+		public string ProductName { get; set; }
+		public string Title { get; set; }
+		public string Price { get; set; }
+		public string Quantity { get; set; }
+		
+		[JsonProperty("Product Description")]
+		public string ProductDescription { get; set; }
+	}
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceProductDescription.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceProductDescription.cs
@@ -7,15 +7,15 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	public class ShopifyPaymentsDisputeEvidenceProductDescription
-	{
-		[JsonProperty("Product name")]
-		public string ProductName { get; set; }
-		public string Title { get; set; }
-		public string Price { get; set; }
-		public string Quantity { get; set; }
-		
-		[JsonProperty("Product Description")]
-		public string ProductDescription { get; set; }
-	}
+    public class ShopifyPaymentsDisputeEvidenceProductDescription
+    {
+        [JsonProperty("Product name")]
+        public string ProductName { get; set; }
+        public string Title { get; set; }
+        public string Price { get; set; }
+        public string Quantity { get; set; }
+
+        [JsonProperty("Product Description")]
+        public string ProductDescription { get; set; }
+    }
 }

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceUpdate.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceUpdate.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShopifySharp
+{
+	public class ShopifyPaymentsDisputeEvidenceUpdate
+	{
+		[JsonProperty("access_activity_log")]
+		public string AccessActivityLog { get; set; }
+
+		[JsonProperty("cancellation_policy_disclosure")]
+		public string CancellationPolicyDisclosure { get; set; }
+
+		[JsonProperty("cancellation_rebuttal")]
+		public string CancellationRebuttal { get; set; }
+
+		[JsonProperty("customer_email_address")]
+		public string CustomerEmailAddress { get; set; }
+
+		[JsonProperty("customer_first_name")]
+		public string CustomerFirstName { get; set; }
+
+		[JsonProperty("customer_last_name")]
+		public string CustomerLastName { get; set; }
+
+		[JsonProperty("refund_policy_disclosure")]
+		public string RefundPolicyDisclosure { get; set; }
+
+		[JsonProperty("refund_refusal_explanation")]
+		public string RefundRefusalExplanation { get; set; }
+
+		[JsonProperty("uncategorized_text")]
+		public string UncategorizedText { get; set; }
+	}
+}

--- a/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceUpdate.cs
+++ b/ShopifySharp/Entities/ShopifyPaymentsDisputeEvidenceUpdate.cs
@@ -7,33 +7,33 @@ using System.Threading.Tasks;
 
 namespace ShopifySharp
 {
-	public class ShopifyPaymentsDisputeEvidenceUpdate
-	{
-		[JsonProperty("access_activity_log")]
-		public string AccessActivityLog { get; set; }
+    public class ShopifyPaymentsDisputeEvidenceUpdate
+    {
+        [JsonProperty("access_activity_log")]
+        public string AccessActivityLog { get; set; }
 
-		[JsonProperty("cancellation_policy_disclosure")]
-		public string CancellationPolicyDisclosure { get; set; }
+        [JsonProperty("cancellation_policy_disclosure")]
+        public string CancellationPolicyDisclosure { get; set; }
 
-		[JsonProperty("cancellation_rebuttal")]
-		public string CancellationRebuttal { get; set; }
+        [JsonProperty("cancellation_rebuttal")]
+        public string CancellationRebuttal { get; set; }
 
-		[JsonProperty("customer_email_address")]
-		public string CustomerEmailAddress { get; set; }
+        [JsonProperty("customer_email_address")]
+        public string CustomerEmailAddress { get; set; }
 
-		[JsonProperty("customer_first_name")]
-		public string CustomerFirstName { get; set; }
+        [JsonProperty("customer_first_name")]
+        public string CustomerFirstName { get; set; }
 
-		[JsonProperty("customer_last_name")]
-		public string CustomerLastName { get; set; }
+        [JsonProperty("customer_last_name")]
+        public string CustomerLastName { get; set; }
 
-		[JsonProperty("refund_policy_disclosure")]
-		public string RefundPolicyDisclosure { get; set; }
+        [JsonProperty("refund_policy_disclosure")]
+        public string RefundPolicyDisclosure { get; set; }
 
-		[JsonProperty("refund_refusal_explanation")]
-		public string RefundRefusalExplanation { get; set; }
+        [JsonProperty("refund_refusal_explanation")]
+        public string RefundRefusalExplanation { get; set; }
 
-		[JsonProperty("uncategorized_text")]
-		public string UncategorizedText { get; set; }
-	}
+        [JsonProperty("uncategorized_text")]
+        public string UncategorizedText { get; set; }
+    }
 }

--- a/ShopifySharp/Services/ShopifyPayments/IShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/IShopifyPaymentsService.cs
@@ -6,63 +6,63 @@ using ShopifySharp.Lists;
 
 namespace ShopifySharp
 {
-	public interface IShopifyPaymentsService : IShopifyService
-	{
-		/// <summary>
-		/// Checks whether the Shopify Payments API is enabled on this store.
-		/// If not enabled, all Shopify Payments API endpoints will return HTTP 404 / Not Found
-		/// </summary>
-		Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default);
+    public interface IShopifyPaymentsService : IShopifyService
+    {
+        /// <summary>
+        /// Checks whether the Shopify Payments API is enabled on this store.
+        /// If not enabled, all Shopify Payments API endpoints will return HTTP 404 / Not Found
+        /// </summary>
+        Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets a count of all of the shop's transactions.
-		/// </summary>
-		/// <param name="orderId">The order id to which the fulfillments belong.</param>
-		/// <param name="cancellationToken">Cancellation Token</param>
-		/// <returns>The count of all fulfillments for the shop.</returns>
-		Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets a count of all of the shop's transactions.
+        /// </summary>
+        /// <param name="orderId">The order id to which the fulfillments belong.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <returns>The count of all fulfillments for the shop.</returns>
+        Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
-		/// </summary>
-		/// <param name="filter">Options for filtering the result.</param>
-		/// <param name="cancellationToken">Cancellation Token</param>
-		Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
+        /// </summary>
+        /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
-		/// </summary>
-		/// <param name="filter">Options for filtering the result.</param>
-		/// <param name="cancellationToken">Cancellation Token</param>
-		Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
+        /// </summary>
+        /// <param name="filter">Options for filtering the result.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default);
 
-		Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default);
+        Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default);
 
-		Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default);
+        Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default);
 
-		Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default);
-		
-		Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default);
-		
-		Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default);
-		
-		Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default);
-		
-		/// <summary>
-		/// Retrieves a single dispute evidence record from the dispute Id.
-		/// </summary>
-		/// <param name="disputeId"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
-		Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default);
-		
-		/// <summary>
-		/// Updates a single dispute evidence record from the dispute Id.
-		/// </summary>
-		/// <param name="disputeId"></param>
-		/// <param name="updateRequest"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
-		Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default);
-	}
+        Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default);
+
+        Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default);
+
+        Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default);
+
+        Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a single dispute evidence record from the dispute Id.
+        /// </summary>
+        /// <param name="disputeId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates a single dispute evidence record from the dispute Id.
+        /// </summary>
+        /// <param name="disputeId"></param>
+        /// <param name="updateRequest"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default);
+    }
 }

--- a/ShopifySharp/Services/ShopifyPayments/IShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/IShopifyPaymentsService.cs
@@ -6,41 +6,63 @@ using ShopifySharp.Lists;
 
 namespace ShopifySharp
 {
-    public interface IShopifyPaymentsService : IShopifyService
-    {
-        /// <summary>
-        /// Checks whether the Shopify Payments API is enabled on this store.
-        /// If not enabled, all Shopify Payments API endpoints will return HTTP 404 / Not Found
-        /// </summary>
-        Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default);
+	public interface IShopifyPaymentsService : IShopifyService
+	{
+		/// <summary>
+		/// Checks whether the Shopify Payments API is enabled on this store.
+		/// If not enabled, all Shopify Payments API endpoints will return HTTP 404 / Not Found
+		/// </summary>
+		Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Gets a count of all of the shop's transactions.
-        /// </summary>
-        /// <param name="orderId">The order id to which the fulfillments belong.</param>
-        /// <param name="cancellationToken">Cancellation Token</param>
-        /// <returns>The count of all fulfillments for the shop.</returns>
-        Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Gets a count of all of the shop's transactions.
+		/// </summary>
+		/// <param name="orderId">The order id to which the fulfillments belong.</param>
+		/// <param name="cancellationToken">Cancellation Token</param>
+		/// <returns>The count of all fulfillments for the shop.</returns>
+		Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
-        /// </summary>
-        /// <param name="filter">Options for filtering the result.</param>
-        /// <param name="cancellationToken">Cancellation Token</param>
-        Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
+		/// </summary>
+		/// <param name="filter">Options for filtering the result.</param>
+		/// <param name="cancellationToken">Cancellation Token</param>
+		Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
-        /// </summary>
-        /// <param name="filter">Options for filtering the result.</param>
-        /// <param name="cancellationToken">Cancellation Token</param>
-        Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Retrieves a list of all payouts ordered by payout date, with the most recent being first.
+		/// </summary>
+		/// <param name="filter">Options for filtering the result.</param>
+		/// <param name="cancellationToken">Cancellation Token</param>
+		Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default);
 
-        Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default);
-        Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default);
-        Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default);
-        Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default);
-        Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default);
-        Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default);
-    }
+		Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default);
+
+		Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default);
+
+		Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default);
+		
+		Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default);
+		
+		Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default);
+		
+		Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default);
+		
+		/// <summary>
+		/// Retrieves a single dispute evidence record from the dispute Id.
+		/// </summary>
+		/// <param name="disputeId"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default);
+		
+		/// <summary>
+		/// Updates a single dispute evidence record from the dispute Id.
+		/// </summary>
+		/// <param name="disputeId"></param>
+		/// <param name="updateRequest"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default);
+	}
 }

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -9,76 +9,76 @@ using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
-	/// <summary>
-	/// A service for manipulating Shopify payments.
-	/// </summary>
-	public class ShopifyPaymentsService : ShopifyService, IShopifyPaymentsService
-	{
-		/// <summary>
-		/// Creates a new instance of <see cref="ShopifyPaymentsService" />.
-		/// </summary>
-		/// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
-		/// <param name="shopAccessToken">An API access token for the shop.</param>
-		public ShopifyPaymentsService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-		internal ShopifyPaymentsService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) { }
+    /// <summary>
+    /// A service for manipulating Shopify payments.
+    /// </summary>
+    public class ShopifyPaymentsService : ShopifyService, IShopifyPaymentsService
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ShopifyPaymentsService" />.
+        /// </summary>
+        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+        /// <param name="shopAccessToken">An API access token for the shop.</param>
+        public ShopifyPaymentsService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
+        internal ShopifyPaymentsService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) { }
 
-		/// <inheritdoc />
-		public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default)
-		{
-			try
-			{
-				//calling any method endpoint would do, but choosing GetBalance because it is likely the most lightweight
-				await this.GetBalanceAsync(cancellationToken);
-				return true;
-			}
-			catch (ShopifyHttpException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
-			{
-				return false;
-			}
-		}
+        /// <inheritdoc />
+        public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                //calling any method endpoint would do, but choosing GetBalance because it is likely the most lightweight
+                await this.GetBalanceAsync(cancellationToken);
+                return true;
+            }
+            catch (ShopifyHttpException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+        }
 
-		/// <inheritdoc />
-		public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default) =>
-			await ExecuteGetAsync<IEnumerable<ShopifyPaymentsBalance>>("shopify_payments/balance.json", "balance", cancellationToken: cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default) =>
+            await ExecuteGetAsync<IEnumerable<ShopifyPaymentsBalance>>("shopify_payments/balance.json", "balance", cancellationToken: cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default) =>
-			await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter, cancellationToken: cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default) =>
+            await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter, cancellationToken: cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default) =>
-			await ListPayoutsAsync(filter?.AsListFilter(), cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default) =>
+            await ListPayoutsAsync(filter?.AsListFilter(), cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default) =>
-			await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout", cancellationToken: cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default) =>
+            await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout", cancellationToken: cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default) =>
-			await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter, cancellationToken: cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default) =>
+            await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter, cancellationToken: cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default) =>
-			await ListDisputesAsync(filter?.AsListFilter(), cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default) =>
+            await ListDisputesAsync(filter?.AsListFilter(), cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default) =>
-			await ExecuteGetAsync<ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute", cancellationToken: cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default) =>
+            await ExecuteGetAsync<ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute", cancellationToken: cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default) =>
-			await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default) =>
+            await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
 
-		/// <inheritdoc />
-		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
-			await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
+        /// <inheritdoc />
+        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
+            await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
 
-		/// <inheritdoc /> 
-		public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
-			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken);
+        /// <inheritdoc /> 
+        public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
+            await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken);
 
-		/// <inheritdoc /> 
-		public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
-			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken, updateRequest);
-	}
+        /// <inheritdoc /> 
+        public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
+            await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken, updateRequest);
+    }
 }

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -72,11 +72,11 @@ namespace ShopifySharp
 		/// <inheritdoc />
 		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
 			await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
-		
+
 		/// <inheritdoc /> //
 		public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
 			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken);
-		
+
 		/// <inheritdoc /> //
 		public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
 			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken, updateRequest);

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -9,68 +9,76 @@ using ShopifySharp.Utilities;
 
 namespace ShopifySharp
 {
-    /// <summary>
-    /// A service for manipulating Shopify payments.
-    /// </summary>
-    public class ShopifyPaymentsService : ShopifyService, IShopifyPaymentsService
-    {
-        /// <summary>
-        /// Creates a new instance of <see cref="ShopifyPaymentsService" />.
-        /// </summary>
-        /// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
-        /// <param name="shopAccessToken">An API access token for the shop.</param>
-        public ShopifyPaymentsService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
-        internal ShopifyPaymentsService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) {}
- 
-        /// <inheritdoc />
-        public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                //calling any method endpoint would do, but choosing GetBalance because it is likely the most lightweight
-                await this.GetBalanceAsync(cancellationToken);
-                return true;
-            }
-            catch (ShopifyHttpException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
-            {
-                return false;
-            }
-        }
+	/// <summary>
+	/// A service for manipulating Shopify payments.
+	/// </summary>
+	public class ShopifyPaymentsService : ShopifyService, IShopifyPaymentsService
+	{
+		/// <summary>
+		/// Creates a new instance of <see cref="ShopifyPaymentsService" />.
+		/// </summary>
+		/// <param name="myShopifyUrl">The shop's *.myshopify.com URL.</param>
+		/// <param name="shopAccessToken">An API access token for the shop.</param>
+		public ShopifyPaymentsService(string myShopifyUrl, string shopAccessToken) : base(myShopifyUrl, shopAccessToken) { }
+		internal ShopifyPaymentsService(string shopDomain, string accessToken, IShopifyDomainUtility shopifyDomainUtility) : base(shopDomain, accessToken, shopifyDomainUtility) { }
 
-        /// <inheritdoc />
-        public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default) =>
-            await ExecuteGetAsync<IEnumerable<ShopifyPaymentsBalance>>("shopify_payments/balance.json", "balance", cancellationToken: cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<bool> IsShopifyPaymentApiEnabledAsync(CancellationToken cancellationToken = default)
+		{
+			try
+			{
+				//calling any method endpoint would do, but choosing GetBalance because it is likely the most lightweight
+				await this.GetBalanceAsync(cancellationToken);
+				return true;
+			}
+			catch (ShopifyHttpException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
+			{
+				return false;
+			}
+		}
 
-        /// <inheritdoc />
-        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default) =>
-            await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter, cancellationToken: cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<IEnumerable<ShopifyPaymentsBalance>> GetBalanceAsync(CancellationToken cancellationToken = default) =>
+			await ExecuteGetAsync<IEnumerable<ShopifyPaymentsBalance>>("shopify_payments/balance.json", "balance", cancellationToken: cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default) =>
-            await ListPayoutsAsync(filter?.AsListFilter(), cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ListFilter<ShopifyPaymentsPayout> filter, CancellationToken cancellationToken = default) =>
+			await ExecuteGetListAsync("shopify_payments/payouts.json", "payouts", filter, cancellationToken: cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default) =>
-            await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout", cancellationToken: cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<ListResult<ShopifyPaymentsPayout>> ListPayoutsAsync(ShopifyPaymentsPayoutListFilter filter = null, CancellationToken cancellationToken = default) =>
+			await ListPayoutsAsync(filter?.AsListFilter(), cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default) =>
-            await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter, cancellationToken: cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<ShopifyPaymentsPayout> GetPayoutAsync(long payoutId, CancellationToken cancellationToken = default) =>
+			await ExecuteGetAsync<ShopifyPaymentsPayout>($"shopify_payments/payouts/{payoutId}.json", "payout", cancellationToken: cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default) =>
-            await ListDisputesAsync(filter?.AsListFilter(), cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ListFilter<ShopifyPaymentsDispute> filter, CancellationToken cancellationToken = default) =>
+			await ExecuteGetListAsync("shopify_payments/disputes.json", "disputes", filter, cancellationToken: cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default) =>
-            await ExecuteGetAsync< ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute", cancellationToken: cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<ListResult<ShopifyPaymentsDispute>> ListDisputesAsync(ShopifyPaymentsDisputeListFilter filter = null, CancellationToken cancellationToken = default) =>
+			await ListDisputesAsync(filter?.AsListFilter(), cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default) =>
-            await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
+		/// <inheritdoc />
+		public virtual async Task<ShopifyPaymentsDispute> GetDisputeAsync(long disputeId, CancellationToken cancellationToken = default) =>
+			await ExecuteGetAsync<ShopifyPaymentsDispute>($"shopify_payments/disputes/{disputeId}.json", "dispute", cancellationToken: cancellationToken);
 
-        /// <inheritdoc />
-        public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
-            await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
-    }
+		/// <inheritdoc />
+		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ListFilter<ShopifyPaymentsTransaction> filter, CancellationToken cancellationToken = default) =>
+			await ExecuteGetListAsync("shopify_payments/balance/transactions.json", "transactions", filter, cancellationToken: cancellationToken);
+
+		/// <inheritdoc />
+		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
+			await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
+		
+		/// <inheritdoc />
+		public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
+			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute", cancellationToken: cancellationToken);
+		
+		/// <inheritdoc />
+		public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
+			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute", cancellationToken: cancellationToken, updateRequest);
+	}
 }

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -73,11 +73,11 @@ namespace ShopifySharp
 		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
 			await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
 		
-		/// <inheritdoc />
+		/// <inheritdoc /> //
 		public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
 			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken);
 		
-		/// <inheritdoc />
+		/// <inheritdoc /> //
 		public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
 			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken, updateRequest);
 	}

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -73,11 +73,11 @@ namespace ShopifySharp
 		public virtual async Task<ListResult<ShopifyPaymentsTransaction>> ListTransactionsAsync(ShopifyPaymentsTransactionListFilter filter = null, CancellationToken cancellationToken = default) =>
 			await ListTransactionsAsync(filter?.AsListFilter(), cancellationToken);
 
-		/// <inheritdoc /> //
+		/// <inheritdoc /> 
 		public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
 			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken);
 
-		/// <inheritdoc /> //
+		/// <inheritdoc /> 
 		public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
 			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken, updateRequest);
 	}

--- a/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
+++ b/ShopifySharp/Services/ShopifyPayments/ShopifyPaymentsService.cs
@@ -75,10 +75,10 @@ namespace ShopifySharp
 		
 		/// <inheritdoc />
 		public async Task<ShopifyPaymentsDisputeEvidence> GetDisputeEvidenceAsync(long disputeId, CancellationToken cancellationToken = default) =>
-			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute", cancellationToken: cancellationToken);
+			await ExecuteGetAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken);
 		
 		/// <inheritdoc />
 		public async Task<ShopifyPaymentsDisputeEvidence> UpdateDisputeEvidenceAsync(long disputeId, ShopifyPaymentsDisputeEvidenceUpdate updateRequest, CancellationToken cancellationToken = default) =>
-			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute", cancellationToken: cancellationToken, updateRequest);
+			await ExecutePutAsync<ShopifyPaymentsDisputeEvidence>($"shopify_payments/disputes/{disputeId}/dispute_evidences.json", "dispute_evidence", cancellationToken: cancellationToken, updateRequest);
 	}
 }


### PR DESCRIPTION
https://github.com/nozzlegear/ShopifySharp/issues/1009
I have attempted to implement this feature. I was able to pull a dispute but when I tried to pull dispute evidence it would always return a 404. I can see from the documentation it says I need the scope -> shopify_payments_dispute_evidences but I don't see how to enable this. 
![DisputeEvidence](https://github.com/nozzlegear/ShopifySharp/assets/7493730/ad180db4-2c3c-4ac3-b8f1-8e35b83ee3ed)
