### PR TITLE
GraphService documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,7 @@
 #
 # Merging from the command prompt will add diff markers to the files if there
 # are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
+# the diff markers are never inserted). Diff markers may cause the following
 # file extensions to fail to load in VS. An alternative would be to treat
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
@@ -46,9 +46,9 @@
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 #*.doc   diff=astextplain
@@ -61,3 +61,9 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# Special handling for Verify's verified.* files
+# https://github.com/VerifyTests/Verify#text-file-settings
+*.verified.txt text eol=lf working-tree-encoding=UTF-8
+*.verified.xml text eol=lf working-tree-encoding=UTF-8
+*.verified.json text eol=lf working-tree-encoding=UTF-8

--- a/.github/scripts/test.fish
+++ b/.github/scripts/test.fish
@@ -4,12 +4,15 @@ echo "Using $(fish --version)"
 
 set experimentalTestProject "ShopifySharp.Experimental.Tests/ShopifySharp.Experimental.Tests.fsproj"
 set diTestProject "ShopifySharp.Extensions.DependencyInjection.Tests/ShopifySharp.Extensions.DependencyInjection.Tests.csproj"
+set integrationTestProject "ShopifySharp.Tests.Integration/ShopifySharp.Tests.Integration.csproj"
+
+set netNine "net9.0"
 
 # Load utility functions
 set utilsFilePath (dirname (status --current-filename))"/utils.fish"
 source "$utilsFilePath"
 
-# Build and run the the tests for the experimental and DI projects all at once
+# Build and run the the tests for the experimental, DI and integration projects all at once
 echo "Testing experimental project."
 buildProject "$experimentalTestProject"; or exit 1;
 executeTests \
@@ -25,6 +28,14 @@ executeTests \
     "$netCoreApp" \
     "$diTestProject"
 success "DI tests succeeded."
+
+echo "Testing integration project."
+buildProject "$integrationTestProject"; or exit 1;
+executeTests \
+    "ShopifySharp.Integration.Tests" \
+    "$netNine" \
+    "$integrationTestProject"
+success "Integration tests succeeded."
 
 # Build the test project once, then let all individual test runs skip build.
 echo "Building test project."

--- a/.gitignore
+++ b/.gitignore
@@ -214,14 +214,18 @@ ModelManifest.xml
 # Ignore private configuration files
 *.private.config
 */env.yml
+appsettings.local.json
 
 # Ignore IDE settings
 .ionide
 .idea
 .vim
- 
+
 # Ignore signing keys
 *.snk
 
 # Ignore nvim mergetool files
 *.orig
+
+# Ignore Verify's received.* files
+*.received.*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,34 +1,36 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="dotenvfile" Version="2.1.0" />
-    <PackageVersion Include="FakeItEasy" Version="8.3.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
-    <PackageVersion Include="FSharp.Core" Version="9.0.100" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageVersion Include="microsoft.extensions.dependencyinjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="newtonsoft.json" Version="13.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Wish.GraphQLSchemaGenerator" Version="1.7.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+        <PackageVersion Include="dotenvfile" Version="2.1.0"/>
+        <PackageVersion Include="FakeItEasy" Version="8.3.0"/>
+        <PackageVersion Include="FluentAssertions" Version="7.0.0"/>
+        <PackageVersion Include="FSharp.Core" Version="9.0.100"/>
+        <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0"/>
+        <PackageVersion Include="microsoft.extensions.dependencyinjection" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
+        <PackageVersion Include="newtonsoft.json" Version="13.0.3"/>
+        <PackageVersion Include="NSubstitute" Version="5.3.0"/>
+        <PackageVersion Include="System.Text.Json" Version="9.0.0"/>
+        <PackageVersion Include="Verify.Xunit" Version="28.7.0"/>
+        <PackageVersion Include="xunit" Version="2.9.2"/>
+        <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageVersion Include="Wish.GraphQLSchemaGenerator" Version="1.7.0"/>
+    </ItemGroup>
 </Project>

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/CreateProductResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/CreateProductResponse.cs
@@ -1,0 +1,4 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record CreateProductResponse(CreatedProductContainer Result, GraphUserError[]? UserErrors = null)
+    : MutationResponse<CreatedProductContainer>(Result, UserErrors);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/CreatedProduct.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/CreatedProduct.cs
@@ -1,0 +1,15 @@
+using ShopifySharp.GraphQL;
+
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record CreatedProduct(
+    string Description,
+    string Id,
+    bool HasOnlyDefaultVariant,
+    string Title,
+    ProductStatus Status,
+    ProductOption[] Options,
+    VariantsCount VariantsCount,
+    NodeCollection<CreatedVariant> Variants,
+    string Vendor
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/CreatedProductContainer.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/CreatedProductContainer.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record CreatedProductContainer(CreatedProduct Product);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/CreatedVariant.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/CreatedVariant.cs
@@ -1,0 +1,8 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record CreatedVariant(
+    string Id,
+    string DisplayName,
+    string Title,
+    SelectedOption[] SelectedOptions
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/DeleteProductOptionsResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/DeleteProductOptionsResponse.cs
@@ -1,0 +1,4 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record DeleteProductOptionsResponse(DeletedProductOptionsContainer Result, GraphUserError[]? UserErrors = null)
+    : MutationResponse<DeletedProductOptionsContainer>(Result, UserErrors);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/DeletedProductOptionsContainer.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/DeletedProductOptionsContainer.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record DeletedProductOptionsContainer(DeletedProductOptionsProduct Product);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/DeletedProductOptionsProduct.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/DeletedProductOptionsProduct.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record DeletedProductOptionsProduct(
+    string Id,
+    ProductOption[] Options
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/GetProductsQueryResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/GetProductsQueryResponse.cs
@@ -1,0 +1,5 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record GetProductsQueryResponse(
+    Products Products
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/GraphUserError.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/GraphUserError.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record GraphUserError(string Message);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/MutationResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/MutationResponse.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record MutationResponse<T>(
+    T Result,
+    GraphUserError[]? UserErrors = null
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/NodeCollection.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/NodeCollection.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record NodeCollection<T>(ICollection<T> Nodes);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/OptionCreateInput.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/OptionCreateInput.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record OptionCreateInput(
+    string Name,
+    OptionValueCreateInput[]? Values
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/OptionValueCreateInput.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/OptionValueCreateInput.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record OptionValueCreateInput(string Name);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ProductContainer.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ProductContainer.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ProductContainer(GraphQL.Product Product);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ProductOption.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ProductOption.cs
@@ -1,0 +1,8 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ProductOption(
+    string Name,
+    string Id,
+    string[] Values,
+    ProductOptionValue[] OptionValues
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ProductOptionValue.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ProductOptionValue.cs
@@ -1,0 +1,7 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ProductOptionValue(
+    string Id,
+    string Name,
+    bool HasVariants
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ProductStatusUpdateContainer.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ProductStatusUpdateContainer.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ProductStatusUpdateContainer(ProductWithStatus Product);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ProductWithStatus.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ProductWithStatus.cs
@@ -1,0 +1,9 @@
+using ShopifySharp.GraphQL;
+
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ProductWithStatus(
+    string Id,
+    string Title,
+    ProductStatus Status
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/Products.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/Products.cs
@@ -1,0 +1,8 @@
+using ShopifySharp.GraphQL;
+
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record Products(
+    GraphQL.Product[] Nodes,
+    PageInfo PageInfo
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/PublicationsQuery.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/PublicationsQuery.cs
@@ -1,0 +1,4 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record PublicationsQuery(NodeCollection<ShopifySharpPublication> Result)
+    : QueryResponse<NodeCollection<ShopifySharpPublication>>(Result);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/PublishableContainer.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/PublishableContainer.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record PublishableContainer(PublishableProduct Product);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/PublishableProduct.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/PublishableProduct.cs
@@ -1,0 +1,10 @@
+using ShopifySharp.GraphQL;
+
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record PublishableProduct(
+    string Id,
+    string Title,
+    ProductStatus Status,
+    bool PublishedOnPublication
+) : ProductWithStatus(Id, Title, Status);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/PublishedProductResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/PublishedProductResponse.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record PublishedProductResponse(
+    ProductStatusUpdateContainer ProductStatusUpdateResult,
+    PublishableContainer PublicationResult
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/QueryResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/QueryResponse.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record QueryResponse<T>(T Result);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/SelectedOption.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/SelectedOption.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record SelectedOption(
+    string Name,
+    string Value
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ShopifySharpCompanyLocation.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ShopifySharpCompanyLocation.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ShopifySharpCompanyLocation(string Id);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/ShopifySharpPublication.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/ShopifySharpPublication.cs
@@ -1,0 +1,6 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record ShopifySharpPublication(
+    string Id,
+    bool SupportsFuturePublishing
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/UpdateProductOptionsResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/UpdateProductOptionsResponse.cs
@@ -1,0 +1,4 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record UpdateProductOptionsResponse(UpdatedProductOptionsContainer Result, GraphUserError[]? UserErrors = null)
+    : MutationResponse<UpdatedProductOptionsContainer>(Result, UserErrors);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/UpdateProductResponse.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/UpdateProductResponse.cs
@@ -1,0 +1,4 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record UpdateProductResponse(ProductContainer Result, GraphUserError[]? UserErrors = null)
+    : MutationResponse<ProductContainer>(Result, UserErrors);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/UpdatedProductOptionsContainer.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/UpdatedProductOptionsContainer.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record UpdatedProductOptionsContainer(UpdatedProductOptionsProduct Product);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/UpdatedProductOptionsProduct.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/UpdatedProductOptionsProduct.cs
@@ -1,0 +1,10 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record UpdatedProductOptionsProduct(
+    string Id,
+    string Title,
+    ProductOption[] Options,
+    VariantsCount VariantsCount,
+    bool HasOnlyDefaultVariant,
+    NodeCollection<UpdatedProductOptionsVariant> Variants
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/UpdatedProductOptionsVariant.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/UpdatedProductOptionsVariant.cs
@@ -1,0 +1,7 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record UpdatedProductOptionsVariant(
+    string Id,
+    string DisplayName,
+    SelectedOption[] SelectedOptions
+);

--- a/ShopifySharp.Tests.Integration/Features/Products/Models/VariantsCount.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/Models/VariantsCount.cs
@@ -1,0 +1,3 @@
+namespace ShopifySharp.Tests.Integration.Features.Products.Models;
+
+public record VariantsCount(int Count);

--- a/ShopifySharp.Tests.Integration/Features/Products/ProductQueryTests.cs
+++ b/ShopifySharp.Tests.Integration/Features/Products/ProductQueryTests.cs
@@ -1,0 +1,691 @@
+using ShopifySharp.Services.Graph;
+using ShopifySharp.GraphQL;
+using ShopifySharp.Tests.Integration.Features.Products.Models;
+
+namespace ShopifySharp.Tests.Integration.Features.Products;
+
+[Collection("Product Queries")]
+public class ProductQueryTests(VerifyFixture verifyFixture, GraphServiceFixture graphServiceFixture)
+    : IClassFixture<VerifyFixture>, IClassFixture<GraphServiceFixture>
+{
+    private readonly VerifySettings _verifySettings = verifyFixture.Settings;
+    private readonly IGraphService _sut = graphServiceFixture.Service;
+
+    [Fact]
+    public async Task ProductsQuery_ShouldListProducts()
+    {
+        // Setup
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                query getProducts($first: Int) {
+                    products(first: $first) {
+                        pageInfo {
+                            startCursor
+                            endCursor
+                            hasNextPage
+                            hasPreviousPage
+                        }
+                        nodes {
+                            id
+                            title
+                            handle
+                            description(truncateAt: 60)
+                            legacyResourceId
+                            publishedAt
+                            status
+                            variants(first: 3) {
+                                pageInfo {
+                                    startCursor
+                                    endCursor
+                                    hasNextPage
+                                    hasPreviousPage
+                                }
+                                nodes {
+                                    id
+                                    availableForSale
+                                    displayName
+                                    sku
+                                    inventoryQuantity
+                                    legacyResourceId
+                                    selectedOptions {
+                                        name
+                                        value
+                                        details: optionValue {
+                                            id
+                                        }
+                                    }
+                                    image {
+                                        id
+                                        altText
+                                        url
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "first", 3 }
+            },
+            UserErrorHandling = GraphRequestUserErrorHandling.Throw
+        };
+
+        // Act
+        var products = await _sut.PostAsync<GetProductsQueryResponse>(request);
+
+        // Assert
+        await Verify(products.Data.Products, _verifySettings);
+    }
+
+    [Fact]
+    public async Task ProductsMutation_ShouldCreateNewProduct()
+    {
+        // Setup
+        const string expectedTitle = "some-expected-title";
+        const string expectedDescriptionHtml = "some-expected-description-html";
+        const string expectedVendor = "some-expected-vendor";
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation createProduct($title: String!, $descriptionHtml: String!, $vendor: String!) {
+                    result: productCreate(product: {
+                        title: $title
+                        status: DRAFT
+                        descriptionHtml: $descriptionHtml
+                        vendor: $vendor
+                    }) {
+                        product {
+                            description
+                            hasOnlyDefaultVariant
+                            id
+                            options {
+                                name
+                                id
+                                values
+                                optionValues {
+                                    id
+                                    name
+                                }
+                            }
+                            status
+                            title
+                            variantsCount {
+                                count
+                            }
+                            vendor
+                            variants(first: 10) {
+                                nodes {
+                                    id
+                                    displayName
+                                    title
+                                    selectedOptions {
+                                        name
+                                        value
+                                    }
+                                }
+                            }
+                        }
+                        userErrors {
+                            field
+                            message
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "title", expectedTitle },
+                { "descriptionHtml", expectedDescriptionHtml },
+                { "vendor", expectedVendor }
+            },
+            UserErrorHandling = GraphRequestUserErrorHandling.Throw
+        };
+
+        // Act
+        var result = await _sut.PostAsync<CreateProductResponse>(request);
+
+        // Assert
+        result.Data.Result.Product.Should().NotBeNull();
+
+        var product = result.Data.Result.Product;
+        await Verify(product, _verifySettings);
+    }
+
+    [Fact]
+    public async Task ProductsMutation_WhenTheMutationDoesNotIncludeTheProductId_ShouldThrow()
+    {
+        // Setup
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation updateProductTitle {
+                    result: productUpdate(product: {title: "some-new-title"}) {
+                        userErrors {
+                            # The id field doesn't exist here, which should cause Shopify to return an error with the request itself
+                            id
+                            message
+                            field
+                        }
+                        product {
+                            id
+                            legacyResourceId
+                            title
+                        }
+                    }
+                }
+                """
+        };
+
+        // Act
+        var act = async () => await _sut.PostAsync<UpdateProductResponse>(request);
+
+        // Assert
+        var exn = await act.Should().ThrowExactlyAsync<ShopifyGraphErrorsException>();
+        exn.WithMessage("undefinedField: Field 'id' doesn't exist on type 'UserError'");
+        exn.And.RequestId.Should().NotBeNullOrEmpty();
+
+        await Verify(exn.Which.GraphErrors, _verifySettings);
+    }
+
+    [Fact]
+    public async Task ProductsMutation_ShouldUpdateTheProductTitle()
+    {
+        // Setup
+        const string expectedNewTitle = "some-expected-new-title";
+        var product = await CreateProductAsync("some-title");
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation updateProductTitle($productId: ID!, $newTitle: String!) {
+                    result: productUpdate(product: {id: $productId, title: $newTitle}) {
+                        product {
+                            id
+                            title
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "productId", product.Id },
+                { "newTitle", expectedNewTitle }
+            }
+        };
+
+        // Act
+        var result = await _sut.PostAsync<UpdateProductResponse>(request);
+
+        // Assert
+        result.Data.Result.Product.title.Should().Be(expectedNewTitle);
+        result.Data.Result.Product.id.Should().Be(product.Id);
+
+        await Verify(result.Data.Result.Product, _verifySettings);
+    }
+
+    [Fact]
+    public async Task ProductsMutation_ShouldAddANewProductOption()
+    {
+        // Setup
+        const string expectedOptionName = "some-expected-option-name";
+        const string expectedOptionValue1 = "some-expected-option-value1";
+        const string expectedOptionValue2 = "some-expected-option-value2";
+        var product = await CreateProductAsync("some-title");
+        OptionCreateInput[] newOptions =
+        [
+            new(expectedOptionName, [
+                new OptionValueCreateInput(expectedOptionValue1),
+                new OptionValueCreateInput(expectedOptionValue2)
+            ])
+        ];
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation updateProductOptions($productId: ID!, $newOptions: [OptionCreateInput!]!) {
+                    result: productOptionsCreate(productId: $productId, options: $newOptions, variantStrategy: CREATE) {
+                        userErrors {
+                            message
+                            field
+                            code
+                        }
+                        product {
+                            id
+                            title
+                            options {
+                                name
+                                id
+                                values
+                                optionValues {
+                                    id
+                                    name
+                                    hasVariants
+                                }
+                            }
+                            variantsCount {
+                                count
+                            }
+                            hasOnlyDefaultVariant
+                            variants(first: 10) {
+                                nodes {
+                                    id
+                                    displayName
+                                    selectedOptions {
+                                        name
+                                        value
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "productId", product.Id },
+                { "newOptions", newOptions }
+            }
+        };
+
+        // Act
+        var result = await _sut.PostAsync<UpdateProductOptionsResponse>(request);
+        var updatedProduct = result.Data.Result.Product;
+        var updatedVariants = updatedProduct.Variants.Nodes;
+
+        // Assert
+        updatedProduct.Id.Should().Be(product.Id);
+        updatedProduct.VariantsCount.Count.Should().BeGreaterThan(product.VariantsCount.Count);
+        updatedProduct.Options
+            .Should().HaveCount(1)
+            .And.AllSatisfy(option =>
+            {
+                option.Name.Should().Be(expectedOptionName);
+                option.Values.Should().Contain([expectedOptionValue1, expectedOptionValue2]);
+            });
+        updatedVariants.Should().HaveCount(2)
+            .And.AllSatisfy(variant =>
+            {
+                variant.SelectedOptions
+                    .Should().HaveCount(1)
+                    .And.AllSatisfy(option =>
+                    {
+                        option.Name.Should().Be(expectedOptionName);
+                        option.Value.Should().BeOneOf(expectedOptionValue1, expectedOptionValue2);
+                    });
+            });
+
+        await Verify(result.Data.Result.Product, _verifySettings);
+    }
+
+    [Fact]
+    public async Task ProductsMutation_ShouldRemoveAProductOptionAndDeleteTheVariant()
+    {
+        // Setup
+        const string expectedOptionName1 = "some-expected-option-name1";
+        const string expectedOptionName2 = "some-expected-option-name2";
+        const string expectedOptionValue1 = "some-expected-option-value1";
+        const string expectedOptionValue2 = "some-expected-option-value2";
+        const string expectedOptionValue3 = "some-expected-option-value3";
+        const string expectedOptionValue4 = "some-expected-option-value4";
+        var product = await CreateProductAsync("some-title", [
+            new OptionCreateInput(expectedOptionName1, [
+                new OptionValueCreateInput(expectedOptionValue1),
+                new OptionValueCreateInput(expectedOptionValue2)
+            ]),
+            new OptionCreateInput(expectedOptionName2, [
+                new OptionValueCreateInput(expectedOptionValue3),
+                new OptionValueCreateInput(expectedOptionValue4)
+            ])
+        ]);
+        // Select just Option 1 for deletion
+        var optionIds = product.Options
+            .Where(option => option.Name == expectedOptionName1)
+            .Select(option => option.Id)
+            .ToArray();
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation deleteProductOptions($productId: ID!, $optionIds: [ID!]!) {
+                    result: productOptionsDelete(productId: $productId, options: $optionIds, strategy: POSITION) {
+                        userErrors {
+                            message
+                            field
+                            code
+                        }
+                        product {
+                            id
+                            title
+                            options {
+                                name
+                                id
+                                optionValues {
+                                    id
+                                    name
+                                    hasVariants                
+                                }
+                                values
+                            }
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "productId", product.Id },
+                { "optionIds", optionIds }
+            }
+        };
+
+        // Act
+        var result = await _sut.PostAsync<DeleteProductOptionsResponse>(request);
+        var updatedProduct = result.Data.Result.Product;
+
+        // Assert
+        await Verify(result.Data, _verifySettings);
+
+        updatedProduct.Id.Should().Be(product.Id);
+        updatedProduct.Options
+            .Should().HaveCount(1)
+            .And.AllSatisfy(option =>
+            {
+                option.Name.Should().Be(expectedOptionName2);
+                option.OptionValues.Select(value => value.Name).Should()
+                    .BeEquivalentTo(expectedOptionValue3, expectedOptionValue4);
+            });
+        // Assert that the original product had variant options
+        product.Options
+            .Should().HaveCount(2)
+            .And.AllSatisfy(option =>
+            {
+                option.Name.Should().BeOneOf(expectedOptionName1, expectedOptionName2);
+                option.OptionValues.Select(value => value.Name).Should().BeSubsetOf([
+                    expectedOptionValue1, expectedOptionValue2, expectedOptionValue3, expectedOptionValue4
+                ]);
+            });
+    }
+
+    [Fact]
+    public async Task ProductsMutation_ShouldPublishTheProductToTheStorefront()
+    {
+        // Setup
+        var product = await CreateProductAsync("some-title", status: ProductStatus.DRAFT);
+        var publicationId = await CreateOrGetShopifySharpPublicationAsync();
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation publishProduct($productId: ID!, $publicationId: ID!, $publishDate: DateTime!) {
+                    productStatusUpdateResult: productUpdate(product: {id: $productId, status: ACTIVE}) {
+                        userErrors {
+                            message 
+                            field
+                        }
+                        product {
+                          id
+                          title
+                          status
+                        }
+                    }
+                    publicationResult: publishablePublish(id: $productId, input: { publicationId: $publicationId, publishDate: $publishDate }) {
+                        userErrors {
+                            message 
+                            field
+                        }
+                        product: publishable {
+                            # Warning: do not use anything that refers to CurrentPublication/CurrentChannel – private apps do not have a publication or channel.
+                            #publishedOnCurrentPublication
+                            #publishedOnCurrentChannel
+                            publishedOnPublication(publicationId: $publicationId)
+                            ...on Product { 
+                              id
+                              title
+                              status
+                            }
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "productId", product.Id },
+                { "publishDate", DateTimeOffset.Now },
+                { "publicationId", publicationId }
+            }
+        };
+
+        // Assert
+        var result = await _sut.PostAsync<PublishedProductResponse>(request);
+        var statusUpdateResult = result.Data.ProductStatusUpdateResult.Product;
+        var publicationResult = result.Data.PublicationResult.Product;
+
+        // Act
+        await Verify(result.Data, _verifySettings);
+
+        product.Status.Should().Be(ProductStatus.DRAFT);
+
+        statusUpdateResult.Id.Should().Be(product.Id);
+        statusUpdateResult.Title.Should().Be(product.Title);
+        statusUpdateResult.Status.Should().Be(ProductStatus.ACTIVE);
+
+        publicationResult.PublishedOnPublication.Should().BeTrue();
+        publicationResult.Id.Should().Be(product.Id);
+        publicationResult.Title.Should().Be(product.Title);
+        publicationResult.Status.Should().Be(ProductStatus.ACTIVE);
+    }
+
+    [Fact]
+    public async Task ProductsMutation_ShouldUnpublishTheProductFromTheStorefront()
+    {
+        // Setup
+        var product = await CreateProductAsync("some-title", status: ProductStatus.ACTIVE);
+        var publicationId = await CreateOrGetShopifySharpPublicationAsync();
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation unpublishProduct($productId: ID!, $publicationId: ID!) {
+                    productStatusUpdateResult: productUpdate(product: {id: $productId, status: DRAFT}) {
+                        userErrors {
+                            message 
+                            field
+                        }
+                        product {
+                          id
+                          title
+                          status
+                        }
+                    }
+                    publicationResult: publishableUnpublish(id: $productId, input: { publicationId: $publicationId }) {
+                        userErrors {
+                            message 
+                            field
+                        }
+                        product: publishable {
+                            # Warning: do not use anything that refers to CurrentPublication/CurrentChannel – private apps do not have a publication or channel.
+                            #publishedOnCurrentPublication
+                            #publishedOnCurrentChannel
+                            publishedOnPublication(publicationId: $publicationId)
+                            ...on Product { 
+                              id
+                              title
+                              status
+                            }
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "productId", product.Id },
+                { "publicationId", publicationId }
+            }
+        };
+
+        // Assert
+        var result = await _sut.PostAsync<PublishedProductResponse>(request);
+        var statusUpdateResult = result.Data.ProductStatusUpdateResult.Product;
+        var publicationResult = result.Data.PublicationResult.Product;
+
+        // Act
+        await Verify(result.Data, _verifySettings);
+
+        product.Status.Should().Be(ProductStatus.ACTIVE);
+
+        statusUpdateResult.Id.Should().Be(product.Id);
+        statusUpdateResult.Title.Should().Be(product.Title);
+        statusUpdateResult.Status.Should().Be(ProductStatus.DRAFT);
+
+        publicationResult.PublishedOnPublication.Should().BeFalse();
+        publicationResult.Id.Should().Be(product.Id);
+        publicationResult.Title.Should().Be(product.Title);
+        publicationResult.Status.Should().Be(ProductStatus.DRAFT);
+    }
+
+    private async Task<string> CreateOrGetShopifySharpPublicationAsync()
+    {
+        var publicationDetails = await GetShopifySharpPublicationDetailsAsync();
+        if (publicationDetails is not null)
+            return publicationDetails.Id;
+
+        // Create the publication
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation createShopifySharpPublication {
+                  result: publicationCreate (input: { autoPublish: false }) { 
+                    userErrors { 
+                      field
+                      message
+                    }
+                    publication { 
+                      id
+                    }
+                  }
+                }
+                """
+        };
+        var result = await _sut.PostAsync<MutationResponse<PublicationCreatePayload>>(request);
+        return result.Data.Result.publication?.id!;
+    }
+
+    // private async Task<string> CreateShopifySharpCatalogAsync()
+    // {
+    //     // Create the catalog
+    //     var request = new GraphRequest
+    //     {
+    //         Query =
+    //             """
+    //             mutation createShopifySharpCatalog {
+    //                 result: catalogCreate(input: {title: "ShopifySharp Test Catalog", status: DRAFT, context: { companyLocationIds: [] }}) {
+    //                     userErrors {
+    //                         field
+    //                         message
+    //                         code
+    //                     }
+    //                     catalog {
+    //                         id
+    //                         __typename
+    //                     }
+    //                 }
+    //             }
+    //             """,
+    //     };
+    //     var createCatalogResult = await _sut.PostAsync<MutationResponse<CatalogCreatePayload>>(request);
+    //     var catalogId = createCatalogResult.Data.Result.catalog?.id!;
+    //     return catalogId;
+    // }
+
+    private async Task<ShopifySharpPublication?> GetShopifySharpPublicationDetailsAsync()
+    {
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                query {
+                    result: publications(first: 10) {
+                        nodes {
+                            id
+                            supportsFuturePublishing
+                        }
+                    }
+                }
+                """
+        };
+        var result = await _sut.PostAsync<PublicationsQuery>(request);
+        return result.Data.Result.Nodes.FirstOrDefault(publication => publication.SupportsFuturePublishing);
+    }
+
+    private async Task<CreatedProduct> CreateProductAsync(string title, OptionCreateInput[]? productOptions = null,
+        ProductStatus status = ProductStatus.DRAFT)
+    {
+        var request = new GraphRequest
+        {
+            Query =
+                """
+                mutation createProduct($title: String!, $productOptions: [OptionCreateInput!], $status: ProductStatus) {
+                    result: productCreate(product: {
+                        title: $title
+                        status: $status
+                        descriptionHtml: "some-description-html"
+                        vendor: "shopifysharp",
+                        productOptions: $productOptions
+                    }) {
+                        product {
+                            description
+                            hasOnlyDefaultVariant
+                            id
+                            options {
+                                name
+                                id
+                                optionValues {
+                                    id
+                                    name
+                                    hasVariants
+                                }
+                                values
+                            }
+                            status
+                            title
+                            variantsCount {
+                                count
+                            }
+                            vendor
+                            variants(first: 10) {
+                                nodes {
+                                    id
+                                    displayName
+                                    title
+                                    selectedOptions {
+                                        name
+                                        value
+                                    }
+                                }
+                            }
+                        }
+                        userErrors {
+                            field
+                            message
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                { "title", title },
+                { "productOptions", productOptions! },
+                { "status", status }
+            },
+            UserErrorHandling = GraphRequestUserErrorHandling.Throw
+        };
+        var result = await _sut.PostAsync<CreateProductResponse>(request);
+        return result.Data.Result.Product;
+    }
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldAddANewProductOption.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldAddANewProductOption.verified.txt
@@ -1,0 +1,54 @@
+﻿{
+  Id: {Scrubbed},
+  Title: some-title,
+  Options: [
+    {
+      Name: some-expected-option-name,
+      Id: {Scrubbed},
+      Values: [
+        some-expected-option-value1,
+        some-expected-option-value2
+      ],
+      OptionValues: [
+        {
+          Id: {Scrubbed},
+          Name: some-expected-option-value1,
+          HasVariants: true
+        },
+        {
+          Id: {Scrubbed},
+          Name: some-expected-option-value2,
+          HasVariants: true
+        }
+      ]
+    }
+  ],
+  VariantsCount: {
+    Count: 2
+  },
+  HasOnlyDefaultVariant: false,
+  Variants: {
+    Nodes: [
+      {
+        Id: {Scrubbed},
+        DisplayName: some-title - some-expected-option-value1,
+        SelectedOptions: [
+          {
+            Name: some-expected-option-name,
+            Value: some-expected-option-value1
+          }
+        ]
+      },
+      {
+        Id: {Scrubbed},
+        DisplayName: some-title - some-expected-option-value2,
+        SelectedOptions: [
+          {
+            Name: some-expected-option-name,
+            Value: some-expected-option-value2
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldCreateNewProduct.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldCreateNewProduct.verified.txt
@@ -1,0 +1,35 @@
+﻿{
+  Description: some-expected-description-html,
+  Id: {Scrubbed},
+  HasOnlyDefaultVariant: true,
+  Title: some-expected-title,
+  Status: DRAFT,
+  Options: [
+    {
+      Name: Title,
+      Id: {Scrubbed},
+      Values: [
+        Default Title
+      ]
+    }
+  ],
+  VariantsCount: {
+    Count: 1
+  },
+  Variants: {
+    Nodes: [
+      {
+        Id: {Scrubbed},
+        DisplayName: some-expected-title - Default Title,
+        Title: Default Title,
+        SelectedOptions: [
+          {
+            Name: Title,
+            Value: Default Title
+          }
+        ]
+      }
+    ]
+  },
+  Vendor: some-expected-vendor
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldPublishTheProductToTheStorefront.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldPublishTheProductToTheStorefront.verified.txt
@@ -1,0 +1,15 @@
+﻿{
+  ProductStatusUpdateResult: {
+    Product: {
+      Id: {Scrubbed},
+      Title: some-title
+    }
+  },
+  PublicationResult: {
+    Product: {
+      PublishedOnPublication: true,
+      Id: {Scrubbed},
+      Title: some-title
+    }
+  }
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldRemoveAProductOptionAndDeleteTheVariant.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldRemoveAProductOptionAndDeleteTheVariant.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  Result: {
+    Product: {
+      Id: {Scrubbed},
+      Options: [
+        {
+          Name: some-expected-option-name2,
+          Id: {Scrubbed},
+          Values: [
+            some-expected-option-value3
+          ],
+          OptionValues: [
+            {
+              Id: {Scrubbed},
+              Name: some-expected-option-value3,
+              HasVariants: true
+            },
+            {
+              Id: {Scrubbed},
+              Name: some-expected-option-value4,
+              HasVariants: false
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldUnpublishTheProductFromTheStorefront.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldUnpublishTheProductFromTheStorefront.verified.txt
@@ -1,0 +1,17 @@
+﻿{
+  ProductStatusUpdateResult: {
+    Product: {
+      Id: {Scrubbed},
+      Title: some-title,
+      Status: DRAFT
+    }
+  },
+  PublicationResult: {
+    Product: {
+      PublishedOnPublication: false,
+      Id: {Scrubbed},
+      Title: some-title,
+      Status: DRAFT
+    }
+  }
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldUpdateTheProductTitle.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_ShouldUpdateTheProductTitle.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  id: {Scrubbed},
+  legacyResourceId: {Scrubbed},
+  title: some-expected-new-title
+}

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_WhenTheMutationDoesNotIncludeTheProductId_ShouldThrow.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsMutation_WhenTheMutationDoesNotIncludeTheProductId_ShouldThrow.verified.txt
@@ -1,0 +1,15 @@
+﻿[
+  {
+    Message: Field 'id' doesn't exist on type 'UserError',
+    Path: [
+      mutation updateProductTitle,
+      result,
+      userErrors,
+      id
+    ],
+    Extensions: {
+      Code: undefinedField,
+      TypeName: UserError
+    }
+  }
+]

--- a/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsQuery_ShouldListProducts.verified.txt
+++ b/ShopifySharp.Tests.Integration/Features/Products/Snapshots/ProductQueryTests.ProductsQuery_ShouldListProducts.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  Nodes: [
+    {
+      description: NOTE:Â Sizes XL-4XL are running one to two sizes small, d...,
+      handle: jackson-3,
+      id: {Scrubbed},
+      legacyResourceId: {Scrubbed},
+      status: ACTIVE,
+      title: Jackson,
+      variants: {
+        nodes: [
+          {
+            availableForSale: false,
+            displayName: Jackson - XS / Dark Wash / $57,
+            id: {Scrubbed},
+            inventoryQuantity: 0,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: XS
+              },
+              {
+                name: Color,
+                value: Dark Wash
+              },
+              {
+                name: Suggested Retail,
+                value: $57
+              }
+            ],
+            sku: 159-246-01-1131
+          }
+        ],
+        pageInfo: {
+          endCursor: {Scrubbed},
+          hasNextPage: {Scrubbed},
+          hasPreviousPage: {Scrubbed},
+          startCursor: {Scrubbed}
+        }
+      }
+    },
+    {
+      description: NOTE:Â Sizes XL-4XL are running one to two sizes small, d...,
+      handle: jackson-2,
+      id: {Scrubbed},
+      legacyResourceId: {Scrubbed},
+      status: ACTIVE,
+      title: Jackson,
+      variants: {
+        nodes: [
+          {
+            availableForSale: false,
+            displayName: Jackson - XS / Light Wash / $57,
+            id: {Scrubbed},
+            inventoryQuantity: 0,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: XS
+              },
+              {
+                name: Color,
+                value: Light Wash
+              },
+              {
+                name: Suggested Retail,
+                value: $57
+              }
+            ],
+            sku: 159-247-01-1131
+          },
+          {
+            availableForSale: false,
+            displayName: Jackson - S / Light Wash / $57,
+            id: {Scrubbed},
+            inventoryQuantity: 0,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: S
+              },
+              {
+                name: Color,
+                value: Light Wash
+              },
+              {
+                name: Suggested Retail,
+                value: $57
+              }
+            ],
+            sku: 159-247-02-1131
+          },
+          {
+            availableForSale: false,
+            displayName: Jackson - M / Light Wash / $57,
+            id: {Scrubbed},
+            inventoryQuantity: 0,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: M
+              },
+              {
+                name: Color,
+                value: Light Wash
+              },
+              {
+                name: Suggested Retail,
+                value: $57
+              }
+            ],
+            sku: 159-247-03-1131
+          }
+        ],
+        pageInfo: {
+          endCursor: {Scrubbed},
+          hasNextPage: {Scrubbed},
+          hasPreviousPage: {Scrubbed},
+          startCursor: {Scrubbed}
+        }
+      }
+    },
+    {
+      description: NOTE: Sizes XL-4XL are running one to two sizes small, de...,
+      handle: jackson,
+      id: {Scrubbed},
+      legacyResourceId: {Scrubbed},
+      status: ACTIVE,
+      title: Jackson,
+      variants: {
+        nodes: [
+          {
+            availableForSale: true,
+            displayName: Jackson - XS / White,
+            id: {Scrubbed},
+            inventoryQuantity: 3,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: XS
+              },
+              {
+                name: Color,
+                value: White
+              }
+            ],
+            sku: 159-001-01-1131
+          },
+          {
+            availableForSale: false,
+            displayName: Jackson - S / White,
+            id: {Scrubbed},
+            inventoryQuantity: 0,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: S
+              },
+              {
+                name: Color,
+                value: White
+              }
+            ],
+            sku: 159-001-02-1131
+          },
+          {
+            availableForSale: false,
+            displayName: Jackson - M / White,
+            id: {Scrubbed},
+            inventoryQuantity: 0,
+            legacyResourceId: {Scrubbed},
+            selectedOptions: [
+              {
+                name: Size,
+                value: M
+              },
+              {
+                name: Color,
+                value: White
+              }
+            ],
+            sku: 159-001-03-1131
+          }
+        ],
+        pageInfo: {
+          endCursor: {Scrubbed},
+          hasNextPage: {Scrubbed},
+          hasPreviousPage: {Scrubbed},
+          startCursor: {Scrubbed}
+        }
+      }
+    }
+  ],
+  PageInfo: {
+    endCursor: {Scrubbed},
+    hasNextPage: {Scrubbed},
+    hasPreviousPage: {Scrubbed},
+    startCursor: {Scrubbed}
+  }
+}

--- a/ShopifySharp.Tests.Integration/GlobalUsings.cs
+++ b/ShopifySharp.Tests.Integration/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Xunit;
+global using FluentAssertions;
+global using ShopifySharp.Credentials;
+global using System.Collections.Generic;

--- a/ShopifySharp.Tests.Integration/GraphServiceFixture.cs
+++ b/ShopifySharp.Tests.Integration/GraphServiceFixture.cs
@@ -1,0 +1,44 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ShopifySharp.Extensions.DependencyInjection;
+using ShopifySharp.Factories;
+
+namespace ShopifySharp.Tests.Integration;
+
+[UsedImplicitly]
+public class GraphServiceFixture
+{
+    public readonly IGraphService Service;
+
+    public GraphServiceFixture()
+    {
+        var builder = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.local.json", false)
+            .Build();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddShopifySharp<LeakyBucketExecutionPolicy>();
+
+        IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true
+        });
+
+        var credentials = builder.GetRequiredSection("ShopifySharp")
+            .GetRequiredSection("Credentials")
+            .Get<Credentials>() ?? throw new ArgumentNullException();
+        var factory = serviceProvider.GetRequiredService<IGraphServiceFactory>();
+
+        Service = factory.Create(new ShopifyApiCredentials(credentials.ShopDomain, credentials.AccessToken));
+    }
+
+    private record Credentials
+    {
+        public required string ShopDomain { get; init; }
+
+        public required string AccessToken { get; init; }
+
+        public required string ApiKey { get; init; }
+    }
+}

--- a/ShopifySharp.Tests.Integration/ShopifySharp.Tests.Integration.csproj
+++ b/ShopifySharp.Tests.Integration/ShopifySharp.Tests.Integration.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="FakeItEasy"/>
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="JetBrains.Annotations"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Verify.Xunit"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="Xunit.Combinatorial"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ShopifySharp.Extensions.DependencyInjection\ShopifySharp.Extensions.DependencyInjection.csproj"/>
+        <ProjectReference Include="..\ShopifySharp\ShopifySharp.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Remove="appsettings.local.json"/>
+        <Content Include="appsettings.local.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="Features\Products\Snapshots\"/>
+    </ItemGroup>
+
+</Project>

--- a/ShopifySharp.Tests.Integration/VerifyCheckTests.cs
+++ b/ShopifySharp.Tests.Integration/VerifyCheckTests.cs
@@ -1,0 +1,11 @@
+namespace ShopifySharp.Tests.Integration;
+
+[Collection("Verify Check")]
+public class VerifyCheckTests
+{
+    [Fact]
+    public void Run()
+    {
+        VerifyChecks.Run();
+    }
+}

--- a/ShopifySharp.Tests.Integration/VerifyFixture.cs
+++ b/ShopifySharp.Tests.Integration/VerifyFixture.cs
@@ -1,0 +1,15 @@
+namespace ShopifySharp.Tests.Integration;
+
+public class VerifyFixture
+{
+    public readonly VerifySettings Settings = new();
+
+    public VerifyFixture()
+    {
+        Settings.ScrubMembers(info => info.Name is "LegacyResourceId" or "legacyResourceId");
+        Settings.ScrubMembers(info => info.Name is "Id" or "id");
+        Settings.ScrubMembers(info => info.Name is "RequestId" or "requestId");
+        Settings.ScrubMembers(info => info.DeclaringType?.Name is "PageInfo" or "pageInfo");
+        Settings.UseDirectory("Snapshots");
+    }
+}

--- a/ShopifySharp.Tests.Integration/appsettings.template.json
+++ b/ShopifySharp.Tests.Integration/appsettings.template.json
@@ -1,0 +1,9 @@
+{
+  "Instructions": "Add your app's credentials below, then rename this file to appsettings.local.json to run the tests in this project. If you're using a custom app to test ShopifySharp, use the app's password as the access token.",
+  "ShopifySharp": {
+    "Credentials": {
+      "ShopDomain": "example.myshopify.com",
+      "AccessToken": "example-access-token"
+    }
+  }
+}

--- a/ShopifySharp.sln
+++ b/ShopifySharp.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		readme.md = readme.md
 		docs\contribution-guide.md = docs\contribution-guide.md
 		Directory.Packages.props = Directory.Packages.props
+		graphql.config.yml = graphql.config.yml
+		graphql.schema.json = graphql.schema.json
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ShopifySharp.Experimental", "ShopifySharp.Experimental\ShopifySharp.Experimental.fsproj", "{DE7BB881-2191-489D-B9AA-F5F910EF55D8}"

--- a/ShopifySharp.sln
+++ b/ShopifySharp.sln
@@ -41,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{1D5F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShopifySharp.Extensions.DependencyInjection.Tests", "ShopifySharp.Extensions.DependencyInjection.Tests\ShopifySharp.Extensions.DependencyInjection.Tests.csproj", "{08A8C056-E0E6-4685-BE40-134C6647A01A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShopifySharp.Tests.Integration", "ShopifySharp.Tests.Integration\ShopifySharp.Tests.Integration.csproj", "{C549D1FC-C4F4-4974-BFD9-02677B669325}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,10 @@ Global
 		{08A8C056-E0E6-4685-BE40-134C6647A01A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08A8C056-E0E6-4685-BE40-134C6647A01A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08A8C056-E0E6-4685-BE40-134C6647A01A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C549D1FC-C4F4-4974-BFD9-02677B669325}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C549D1FC-C4F4-4974-BFD9-02677B669325}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C549D1FC-C4F4-4974-BFD9-02677B669325}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C549D1FC-C4F4-4974-BFD9-02677B669325}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ShopifySharp/Services/Graph/GraphRequest.cs
+++ b/ShopifySharp/Services/Graph/GraphRequest.cs
@@ -28,6 +28,9 @@ public class GraphRequest
         set => _variables = value as IDictionary<string, object> ?? value?.ToDictionary();
     }
 
+    #if NET8_0_OR_GREATER
+    [StringSyntax("graphql")]
+    #endif
     public string Query
     {
         get => _query ?? "";

--- a/ShopifySharp/Services/Graph/GraphResult.cs
+++ b/ShopifySharp/Services/Graph/GraphResult.cs
@@ -15,6 +15,7 @@ public class GraphResult<T>
     public T Data { get; set; } = default!;
     #endif
 
+    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
     public string? RequestId { get; set; }
 }
 
@@ -28,6 +29,7 @@ public class GraphResult : IDisposable
     public IJsonElement Json { get; set; } = null!;
     #endif
 
+    /// The X-Request-Id header returned by Shopify. This can be used when working with the Shopify support team to identify the failed request.
     public string? RequestId { get; set; }
 
     public void Dispose()

--- a/graphql.config.yml
+++ b/graphql.config.yml
@@ -1,0 +1,2 @@
+schema: graphql.schema.json
+documents: '**/*.graphql'

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,11 @@
 [![Build status](https://github.com/nozzlegear/ShopifySharp/actions/workflows/build-and-test.yml/badge.svg?branch=master)](https://github.com/nozzlegear/ShopifySharp/actions/workflows/build-and-test.yml)
 [![license](https://img.shields.io/github/license/nozzlegear/shopifysharp.svg?maxAge=3600)](https://github.com/nozzlegear/shopifysharp/blob/master/LICENSE)
 
-ShopifySharp is a .NET library that enables you to authenticate and make API calls to Shopify. It's great for building custom Shopify Apps using C# and .NET. You can quickly and easily get up and running with Shopify using this library.
+ShopifySharp is a .NET library that helps developers build custom Shopify apps using C#, .NET and GraphQL. It also handles the tricky parts of authentication and validation for you, so you can quickly get up and running with Shopify using this library.
+
+### Migrating to GraphQL using ShopifySharp's GraphService
+
+Already using ShopifySharp and wondering how to migrate from Shopify's REST API to their GraphQL API? [Head over to the wiki page](https://github.com/nozzlegear/shopifysharp/wiki/graphql) where we've got a dedicated page using ShopifySharp's GraphService to send queries and mutations to Shopify.
 
 # The Shopify Development Handbook
 
@@ -14,8 +18,9 @@ Building an app or integration for the Shopify store is hard work. There are a t
 
 You're going to be asking yourself all of these questions when you try to build an app for the Shopify store:
 
+-   What on earth is GraphQL and how do I use it with .NET?
 -   How can I charge my users when they use my app?
--   What in the world is an embedded app?
+-   What is an embedded app?
 -   How should I be using Shopify's redirect URLs?
 -   When should I be using a proxy page?
 -   Am I dealing with webhooks the right way?
@@ -65,7 +70,7 @@ Check the [package's documentation](./ShopifySharp.Extensions.DependencyInjectio
 
 # A work-in-progress
 
-I first started working on ShopifySharp because .NET developers need a fully-featured library for interacting with Shopify and building Shopify apps, which didn't exist several years ago. My goal is to eventually reach 100% compatibility with the Shopify REST API, but, with that said, Shopify is constantly adding new APIs and altering old ones. I try my best to keep up with them, but I tend to prioritize the support of new APIs by how much I need them in my own Shopify apps.
+I first started working on ShopifySharp because .NET developers need a fully-featured library for interacting with Shopify and building Shopify apps, which didn't exist several years ago. My goal is to eventually reach 100% compatibility with the Shopify API, but, with that said, Shopify is constantly adding new APIs and altering old ones. I try my best to keep up with them, but I tend to prioritize the support of new APIs by how much I need them in my own Shopify apps.
 
 # Documentation
 


### PR DESCRIPTION
This pull request adds documentation for using ShopifySharp's recently-updated GraphService. 

TODO:

- [x] Document how to enable intellisense in Rider, VS Code and Visual Studio using the editor config and schema files in this PR.
- [x] Document how to create a product using the GraphService.
- [x] Document how to update a product.
- [x] Document how to add new product options to an existing product.
- [x] Document how to remove product options from an existing product.
- [x] Document how to list all existing products on the store.
- [x] Document how to search for a product by name, sku or vendor.
- [x] Update readme noting that devs creating new apps must use the GraphService.
  - Also note that devs with existing apps already published on the app store can still use the REST services, but should begin their migration to the GraphService if they haven't already.
- [x] Update readme with notes for future plans to improve the GraphService and working with the Graph API (Fluent API, generated clients via second ShopifySharp package or CLI tool).

This PR also includes a new test project called `ShopifySharp.Tests.Integration`, which is intended for any test that makes live calls to Shopify's API. Eventually I want to move all integration tests over to this new project, and keep all non-integration tests (i.e. unit tests) in their current projects.