### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="dotenvfile" Version="2.1.0" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
-    <PackageVersion Include="fsharp.core" Version="9.0.100" />
+    <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="microsoft.extensions.dependencyinjection" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="dotenvfile" Version="2.1.0" />
+    <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="fsharp.core" Version="8.0.400" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,20 +7,23 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="dotenvfile" Version="2.1.0" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="fsharp.core" Version="8.0.400" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageVersion Include="microsoft.extensions.dependencyinjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="fsharp.core" Version="9.0.100" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageVersion Include="microsoft.extensions.dependencyinjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="newtonsoft.json" Version="13.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/ShopifySharp.Experimental.Tests/ShopifySharp.Experimental.Tests.fsproj
+++ b/ShopifySharp.Experimental.Tests/ShopifySharp.Experimental.Tests.fsproj
@@ -5,6 +5,7 @@
 
         <IsPackable>false</IsPackable>
         <GenerateProgramFile>false</GenerateProgramFile>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />

--- a/ShopifySharp.Experimental/ShopifySharp.Experimental.fsproj
+++ b/ShopifySharp.Experimental/ShopifySharp.Experimental.fsproj
@@ -4,6 +4,7 @@
     <AssemblyName>ShopifySharp.Experimental</AssemblyName>
     <RootNamespace>ShopifySharp.Experimental</RootNamespace>
     <VersionPrefix>5.14.2</VersionPrefix>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Description>A package containing enhancements, experiments and extensions which have not yet (or may never) make it into the ShopifySharp package. This experimental package does not promise to be stable or adhere to SemVer, it may break between builds. Use at your own risk!</Description>
@@ -33,5 +34,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShopifySharp\ShopifySharp.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 </Project>

--- a/ShopifySharp.Extensions.DependencyInjection/ShopifySharp.Extensions.DependencyInjection.csproj
+++ b/ShopifySharp.Extensions.DependencyInjection/ShopifySharp.Extensions.DependencyInjection.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
     <VersionPrefix>1.7.0</VersionPrefix>

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotenvfile" />
+    <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="fsharp.core" />
     <PackageReference Include="JetBrains.Annotations" />

--- a/ShopifySharp.Tests/ShopifySharp.Tests.csproj
+++ b/ShopifySharp.Tests/ShopifySharp.Tests.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="dotenvfile" />
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="fsharp.core" />
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/ShopifySharp.sln
+++ b/ShopifySharp.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		readme.md = readme.md
 		docs\contribution-guide.md = docs\contribution-guide.md
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ShopifySharp.Experimental", "ShopifySharp.Experimental\ShopifySharp.Experimental.fsproj", "{DE7BB881-2191-489D-B9AA-F5F910EF55D8}"

--- a/ShopifySharp/ShopifySharp.csproj
+++ b/ShopifySharp/ShopifySharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>ShopifySharp</AssemblyName>
     <RootNamespace>ShopifySharp</RootNamespace>
     <VersionPrefix>6.22.0</VersionPrefix>

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -101,17 +101,17 @@ Once you've got the env file configured, you'll be ready to run the tests. Most 
 If you've got a ton of time on your hands, you could run all tests at once with the following command:
 
 ```sh
-dotnet test --framework net6.0 ShopifySharp.Tests
+dotnet test --framework net8.0 ShopifySharp.Tests
 ```
 
-That command will run all of the tests in the solution using the `net6.0` (.NET 6) framework. It can take upwards of 15 minutes to run the entire suite, and it's likely that things will break due to rate limits. ShopifySharp's automated tests actually run each test category one at a time, rather than the entire suite all at once. 
+That command will run all of the tests in the solution using the `net8.0` (.NET 8) framework. It can take upwards of 15 minutes to run the entire suite, and it's likely that things will break due to rate limits. ShopifySharp's automated tests actually run each test category one at a time, rather than the entire suite all at once. 
 
 ### Running tests for specific categories/services
 
 Every test file in the _ShopifySharp.Tests_ folder has its own category. For example, tests for the order service use the `Order` category. We use xUnit as our test runner, which means you can run all the tests in just one category using this command:
 
 ```sh
-dotnet test --framework net6.0 --filter "Category=Order"
+dotnet test --framework net8.0 --filter "Category=Order"
 ```
 
 It's generally recommended that you run one single test category for whatever you're testing, rather than running the entire ShopifySharp suite of tests all at once.


### PR DESCRIPTION
This pull request updates the dependencies for ShopifySharp and ShopifySharp.Extensions.DependencyInjection, along with the various test projects. It also removes .NET 6.0 as a target, introduces .NET 8.0 as a target, and adds the FakeItEasy and XUnit.Combinatorial packages to the test projects.