### PR TITLE
API version 2024-07

### DIFF
--- a/ShopifySharp.Tests/Article_Tests.cs
+++ b/ShopifySharp.Tests/Article_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using EmptyAssert = ShopifySharp.Tests.Extensions.EmptyExtensions;
@@ -150,7 +151,7 @@ public class Article_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(BlogId.Value, article.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Asset_Tests.cs
+++ b/ShopifySharp.Tests/Asset_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -143,7 +144,7 @@ public class Asset_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(ThemeId, asset.Key);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Blog_Tests.cs
+++ b/ShopifySharp.Tests/Blog_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -121,7 +122,7 @@ public class Blog_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Carrier_Tests.cs
+++ b/ShopifySharp.Tests/Carrier_Tests.cs
@@ -113,7 +113,7 @@ public class Carrier_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Collect_Tests.cs
+++ b/ShopifySharp.Tests/Collect_Tests.cs
@@ -144,7 +144,7 @@ public class Collect_Tests_Fixture : IAsyncLifetime
                 await Service.DeleteAsync(obj.Id.Value);
                 await ProductService.DeleteAsync(obj.ProductId.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {
@@ -158,7 +158,7 @@ public class Collect_Tests_Fixture : IAsyncLifetime
         {
             await CustomCollectionService.DeleteAsync(CollectionId);
         }
-        catch (ShopifyException ex) when ((int)ex.HttpStatusCode == 404)
+        catch (ShopifyHttpException ex) when ((int)ex.HttpStatusCode == 404)
         {
             // Collection has already been deleted
         }

--- a/ShopifySharp.Tests/Collection_Tests.cs
+++ b/ShopifySharp.Tests/Collection_Tests.cs
@@ -108,7 +108,7 @@ public class Collection_Tests_Fixture : IAsyncLifetime
                 await CollectService.DeleteAsync(obj.Id.Value);
                 await ProductService.DeleteAsync(obj.ProductId.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Country_Tests.cs
+++ b/ShopifySharp.Tests/Country_Tests.cs
@@ -129,7 +129,7 @@ public class Country_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/CustomCollection_Tests.cs
+++ b/ShopifySharp.Tests/CustomCollection_Tests.cs
@@ -120,7 +120,7 @@ public class CustomCollection_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/CustomerAddress_Tests.cs
+++ b/ShopifySharp.Tests/CustomerAddress_Tests.cs
@@ -137,7 +137,7 @@ public class CustomerAddress_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(CustomerId.Value, Address.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Customer_Tests.cs
+++ b/ShopifySharp.Tests/Customer_Tests.cs
@@ -269,7 +269,7 @@ public class Customer_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/DiscountCode_Tests.cs
+++ b/ShopifySharp.Tests/DiscountCode_Tests.cs
@@ -174,7 +174,7 @@ public class DiscountCodes_Tests_Fixture : IAsyncLifetime
             {
                 await DiscountCodeService.DeleteAsync(obj.PriceRuleId.Value, obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {
@@ -192,7 +192,7 @@ public class DiscountCodes_Tests_Fixture : IAsyncLifetime
             {
                 await PriceRuleService.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/DraftOrder_Tests.cs
+++ b/ShopifySharp.Tests/DraftOrder_Tests.cs
@@ -182,7 +182,7 @@ public class DraftOrder_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentOrder_Tests.cs
@@ -353,7 +353,6 @@ public class FulfillmentOrder_Tests_Fixture : IAsyncLifetime
                 TrackingSupport = true,
                 RequiresShippingMethod = false,
                 Format = "json",
-                FulfillmentOrdersOptIn = true,
             });
         }
 

--- a/ShopifySharp.Tests/FulfillmentService_Tests.cs
+++ b/ShopifySharp.Tests/FulfillmentService_Tests.cs
@@ -116,7 +116,6 @@ public class FulfillmentService_Tests_Fixture : IAsyncLifetime
             TrackingSupport = false,
             RequiresShippingMethod = false,
             Format = "json",
-            FulfillmentOrdersOptIn= true,//mandatory to set this to true starting from API 2022-10
         });
 
         if (!skipAddToCreateList) Created.Add(fulfillmentServiceEntity);

--- a/ShopifySharp.Tests/Fulfillment_Tests.cs
+++ b/ShopifySharp.Tests/Fulfillment_Tests.cs
@@ -218,7 +218,7 @@ public class Fulfillment_Tests_Fixture : IAsyncLifetime
             {
                 await OrderService.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if ((int)ex.HttpStatusCode != 404)
                 {

--- a/ShopifySharp.Tests/Infrastructure/CloneableRequestMessageTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/CloneableRequestMessageTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using JetBrains.Annotations;
 using ShopifySharp.Infrastructure;
 using Xunit;
-#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace ShopifySharp.Tests.Infrastructure;
 
@@ -19,107 +18,6 @@ public class CloneableRequestMessageTests
 {
     private static readonly Uri Host = new("https://fake-url.com/admin/api.json");
     private static readonly HttpMethod Method = HttpMethod.Post;
-
-    [Fact]
-    public void Clone_ShouldCloneWithNoHttpContent_AndPreserveHeaders()
-    {
-        // Setup
-        var cloneableRequest = new CloneableRequestMessage(Host, Method);
-        cloneableRequest.Headers.Add("some-key", "some-value");
-
-        // Act
-        var clonedRequest = cloneableRequest.Clone();
-
-        // Assert
-        clonedRequest.Should().NotBeNull();
-        clonedRequest.RequestUri.Should().Be(Host);
-        clonedRequest.Method.Should().Be(Method);
-        clonedRequest.Content.Should().BeNull();
-        clonedRequest.Headers.Should().ContainKey("some-key")
-            .WhoseValue.Should().Contain("some-value");
-    }
-
-    [Fact]
-    public void Clone_ShouldCloneJsonContent_AndPreserveHeaders()
-    {
-        // Setup
-        var jsonContent = new JsonContent(new { Foo = "bar" })
-        {
-            Headers = { {"some-key-1", "some-value-1"} }
-        };
-        var cloneableRequest = new CloneableRequestMessage(Host, Method, jsonContent);
-        cloneableRequest.Headers.Add("some-key-2", "some-value-2");
-
-        // Act
-        var clonedRequest = cloneableRequest.Clone();
-
-        // Assert
-        clonedRequest.Should().NotBeNull();
-        clonedRequest.RequestUri.Should().Be(Host);
-        clonedRequest.Method.Should().Be(Method);
-        clonedRequest.Content.Should().NotBeNull();
-        clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
-            .WhoseValue.Should().BeEquivalentTo(["application/json"]);
-        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
-            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
-        clonedRequest.Content!.Headers.Should().ContainKey("some-key-1")
-            .WhoseValue.Should().BeEquivalentTo(["some-value-1"]);
-        clonedRequest.Headers.Should().ContainKey("some-key-2")
-            .WhoseValue.Should().BeEquivalentTo(["some-value-2"]);
-    }
-
-    [Fact]
-    public void Clone_ShouldNotThrowWhenCloningDisposedRequest()
-    {
-        // The original Clone method did not interact with the underlying request's memory stream. Instead,
-        // it holds the original data object in memory and reserializes it to a byte array on each clone.
-        // It is only serializing the request/content into an Http pipeline that will throw an exception here.
-
-        // Setup
-        var jsonContent = new JsonContent(new { Foo = "bar" })
-        {
-            Headers = { {"some-key-1", "some-value-1"} }
-        };
-        var cloneableRequest = new CloneableRequestMessage(Host, Method, jsonContent);
-        cloneableRequest.Dispose();
-
-        // Act
-        var clonedRequest = () => cloneableRequest.Clone();
-
-        // Assert
-        clonedRequest.Should().NotThrow();
-    }
-
-    [Fact]
-    public void Clone_ShouldCloneMultipleTimesWithoutDisposalExceptions()
-    {
-        // Setup
-        var jsonContent = new JsonContent(new { Foo = "bar" })
-        {
-            Headers = { {"some-key-1", "some-value-1"} }
-        };
-        var baseRequest = new TestCloneableRequestMessage(Host, Method, jsonContent);
-
-        // Act
-        var act = () =>
-        {
-            for (var i = 0; i < 5; i++)
-            {
-                var clonedRequest = baseRequest.Clone();
-
-                clonedRequest.Should().NotBeNull();
-                clonedRequest.RequestUri.Should().Be(Host);
-                clonedRequest.Method.Should().Be(Method);
-                clonedRequest.Content.Should().NotBeNull();
-                clonedRequest.Content!.Headers.Should().ContainKey("Content-Type")
-                    .WhoseValue.Should().BeEquivalentTo(["application/json"]);
-            }
-        };
-
-        // Assert
-        act.Should().NotThrow();
-        baseRequest.Disposed.Should().BeFalse();
-    }
 
     #region CloneAsync
 

--- a/ShopifySharp.Tests/InventoryItem_Tests.cs
+++ b/ShopifySharp.Tests/InventoryItem_Tests.cs
@@ -96,7 +96,7 @@ public class InventoryItem_Tests_Fixture : IAsyncLifetime
             {
                 await VariantService.DeleteAsync(ProductId, obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/InventoryLevel_Tests.cs
+++ b/ShopifySharp.Tests/InventoryLevel_Tests.cs
@@ -196,7 +196,7 @@ public class InventoryLevel_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(created.InventoryItemId.Value, created.LocationId.Value);
             }
-            catch (ShopifyException ex) when ((int) ex.HttpStatusCode == 406)
+            catch (ShopifyHttpException ex) when ((int) ex.HttpStatusCode == 406)
             {
                 // The last inventory level for an item cannot be deleted. In this case, Shopify will return a 406.
             }

--- a/ShopifySharp.Tests/MetaField_Tests.cs
+++ b/ShopifySharp.Tests/MetaField_Tests.cs
@@ -291,7 +291,7 @@ public class MetaField_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/OrderRisk_Tests.cs
+++ b/ShopifySharp.Tests/OrderRisk_Tests.cs
@@ -145,7 +145,7 @@ public class OrderRisk_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(OrderId, obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Order_Tests.cs
+++ b/ShopifySharp.Tests/Order_Tests.cs
@@ -249,7 +249,7 @@ public class Order_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Page_Tests.cs
+++ b/ShopifySharp.Tests/Page_Tests.cs
@@ -121,7 +121,7 @@ public class Page_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/PriceRule_Tests.cs
+++ b/ShopifySharp.Tests/PriceRule_Tests.cs
@@ -137,7 +137,7 @@ public class PriceRule_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/ProductImage_Tests.cs
+++ b/ShopifySharp.Tests/ProductImage_Tests.cs
@@ -133,7 +133,7 @@ public class ProductImage_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(ProductId, obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/ProductVariant_Tests.cs
+++ b/ShopifySharp.Tests/ProductVariant_Tests.cs
@@ -144,7 +144,7 @@ public class ProductVariant_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(ProductId, obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Product_Tests.cs
+++ b/ShopifySharp.Tests/Product_Tests.cs
@@ -246,7 +246,7 @@ public class Product_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Redirect_Tests.cs
+++ b/ShopifySharp.Tests/Redirect_Tests.cs
@@ -123,7 +123,7 @@ public class Redirect_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Refund_Tests.cs
+++ b/ShopifySharp.Tests/Refund_Tests.cs
@@ -161,7 +161,7 @@ public class Refund_Tests_Fixture : IAsyncLifetime
             {
                 await OrderService.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/SalesChannel/ProductListing_Tests.cs
+++ b/ShopifySharp.Tests/SalesChannel/ProductListing_Tests.cs
@@ -72,7 +72,7 @@ public class ProductListing_Tests_Fixture : IAsyncLifetime
                 await Service.DeleteAsync(obj.Id.Value);
                 await ProductService.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/ScriptTag_Tests.cs
+++ b/ShopifySharp.Tests/ScriptTag_Tests.cs
@@ -127,7 +127,7 @@ public class ScriptTag_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/ShopifyException_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyException_Tests.cs
@@ -47,13 +47,13 @@ public class ShopifyException_Tests
         };
         res.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, rawBody);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -70,7 +70,7 @@ public class ShopifyException_Tests
     {
         HttpResponseMessage response;
         string rawBody;
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         using (var client = new HttpClient())
         {
@@ -93,7 +93,7 @@ public class ShopifyException_Tests
                         // RateLimitExceptions may happen when all Exception tests are running and
                         // execution policies are retrying.
                     }
-                    catch (ShopifyException e)
+                    catch (ShopifyHttpException e)
                     {
                         ex = e;
                     }
@@ -112,7 +112,7 @@ public class ShopifyException_Tests
     {
         HttpResponseMessage response;
         string rawBody;
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         using (var client = new HttpClient())
         {
@@ -135,7 +135,7 @@ public class ShopifyException_Tests
                         // RateLimitExceptions may happen when all Exception tests are running and
                         // execution policies are retrying.
                     }
-                    catch (ShopifyException e)
+                    catch (ShopifyHttpException e)
                     {
                         ex = e;
                     }
@@ -190,7 +190,7 @@ public class ShopifyException_Tests
         };
         HttpResponseMessage response;
         string rawBody;
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         using (var client = new HttpClient())
         {
@@ -214,7 +214,7 @@ public class ShopifyException_Tests
                         // RateLimitExceptions may happen when all Exception tests are running and
                         // execution policies are retrying.
                     }
-                    catch (ShopifyException e)
+                    catch (ShopifyHttpException e)
                     {
                         ex = e;
                     }
@@ -325,7 +325,7 @@ public class ShopifyException_Tests
 
         int requestCount = 60;
         var service = new OrderService(Utils.MyShopifyUrl, Utils.AccessToken);
-        ShopifyException ex = null;
+        ShopifyRateLimitException ex = null;
 
         try
         {
@@ -336,7 +336,7 @@ public class ShopifyException_Tests
 
             await Task.WhenAll(tasks);
         }
-        catch (ShopifyException e)
+        catch (ShopifyRateLimitException e)
         {
             ex = e;
         }

--- a/ShopifySharp.Tests/ShopifyService_Tests.cs
+++ b/ShopifySharp.Tests/ShopifyService_Tests.cs
@@ -50,13 +50,13 @@ public class ShopifyService_Tests
     {
         var json = "{}";
         var res = BadResponse(HttpStatusCode.InternalServerError, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -72,13 +72,13 @@ public class ShopifyService_Tests
         var json = "<p>testing</p>";
         var res = BadResponse(HttpStatusCode.InternalServerError, json);
         res.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -94,13 +94,13 @@ public class ShopifyService_Tests
         var json = "{\"errors\":\"foo error message\"}";
         var code = HttpStatusCode.BadRequest;
         var res = BadResponse(code, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -116,13 +116,13 @@ public class ShopifyService_Tests
         var json = "{\"errors\":{\"order\":\"foo error message\"}}";
         var code = HttpStatusCode.BadRequest;
         var res = BadResponse(code, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -138,13 +138,13 @@ public class ShopifyService_Tests
         var json = "{\"errors\":{\"order\":[\"foo error message\"]}}";
         var code = HttpStatusCode.BadRequest;
         var res = BadResponse(code, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -160,13 +160,13 @@ public class ShopifyService_Tests
         var json = "{\"errors\":{\"order\":[\"foo error message\",\"bar error message\"]}}";
         var code = HttpStatusCode.BadRequest;
         var res = BadResponse(code, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -183,13 +183,13 @@ public class ShopifyService_Tests
         var json = "{\"error\":\"foo\",\"error_description\":\"bar\"}";
         var code = HttpStatusCode.BadRequest;
         var res = BadResponse(code, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }
@@ -205,13 +205,13 @@ public class ShopifyService_Tests
         var json = "{\"error\":\"location_id must be specified when creating fulfillments.\"}";
         var code = HttpStatusCode.BadRequest;
         var res = BadResponse(code, json);
-        ShopifyException ex = null;
+        ShopifyHttpException ex = null;
 
         try
         {
             ShopifyService.CheckResponseExceptions(string.Empty, res, json);
         }
-        catch (ShopifyException e)
+        catch (ShopifyHttpException e)
         {
             ex = e;
         }

--- a/ShopifySharp.Tests/SmartCollection_Tests.cs
+++ b/ShopifySharp.Tests/SmartCollection_Tests.cs
@@ -233,7 +233,7 @@ public class SmartCollection_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/StorefrontAccessToken_Tests.cs
+++ b/ShopifySharp.Tests/StorefrontAccessToken_Tests.cs
@@ -71,7 +71,7 @@ public class StorefrontAccessToken_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/TestClasses/TestRequestResult.cs
+++ b/ShopifySharp.Tests/TestClasses/TestRequestResult.cs
@@ -5,18 +5,9 @@ using System.Net.Http;
 
 namespace ShopifySharp.Tests.TestClasses;
 
-public class TestRequestResult<T> : RequestResult<T>
-{
-    public TestRequestResult(
-        T result
-    ) : base("",
-        new HttpResponseMessage(HttpStatusCode.OK),
-        new HttpResponseMessage(HttpStatusCode.OK).Headers,
-        result,
-        "",
-        "",
-        HttpStatusCode.OK
-    )
-    {
-    }
-}
+public class TestRequestResult<T>(T result) : RequestResult<T>("",
+    new HttpResponseMessage(HttpStatusCode.OK).Headers,
+    result,
+    "",
+    "",
+    HttpStatusCode.OK);

--- a/ShopifySharp.Tests/TestClasses/TestShopifyException.cs
+++ b/ShopifySharp.Tests/TestClasses/TestShopifyException.cs
@@ -2,7 +2,7 @@
 
 namespace ShopifySharp.Tests.TestClasses;
 
-public class TestShopifyException : ShopifyException
+public class TestShopifyException() : ShopifyException("A test exception")
 {
     public override string ToString()
     {

--- a/ShopifySharp.Tests/Theme_Tests.cs
+++ b/ShopifySharp.Tests/Theme_Tests.cs
@@ -132,7 +132,7 @@ public class Theme_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Transaction_Tests.cs
+++ b/ShopifySharp.Tests/Transaction_Tests.cs
@@ -139,7 +139,7 @@ public class Transaction_Tests_Fixture : IAsyncLifetime
             {
                 await OrderService.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp.Tests/Webhook_Tests.cs
+++ b/ShopifySharp.Tests/Webhook_Tests.cs
@@ -123,7 +123,7 @@ public class Webhook_Tests_Fixture : IAsyncLifetime
             {
                 await Service.DeleteAsync(obj.Id.Value);
             }
-            catch (ShopifyException ex)
+            catch (ShopifyHttpException ex)
             {
                 if (ex.HttpStatusCode != HttpStatusCode.NotFound)
                 {

--- a/ShopifySharp/Entities/FulfillmentServiceEntity.cs
+++ b/ShopifySharp/Entities/FulfillmentServiceEntity.cs
@@ -87,11 +87,4 @@ public class FulfillmentServiceEntity : ShopifyObject
     /// </summary>
     [JsonProperty("service_name")]
     public string ServiceName { get; set; }
-
-    /// <summary>
-    /// Whether the fulfillment service wants to register for APIs related to fulfillment orders.
-    /// </summary>
-    [JsonProperty("fulfillment_orders_opt_in")]
-    [Obsolete("https://shopify.dev/changelog/deprecation-of-the-fulfillmentservice-fulfillmentordersoptin-field")]
-    public bool? FulfillmentOrdersOptIn { get; set; }
 }

--- a/ShopifySharp/Entities/Order.cs
+++ b/ShopifySharp/Entities/Order.cs
@@ -231,13 +231,6 @@ public class Order : ShopifyObject
     public DateTimeOffset? ProcessedAt { get; set; }
 
     /// <summary>
-    /// The type of payment processing method. Known values are 'checkout', 'direct', 'manual', 'offsite', 'express', 'free' and 'none'.
-    /// </summary>
-    [JsonProperty("processing_method")]
-    [Obsolete("Deprecated in version 2023-04. https://shopify.dev/docs/api/release-notes/2023-04#payment-properties-on-the-order-resource-have-been-removed")]
-    public string ProcessingMethod { get; set; }
-
-    /// <summary>
     /// The website that the customer clicked on to come to the shop.
     /// </summary>
     [JsonProperty("referring_site")]

--- a/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
+++ b/ShopifySharp/Infrastructure/CloneableRequestMessage.cs
@@ -16,35 +16,6 @@ public class CloneableRequestMessage: HttpRequestMessage
         }
     }
 
-    [Obsolete("This method has been replaced with " + nameof(CloneAsync) + ", it will be removed in a future version of ShopifySharp.")]
-    public CloneableRequestMessage Clone()
-    {
-        var newContent = Content;
-
-        if (newContent is JsonContent c)
-        {
-            newContent = c.Clone();
-
-            foreach (var header in Content.Headers)
-            {
-                if (!newContent.Headers.Contains(header.Key))
-                {
-                    newContent.Headers.Add(header.Key, header.Value);
-                }
-            }
-        }
-
-        var cloned = new CloneableRequestMessage(RequestUri, Method, newContent);
-
-        // Copy over the request's headers which includes the access token if set
-        foreach (var header in Headers)
-        {
-            cloned.Headers.Add(header.Key, header.Value);
-        }
-
-        return cloned;
-    }
-
     public virtual async Task<CloneableRequestMessage> CloneAsync(CancellationToken cancellationToken = default)
     {
         var newContent = Content is null ? null : await CloneToStreamOrReadOnlyMemoryContent(Content, cancellationToken);

--- a/ShopifySharp/Infrastructure/RequestResult.cs
+++ b/ShopifySharp/Infrastructure/RequestResult.cs
@@ -1,7 +1,5 @@
 #nullable enable
-using System;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace ShopifySharp;
@@ -9,9 +7,6 @@ namespace ShopifySharp;
 public class RequestResult<T>
 {
     public string? RequestInfo { get; }
-
-    [Obsolete("This property is obsolete and will be removed in a future version of ShopifySharp. If you need to use the response headers, please use the " + nameof(ResponseHeaders) + " property instead.")]
-    public HttpResponseMessage Response { get; }
 
     public HttpResponseHeaders ResponseHeaders { get; }
 
@@ -26,20 +21,8 @@ public class RequestResult<T>
     /// </summary>
     public string? RawLinkHeaderValue { get; }
 
-    [Obsolete("This constructor is obsolete and will be removed in a future version of ShopifySharp.")]
-    public RequestResult(HttpResponseMessage response, T result, string rawResult, string rawLinkHeaderValue)
-    {
-        Response = response;
-        ResponseHeaders = response.Headers;
-        Result = result;
-        RawResult = rawResult;
-        RawLinkHeaderValue = rawLinkHeaderValue;
-        StatusCode = response.StatusCode;
-    }
-
     public RequestResult(
         string requestInfo,
-        HttpResponseMessage httpResponseMessage,
         HttpResponseHeaders httpResponseHeaders,
         T result,
         string rawResult,
@@ -47,7 +30,6 @@ public class RequestResult<T>
         HttpStatusCode statusCode)
     {
         RequestInfo = requestInfo;
-        Response = httpResponseMessage;
         ResponseHeaders = httpResponseHeaders;
         Result = result;
         RawResult = rawResult;

--- a/ShopifySharp/Infrastructure/ShopifyException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyException.cs
@@ -1,46 +1,6 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using ShopifySharp.Infrastructure;
 
 namespace ShopifySharp;
 
-public class ShopifyException : Exception
-{
-    /// The Http response status code.
-    [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
-    public HttpStatusCode HttpStatusCode { get; }
-
-    /// The X-Request-Id header returned by Shopify. Can be used when working with the Shopify support team to identify the failed request.
-    [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
-    public string? RequestId { get; }
-
-    /// A list of error messages returned by Shopify.
-    [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
-    public IEnumerable<string> Errors { get; } = Enumerable.Empty<string>();
-
-    /// The raw string body returned by Shopify.
-    [Obsolete("This property has been moved to the " + nameof(ShopifyHttpException) + " and will be removed in a future version of ShopifySharp.")]
-    public string RawBody { get; }
-
-    public ShopifyException() { }
-
-    public ShopifyException(string message, Exception? innerException = null) : base(message, innerException) { }
-
-    public ShopifyException(
-        HttpStatusCode httpStatusCode,
-        IEnumerable<string> errors,
-        string message,
-        string rawBody,
-        string? requestId
-    ) : base(message)
-    {
-        HttpStatusCode = httpStatusCode;
-        Errors = (errors ?? Enumerable.Empty<string>()).ToArray();
-        RawBody = rawBody;
-        RequestId = requestId;
-    }
-}
+public class ShopifyException(string message, Exception? innerException = null) : Exception(message, innerException);

--- a/ShopifySharp/Infrastructure/ShopifyExponentialRetryCanceledException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyExponentialRetryCanceledException.cs
@@ -7,8 +7,9 @@ namespace ShopifySharp;
 [Serializable]
 public class ShopifyExponentialRetryCanceledException(
     int currentTry,
-    ExponentialRetryPolicyOptions options
-) : ShopifyException
+    ExponentialRetryPolicyOptions options,
+    Exception? innerException = null
+) : ShopifyException("Exponential Retry Policy request was canceled.", innerException)
 {
     public int CurrentTry { get; } = currentTry;
     public int BackoffInMilliseconds { get; } = options.InitialBackoffInMilliseconds;

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -12,21 +12,6 @@ public class ShopifyHttpException(
     string? requestId)
     : ShopifyException(message)
 {
-    /// The Http response status code.
-    public new readonly HttpStatusCode HttpStatusCode = statusCode;
-
-    /// A list of error messages returned by Shopify.
-    public new readonly ICollection<string> Errors = errors;
-
-    /// The raw response body returned by Shopify.
-    public new readonly string RawBody = rawResponseBody;
-
-    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
-    public new readonly string? RequestId = requestId;
-
-    /// Extra details about the request, for logging purposes.
-    public readonly string? RequestInfo;
-
     public ShopifyHttpException(
         string requestInfo,
         HttpStatusCode statusCode,
@@ -38,4 +23,19 @@ public class ShopifyHttpException(
     {
         RequestInfo = requestInfo;
     }
+
+    /// The Http response status code.
+    public readonly HttpStatusCode HttpStatusCode = statusCode;
+
+    /// A list of error messages returned by Shopify.
+    public readonly ICollection<string> Errors = errors;
+
+    /// The raw response body returned by Shopify.
+    public readonly string RawBody = rawResponseBody;
+
+    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
+    public readonly string? RequestId = requestId;
+
+    /// Extra details about the request, for logging purposes.
+    public readonly string? RequestInfo;
 }

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -10,7 +10,7 @@ public class ShopifyHttpException(
     string message,
     string rawResponseBody,
     string? requestId)
-    : ShopifyException(statusCode, errors, message, rawResponseBody, requestId)
+    : ShopifyException(message)
 {
     /// The Http response status code.
     public new readonly HttpStatusCode HttpStatusCode = statusCode;

--- a/ShopifySharp/Infrastructure/ShopifyHttpException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyHttpException.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 
-namespace ShopifySharp.Infrastructure;
+namespace ShopifySharp;
 
 public class ShopifyHttpException(
     HttpStatusCode statusCode,

--- a/ShopifySharp/Services/AssignedFulfillmentOrder/AssignedFulfillmentOrderService.cs
+++ b/ShopifySharp/Services/AssignedFulfillmentOrder/AssignedFulfillmentOrderService.cs
@@ -2,7 +2,6 @@ using ShopifySharp.Filters;
 using ShopifySharp.Lists;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading;
 using ShopifySharp.Utilities;
 
 namespace ShopifySharp;

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -220,7 +220,6 @@ public abstract class ShopifyService : IShopifyService
             var result = method == HttpMethod.Delete ? default : Serializer.Deserialize<T>(rawResult, rootElement, dateParseHandlingOverride);
 
             return new RequestResult<T>(await baseRequestMessage.GetRequestInfo(),
-                response,
                 response.Headers,
                 result,
                 rawResult,

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -125,10 +125,6 @@ public abstract class ShopifyService : IShopifyService
         return new RequestUri(ub.Uri);
     }
 
-    [Obsolete("This method is deprecated and has been replaced by BuildAdminRequestUri(string, bool).")]
-    protected RequestUri PrepareRequest(string path) =>
-        BuildRequestUri(path);
-
     /// <summary>
     /// Prepares a request to the path and appends the shop's access token header if applicable.
     /// </summary>

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -67,29 +67,6 @@ public abstract class ShopifyService : IShopifyService
         _ExecutionPolicy = _GlobalExecutionPolicy;
     }
 
-    /// <summary>
-    /// Attempts to build a shop API <see cref="Uri"/> for the given shop.
-    /// </summary>
-    /// <param name="shopDomain">The shop's *.myshopify.com URL.</param>
-    /// <param name="withAdminPath">Whether the <c>/admin</c> path should be included in the resulting URI.</param>
-    [Obsolete("This method is deprecated and will be removed in a future version of ShopifySharp. Please use the ShopifySharp.Utilities.ShopifyDomainUtility instead.")]
-    // TODO: remove this method after 6-8 weeks
-    public static Uri BuildShopUri(string shopDomain, bool withAdminPath)
-    {
-        var domainUtility = new ShopifyDomainUtility();
-        var shopUri = domainUtility.BuildShopDomainUri(shopDomain);
-
-        if (!withAdminPath)
-            return shopUri;
-
-        var uriBuilder = new UriBuilder(shopUri)
-        {
-            Path = "admin"
-        };
-
-        return uriBuilder.Uri;
-    }
-
 #nullable disable
 
     /// <summary>


### PR DESCRIPTION
Note: the GraphQL schema and REST changes were already merged into master before this PR.

This PR contains the following changes:

- Remove obsolete `FulfillmentServiceEntity.FulfillmentOrdersOptIn` property
- Remove obsolete `RequestResult.Response` property
- Remove obsolete `ShopifyException` http properties
- Move `ShopifyHttpException` into ShopifySharp namespace
- Add default exception message for `ShopifyExponentialRetryCanceledException`
- Remove obsolete `Order.ProcessingMethod` property
- Remove obsolete `ShopifyService.PrepareRequest` method
- Remove obsolete `ShopifyService.BuildShopUri` method
- Remove obsolete `CloneableRequestMessage.Clone` method

