### PR TITLE
fix: Dispose cloned request messages in `ExponentialRetryPolicy`

### DIFF
--- a/ShopifySharp.Extensions.DependencyInjection.Tests/TestClasses.cs
+++ b/ShopifySharp.Extensions.DependencyInjection.Tests/TestClasses.cs
@@ -8,7 +8,7 @@ public class TestException : Exception;
 public class TestRequestExecutionPolicy : IRequestExecutionPolicy
 {
     public Task<RequestResult<T>> Run<T>(
-        CloneableRequestMessage requestMessage,
+        CloneableRequestMessage baseRequestMessage,
         ExecuteRequestAsync<T> executeRequestAsync,
         CancellationToken cancellationToken,
         int? graphqlQueryCost = null

--- a/ShopifySharp.Tests/Infrastructure/Policies/ExponentialRetry/ExponentialRetryPolicyTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/Policies/ExponentialRetry/ExponentialRetryPolicyTests.cs
@@ -81,6 +81,19 @@ public class ExponentialRetryPolicyTests
     }
 
     [Fact]
+    public async Task Run_ShouldDisposeClonedRequestMessages()
+    {
+        _cloneableRequestMessage.When(x => x.Dispose())
+            .Throw<TestException>();
+
+        var policy = SetupPolicy();
+        var act = () => policy.Run(_cloneableRequestMessage, _executeRequest, CancellationToken.None);
+
+        await act.Should().ThrowAsync<TestException>();
+        _cloneableRequestMessage.Received(1).Dispose();
+    }
+
+    [Fact]
     public async Task Run_ShouldThrowWhenRequestIsNotRetriableAsync()
     {
         var ex = new TestShopifyException();

--- a/ShopifySharp/Infrastructure/Policies/Default/DefaultRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/Default/DefaultRequestExecutionPolicy.cs
@@ -7,9 +7,9 @@ namespace ShopifySharp;
 
 public class DefaultRequestExecutionPolicy : IRequestExecutionPolicy
 {
-    public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage request, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
+    public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
     {
-        var fullResult = await executeRequestAsync(request);
+        var fullResult = await executeRequestAsync(baseRequestMessage);
 
         return fullResult;
     }

--- a/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/IRequestExecutionPolicy.cs
@@ -13,9 +13,9 @@ public delegate Task<RequestResult<T>> ExecuteRequestAsync<T>(CloneableRequestMe
 /// </summary>
 public interface IRequestExecutionPolicy
 {
-    /// <param name="requestMessage">The base request that was built by a service to execute.</param>
+    /// <param name="baseRequestMessage">The base request that was built by a service to execute.</param>
     /// <param name="executeRequestAsync">A delegate that executes the request you pass to it.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="graphqlQueryCost">Optional expected Graphql query cost (as seen in GraphQL response at extensions.cost.requestedQueryCost</param>
-    Task<RequestResult<T>> Run<T>(CloneableRequestMessage requestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null);
+    Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null);
 }

--- a/ShopifySharp/Infrastructure/Policies/Retry/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/Retry/RetryExecutionPolicy.cs
@@ -42,7 +42,7 @@ public class RetryExecutionPolicy : IRequestExecutionPolicy
     }
 
     public async Task<RequestResult<T>> Run<T>(
-        CloneableRequestMessage baseRequest,
+        CloneableRequestMessage baseRequestMessage,
         ExecuteRequestAsync<T> executeRequestAsync,
         CancellationToken cancellationToken,
         int? graphqlQueryCost = null
@@ -53,7 +53,7 @@ public class RetryExecutionPolicy : IRequestExecutionPolicy
 
         while (true)
         {
-            using var request = await baseRequest.CloneAsync();
+            using var request = await baseRequestMessage.CloneAsync();
 
             try
             {


### PR DESCRIPTION
This pull request fixes a bug in the `ExponentialRetryPolicy` where cloned request messages were not being disposed between retries, leading to a potential memory leak.