### PR TITLE
Fix PartnerServiceFactory initialization

### DIFF
--- a/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/ShopifySharp.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -117,7 +117,7 @@ public static class ServiceCollectionExtensions
                 : new ServiceDescriptor(serviceType, type, lifetime));
         }
 
-        services.TryAdd(new ServiceDescriptor(typeof(IPartnerServiceFactory), typeof(PartnerServiceFactory), lifetime));
+        services.TryAdd(new ServiceDescriptor(typeof(IPartnerServiceFactory), (sp) => new PartnerServiceFactory(sp), lifetime));
 
         return services;
     }


### PR DESCRIPTION
This pull request fixes a bug introduced in #1051 that affected the ShopifySharp.Extensions.DependencyInjection package. The bug broke the PartnerServiceFactory's initialization via `serviceCollection.AddShopifySharpServiceFactories<T>` and `serviceCollection.AddShopifySharp<T>()` due to ambiguous constructors.

This bug was only published to Nuget in prerelease versions of the DI package, so no production version of ShopifySharp.Extensions.DependencyInjection were affected.