### PR TITLE
fix: Update TaxLine to have channelLiable, ratePercentage and source

### DIFF
--- a/ShopifySharp/Entities/TaxLine.cs
+++ b/ShopifySharp/Entities/TaxLine.cs
@@ -8,7 +8,7 @@ public class TaxLine
     /// Whether the channel that submitted the tax line is responsible for remitting it.
     /// </summary>
     [JsonProperty("channelLiable")]
-    public bool ChannelLiable { get; set; }
+    public bool? ChannelLiable { get; set; }
 
     /// <summary>
     /// The amount of tax to be charged.

--- a/ShopifySharp/Entities/TaxLine.cs
+++ b/ShopifySharp/Entities/TaxLine.cs
@@ -5,6 +5,12 @@ namespace ShopifySharp;
 public class TaxLine
 {
     /// <summary>
+    /// Whether the channel that submitted the tax line is responsible for remitting it.
+    /// </summary>
+    [JsonProperty("channelLiable")]
+    public bool ChannelLiable { get; set; }
+
+    /// <summary>
     /// The amount of tax to be charged.
     /// </summary>
     [JsonProperty("price")]
@@ -15,6 +21,18 @@ public class TaxLine
     /// </summary>
     [JsonProperty("rate")]
     public decimal? Rate { get; set; }
+
+    /// <summary>
+    /// The proportion of the line item price represented by the tax, expressed as a percentage.
+    /// </summary>
+    [JsonProperty("ratePercentage")]
+    public decimal? RatePercentage { get; set; }
+
+    /// <summary>
+    /// The origin of the tax.
+    /// </summary>
+    [JsonProperty("source")]
+    public string Source { get; set; }
 
     /// <summary>
     /// The name of the tax.


### PR DESCRIPTION
Fixes TaxLine to contain properties from Shopify API: https://shopify.dev/docs/api/customer/2024-07/objects/TaxLine