### PR TITLE
Make ShopifyHttpException.RequestInfo a nullable string

### DIFF
--- a/ShopifySharp.Tests/Infrastructure/ResponseClassifierTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/ResponseClassifierTests.cs
@@ -142,7 +142,7 @@ public class ResponseClassifierTest
 
     private ShopifyHttpException CreateHttpException(int statusCode)
     {
-        return new ShopifyHttpException(string.Empty, (HttpStatusCode)statusCode,
+        return new ShopifyHttpException((HttpStatusCode)statusCode,
             [],
             "some-exception-message",
             "some-raw-response-body",

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -5,7 +5,6 @@ using System.Net;
 namespace ShopifySharp.Infrastructure;
 
 public class ShopifyHttpException(
-    string requestInfo,
     HttpStatusCode statusCode,
     ICollection<string> errors,
     string message,
@@ -25,5 +24,6 @@ public class ShopifyHttpException(
     /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
     public new readonly string? RequestId = requestId;
 
-    public readonly string RequestInfo = requestInfo;
+    /// Extra details about the request, for logging purposes.
+    public readonly string? RequestInfo = requestInfo;
 }

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -9,8 +9,8 @@ public class ShopifyHttpException(
     ICollection<string> errors,
     string message,
     string rawResponseBody,
-    string? requestId
-) : ShopifyException(statusCode, errors, message, rawResponseBody, requestId)
+    string? requestId)
+    : ShopifyException(statusCode, errors, message, rawResponseBody, requestId)
 {
     /// The Http response status code.
     public new readonly HttpStatusCode HttpStatusCode = statusCode;
@@ -25,5 +25,17 @@ public class ShopifyHttpException(
     public new readonly string? RequestId = requestId;
 
     /// Extra details about the request, for logging purposes.
-    public readonly string? RequestInfo = requestInfo;
+    public readonly string? RequestInfo;
+
+    public ShopifyHttpException(
+        string requestInfo,
+        HttpStatusCode statusCode,
+        ICollection<string> errors,
+        string message,
+        string rawResponseBody,
+        string? requestId)
+        : this(statusCode, errors, message, rawResponseBody, requestId)
+    {
+        RequestInfo = requestInfo;
+    }
 }


### PR DESCRIPTION
This PR just makes the `ShopifyHttpException.RequestInfo` property a nullable string, and restores the old constructor where that property wasn't passed in. When that constructor is used (only in tests, which I'm writing in a different branch), the property will be its default null value.