### PR TITLE
Add `IHttpContentSerializer` and `GraphContentSerializer`

### DIFF
--- a/ShopifySharp.Tests/Infrastructure/Serialization/Http/GraphHttpContentSerializerTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/Serialization/Http/GraphHttpContentSerializerTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Infrastructure;
+using ShopifySharp.Services.Graph;
+using Xunit;
+
+namespace ShopifySharp.Tests.Infrastructure.Serialization.Http;
+
+[Trait("Category", "Serialization"), TestSubject(typeof(GraphHttpContentSerializer))]
+public class GraphHttpContentSerializerTests
+{
+    private const string Query = "some-query";
+    private readonly RequestUri _requestUri = new (new Uri("https://example.com"));
+
+    private readonly GraphHttpContentSerializer _sut = new(Serializer.SerializerDefaults);
+
+    [Fact]
+    public async Task SerializeGraphRequest_ShouldSerializeDataToJson()
+    {
+        // Setup
+        var variables = new Dictionary<string, object>
+        {
+            { "baz", "bat" },
+            { "hello", "world" },
+        };
+
+        // Act
+        var result = _sut.SerializeGraphRequest(_requestUri, new GraphRequest
+        {
+            Query = Query,
+            Variables = variables,
+        });
+        var jsonStr = await result.ReadAsStringAsync();
+
+        // Assert
+        jsonStr.Should().Be($$$"""{"query":"{{{Query}}}","variables":{"baz":"bat","hello":"world"}}""");
+    }
+
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void SerializeGraphRequest_WhenExecutingInEnvironmentThatSupportsSystemMemory_ShouldReturnReadOnlyMemoryContent()
+    {
+        // Setup
+        var variables = new Dictionary<string, object>
+        {
+            { "baz", "bat" },
+            { "hello", "world" },
+        };
+
+        // Act
+        var result = _sut.SerializeGraphRequest(_requestUri, new GraphRequest
+        {
+            Query = Query,
+            Variables = variables,
+        });
+
+        // Assert
+        result.Should().BeOfType<ReadOnlyMemoryContent>();
+        result.Headers.ContentType?.MediaType.Should().Be("application/json");
+    }
+#else
+    [Fact]
+    public void SerializeGraphRequest_WhenExecutingInEnvironmentThatDoesNotSupportSystemMemory_ShouldReturnStringContent()
+    {
+        // Setup
+        var variables = new Dictionary<string, object>
+        {
+            { "baz", "bat" },
+            { "hello", "world" },
+        };
+
+        // Act
+        var result = _sut.SerializeGraphRequest(_requestUri, new GraphRequest
+        {
+            Query = Query,
+            Variables = variables,
+        });
+
+        // Assert
+        result.Should().BeOfType<StringContent>();
+        result.Headers.ContentType.MediaType.Should().Be("application/json");
+    }
+#endif
+
+    #region Serializer.SerializerDefaults
+
+    [Fact]
+    public async Task WhenSerializingGraphRequest_ShouldOnlySerializeTheQueryAndVariablesPropertiesAndIgnoreAllOtherProperties()
+    {
+        // Setup
+        var variables = new Dictionary<string, object>
+        {
+            { "baz", "bat" },
+            { "hello", null },
+            { "world", 1 }
+        };
+        const string expectedJson =
+            $$$"""
+              {"query":"{{{Query}}}","variables":{"baz":"bat","hello":null,"world":1}}
+              """;
+
+        // Act
+        var result = _sut.SerializeGraphRequest(_requestUri, new GraphRequest
+        {
+            Query = Query,
+            Variables = variables,
+            EstimatedQueryCost = 123,
+            UserErrorHandling = GraphRequestUserErrorHandling.DoNotThrow
+        });
+        var jsonStr = await result.ReadAsStringAsync();
+
+        // Assert
+        jsonStr.Should().Be(expectedJson);
+    }
+
+    #endregion
+}

--- a/ShopifySharp/Infrastructure/Serialization/Http/GraphHttpContentSerializer.cs
+++ b/ShopifySharp/Infrastructure/Serialization/Http/GraphHttpContentSerializer.cs
@@ -1,0 +1,38 @@
+#if NETSTANDARD2_0
+using System.Text;
+#else
+using System.Buffers;
+using System.Net.Http.Headers;
+#endif
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+
+namespace ShopifySharp.Infrastructure.Serialization.Http;
+
+public class GraphHttpContentSerializer(JsonSerializerOptions jsonSerializerOptions) : IHttpContentSerializer
+{
+    public HttpContent SerializeGraphRequest(RequestUri requestUri, GraphRequest graphRequest)
+    {
+        var jsonData = new Dictionary<string, object>
+        {
+            { "query", graphRequest.Query },
+            { "variables", graphRequest.Variables },
+        };
+
+#if NET6_0_OR_GREATER
+        var bufferWriter = new ArrayBufferWriter<byte>();
+        using var utf8JsonWriter = new Utf8JsonWriter(bufferWriter);
+
+        JsonSerializer.Serialize(utf8JsonWriter, jsonData, jsonSerializerOptions);
+
+        var content = new ReadOnlyMemoryContent(bufferWriter.WrittenMemory);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+#else
+        var jsonStr = JsonSerializer.Serialize(jsonData, jsonSerializerOptions);
+        const string mediaType = "application/json";
+        var content = new StringContent(jsonStr, Encoding.UTF8, mediaType);
+#endif
+        return content;
+    }
+}

--- a/ShopifySharp/Infrastructure/Serialization/Http/IHttpContentSerializer.cs
+++ b/ShopifySharp/Infrastructure/Serialization/Http/IHttpContentSerializer.cs
@@ -1,0 +1,8 @@
+using System.Net.Http;
+
+namespace ShopifySharp.Infrastructure.Serialization.Http;
+
+public interface IHttpContentSerializer
+{
+    public HttpContent SerializeGraphRequest(RequestUri requestUri, GraphRequest graphRequest);
+}


### PR DESCRIPTION
This adds an `IHttpContentSerializer` interface along with a `GraphContentSerializer` class which implements the interface. These content serializers are responsible for serializing a ShopifySharp's `RequestUri` and `GraphRequest` to `HttpContent`. This will help add some extra mockability to the service classes, in addition to finer-grained control over what exactly is being serialized and sent to Shopify.