### PR TITLE
feature: Add support for retrying first failure immediately in ExponentialRetryPolicy with `ExponentialRetryPolicyOptions.FirstRetryIsImmediate`

### DIFF
--- a/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
+++ b/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
@@ -45,7 +45,7 @@ public class CloneableRequestMessage: HttpRequestMessage
         return cloned;
     }
 
-    public async Task<CloneableRequestMessage> CloneAsync(CancellationToken cancellationToken = default)
+    public virtual async Task<CloneableRequestMessage> CloneAsync(CancellationToken cancellationToken = default)
     {
         var newContent = Content is null ? null : await CloneToStreamOrReadOnlyMemoryContent(Content, cancellationToken);
         var cloned = new CloneableRequestMessage(RequestUri, Method, newContent);

--- a/ShopifySharp/Infrastructure/Policies/Default/DefaultRequestExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/Default/DefaultRequestExecutionPolicy.cs
@@ -9,8 +9,6 @@ public class DefaultRequestExecutionPolicy : IRequestExecutionPolicy
 {
     public async Task<RequestResult<T>> Run<T>(CloneableRequestMessage baseRequestMessage, ExecuteRequestAsync<T> executeRequestAsync, CancellationToken cancellationToken, int? graphqlQueryCost = null)
     {
-        var fullResult = await executeRequestAsync(baseRequestMessage);
-
-        return fullResult;
+        return await executeRequestAsync(baseRequestMessage);
     }
 }

--- a/ShopifySharp/Infrastructure/Policies/ExponentialRetry/ExponentialRetryPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/ExponentialRetry/ExponentialRetryPolicy.cs
@@ -56,8 +56,7 @@ public class ExponentialRetryPolicy : IRequestExecutionPolicy
 
             try
             {
-                var value = await executeRequestAsync.Invoke(clonedRequestMessage);
-                return value;
+                return await executeRequestAsync.Invoke(clonedRequestMessage);
             }
             catch (ShopifyException ex)
             {

--- a/ShopifySharp/Infrastructure/Policies/ExponentialRetry/ExponentialRetryPolicyOptions.cs
+++ b/ShopifySharp/Infrastructure/Policies/ExponentialRetry/ExponentialRetryPolicyOptions.cs
@@ -10,23 +10,45 @@ namespace ShopifySharp.Infrastructure.Policies.ExponentialRetry;
 /// </summary>
 public record ExponentialRetryPolicyOptions
 {
+    /// <summary>
+    /// Indicates whether the policy should immediately retry the first failure per request before applying the
+    /// exponential backoff strategy.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the first retry should be immediate; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// Setting this property to <c>true</c> can be useful in scenarios where transient failures are likely and
+    /// immediate retry might resolve the failure. If set to <c>false</c>, all retries including the first one
+    /// will follow the exponential backoff intervals.
+    /// </remarks>
+    public bool FirstRetryIsImmediate { get; set; }
+
 #if NET8_0_OR_GREATER
     public required int InitialBackoffInMilliseconds { get; set; }
+
+    /// <summary>
     /// The maximum amount of time that can be spent waiting before retrying a request. This is an effective cap on the
     /// exponential growth of the policy's retry delay, which could eventually lead to an overflow without it.
+    /// </summary>
     public required TimeSpan MaximumDelayBetweenRetries { get; set; }
 #else
     public int InitialBackoffInMilliseconds { get; set; }
+    /// <summary>
     /// The maximum amount of time that can be spent waiting before retrying a request. This is an effective cap on the
     /// exponential growth of the policy's retry delay, which could eventually lead to an overflow without it.
+    /// </summary>
     public TimeSpan MaximumDelayBetweenRetries { get; set; }
 #endif
     public int? MaximumRetriesBeforeRequestCancellation { get; set; }
     public TimeSpan? MaximumDelayBeforeRequestCancellation { get; set; }
 
     /// <summary>
-    /// Validates this instance and throws an <see cref="ArgumentException"/> if misconfigured.
+    /// Validates this instance and throws <see cref="ArgumentException"/> if misconfigured.
     /// </summary>
+    /// <throws>
+    /// <see cref="ArgumentException"/> when the options are misconfigured.
+    /// </throws>
     public void Validate()
     {
         if (InitialBackoffInMilliseconds <= 0)
@@ -42,6 +64,7 @@ public record ExponentialRetryPolicyOptions
     public static ExponentialRetryPolicyOptions Default() =>
         new()
         {
+            FirstRetryIsImmediate = false,
             MaximumRetriesBeforeRequestCancellation = 10,
             MaximumDelayBetweenRetries = TimeSpan.FromSeconds(1),
             MaximumDelayBeforeRequestCancellation = TimeSpan.FromSeconds(5),

--- a/ShopifySharp/Infrastructure/Policies/LeakyBucket/LeakyBucketExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/LeakyBucket/LeakyBucketExecutionPolicy.cs
@@ -118,7 +118,7 @@ public class LeakyBucketExecutionPolicy : IRequestExecutionPolicy
         while (true)
         {
             // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-            using var request = await baseRequest.CloneAsync();
+            using var request = await baseRequest.CloneAsync(cancellationToken);
 
             if (bucket != null)
             {
@@ -155,7 +155,7 @@ public class LeakyBucketExecutionPolicy : IRequestExecutionPolicy
         while (true)
         {
             // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-            var request = await baseRequest.CloneAsync();
+            var request = await baseRequest.CloneAsync(cancellationToken);
 
             if (bucket != null)
             {
@@ -229,7 +229,7 @@ public class LeakyBucketExecutionPolicy : IRequestExecutionPolicy
         while (true)
         {
             // TODO: add a check to see if the request should be cloned, so the clone can be skipped on the first request
-            using var request = await baseRequest.CloneAsync();
+            using var request = await baseRequest.CloneAsync(cancellationToken);
 
             if (bucket != null)
             {

--- a/ShopifySharp/Infrastructure/Policies/Retry/RetryExecutionPolicy.cs
+++ b/ShopifySharp/Infrastructure/Policies/Retry/RetryExecutionPolicy.cs
@@ -53,7 +53,7 @@ public class RetryExecutionPolicy : IRequestExecutionPolicy
 
         while (true)
         {
-            using var request = await baseRequestMessage.CloneAsync();
+            using var request = await baseRequestMessage.CloneAsync(cancellationToken);
 
             try
             {


### PR DESCRIPTION
This pull request adds a new option to the `ExponentialRetryPolicyOptions` named `FirstRetryIsImmediate`. When true, each request will be retried immediately if it fails before the exponential delay begins. The default value for the option is false.

There's also a small "feature" in this PR that enables cancellation token support for `CloneableRequestMessage.CloneAsync()`. 