### PR TITLE
Exception handling updates for GraphService

### DIFF
--- a/ShopifySharp.Tests/Infrastructure/Serialization/Json/SystemJsonSerializerTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/Serialization/Json/SystemJsonSerializerTests.cs
@@ -218,7 +218,6 @@ public class SystemJsonSerializerTests
         // Assert
         act.Should()
             .Throw<ArgumentException>()
-            .WithMessage($"Expected a {nameof(SystemJsonElement)} but got *. (Parameter 'element')")
             .And
             .ParamName
             .Should()
@@ -305,7 +304,6 @@ public class SystemJsonSerializerTests
         // Assert
         act.Should()
             .Throw<ArgumentException>()
-            .WithMessage($"Expected a {nameof(SystemJsonElement)} but got *. (Parameter 'element')")
             .And
             .ParamName
             .Should()
@@ -378,8 +376,7 @@ public class SystemJsonSerializerTests
 
         // Assert
         var exn = await act.Should()
-            .ThrowAsync<ArgumentException>()
-            .WithMessage($"Expected a {nameof(SystemJsonElement)} but got *. (Parameter 'element')");
+            .ThrowAsync<ArgumentException>();
         exn.And.ParamName.Should().Be("element");
     }
 
@@ -458,8 +455,7 @@ public class SystemJsonSerializerTests
 
         // Assert
         var exn = await act.Should()
-            .ThrowAsync<ArgumentException>()
-            .WithMessage($"Expected a {nameof(SystemJsonElement)} but got *. (Parameter 'element')");
+            .ThrowAsync<ArgumentException>();
         exn.And.ParamName.Should().Be("element");
     }
 

--- a/ShopifySharp.Tests/Infrastructure/ShopifyGraphErrorsExceptionTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/ShopifyGraphErrorsExceptionTests.cs
@@ -1,0 +1,168 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Services.Graph;
+using Xunit;
+
+namespace ShopifySharp.Tests.Infrastructure;
+
+[Trait("Category", "Infrastructure"), TestSubject(typeof(ShopifyGraphErrorsException))]
+public class ShopifyGraphErrorsExceptionTests
+{
+    private const string GenericExceptionMessage = "GraphQL operation returned one or more errors.";
+
+    private static IReadOnlyList<GraphError> CreateErrors(Action<GraphError, GraphErrorExtensions>? customize = null)
+    {
+        var list = new List<GraphError>();
+        var userError = new GraphError
+        {
+            Message = "some-message",
+            Extensions = new GraphErrorExtensions
+            {
+                Code = "some-code",
+            }
+        };
+        customize?.Invoke(userError, userError.Extensions);
+        list.Add(userError);
+
+        return list;
+    }
+
+    [Fact]
+    public void WhenErrorsListIsEmpty_ItShouldUseAGenericExceptionMessage()
+    {
+        // Setup
+        const string expectedRequestId = "some-request-id";
+
+        // Act
+        var exn = new ShopifyGraphErrorsException([], expectedRequestId);
+
+        // Assert
+        exn.Message.Should().Be(GenericExceptionMessage);
+        exn.RequestId.Should().Be(expectedRequestId);
+    }
+
+    [Fact]
+    public void WhenErrorsListIsNotEmpty_ItShouldCreateAnExceptionMessageFromTheFirstErrorCodeAndMessage()
+    {
+        // Setup
+        const string expectedRequestId = "some-request-id";
+        const string expectedCode = "some-expected-code";
+        const string expectedMessage = "some-expected-message";
+        var userErrors = CreateErrors((err, ex) =>
+        {
+            err.Message = expectedMessage;
+            ex.Code = expectedCode;
+        });
+
+        // Act
+        var exn = new ShopifyGraphErrorsException(userErrors, expectedRequestId);
+
+        // Assert
+        exn.Message.Should().Be($"{expectedCode}: {expectedMessage}");
+        exn.RequestId.Should().Be(expectedRequestId);
+        exn.GraphErrors.Should().HaveCount(1).And.AllSatisfy(x =>
+        {
+            x.Message.Should().Be(expectedMessage);
+            x.Extensions.Should().BeEquivalentTo(new GraphErrorExtensions
+            {
+                Code = expectedCode
+            });
+        });
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void WhenErrorsListIsNotEmpty_AndTheFirstErrorHasAnEmptyMessage_AndTheFirstErrorHasANonEmptyCode_ItShouldCreateAnExceptionMessageFromTheFirstCode(
+        [CombinatorialValues(null, "")] string? expectedMessageValue
+    )
+    {
+        // Setup
+        const string expectedRequestId = "some-request-id";
+        const string expectedCode = "some-expected-code";
+        var userErrors = CreateErrors((err, ex) =>
+        {
+            err.Message = expectedMessageValue!;
+            ex.Code = expectedCode;
+        });
+
+        // Act
+        var exn = new ShopifyGraphErrorsException(userErrors, expectedRequestId);
+
+        // Assert
+        exn.Message.Should().Be($"{expectedCode}: ");
+        exn.RequestId.Should().Be(expectedRequestId);
+        exn.GraphErrors.Should().HaveCount(1).And.AllSatisfy(x =>
+        {
+            x.Message.Should().Be(expectedMessageValue);
+            x.Extensions.Should().BeEquivalentTo(new GraphErrorExtensions
+            {
+                Code = expectedCode
+            });
+        });
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void WhenErrorsListIsNotEmpty_AndTheFirstErrorHasANonEmptyMessage_AndTheFirstErrorHasAnEmptyCode_ItShouldCreateAnExceptionMessageFromTheFirstMessage(
+        [CombinatorialValues(null, "")] string? expectedCodeValue
+    )
+    {
+        // Setup
+        const string expectedRequestId = "some-request-id";
+        const string expectedMessage = "some-expected-message";
+        var userErrors = CreateErrors((err, ex) =>
+        {
+            err.Message = expectedMessage;
+            ex.Code = expectedCodeValue!;
+        });
+
+        // Act
+        var exn = new ShopifyGraphErrorsException(userErrors, expectedRequestId);
+
+        // Assert
+        exn.Message.Should().Be(expectedMessage, "the exception should use the first error's message value as the exception message");
+        exn.RequestId.Should().Be(expectedRequestId);
+        exn.GraphErrors.Should().HaveCount(1).And.AllSatisfy(x =>
+        {
+            x.Message.Should().Be(expectedMessage);
+            x.Extensions.Should().BeEquivalentTo(new GraphErrorExtensions
+            {
+                Code = expectedCodeValue!
+            });
+        });
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void WhenErrorsListIsNotEmpty_AndTheFirstErrorHasAnEmptyMessage_AndTheFirstErrorHasAnEmptyCode_ItShouldUseAGenericExceptionMessage(
+        [CombinatorialValues(null, "")] string? expectedMessageValue,
+        [CombinatorialValues(null, "")] string? expectedCodeValue
+    )
+    {
+        // Setup
+        const string expectedRequestId = "some-request-id";
+        var userErrors = CreateErrors((err, ex) =>
+        {
+            err.Message = expectedMessageValue!;
+            ex.Code = expectedCodeValue!;
+        });
+
+        // Act
+        var exn = new ShopifyGraphErrorsException(userErrors, expectedRequestId);
+
+        // Assert
+        exn.Message.Should().Be(GenericExceptionMessage);
+        exn.RequestId.Should().Be(expectedRequestId);
+        exn.GraphErrors.Should().HaveCount(1).And.AllSatisfy(x =>
+        {
+            x.Message.Should().Be(expectedMessageValue);
+            x.Extensions.Should().BeEquivalentTo(new GraphErrorExtensions
+            {
+                Code = expectedCodeValue!
+            });
+        });
+    }
+}

--- a/ShopifySharp.Tests/Infrastructure/ShopifyGraphUserErrorsExceptionTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/ShopifyGraphUserErrorsExceptionTests.cs
@@ -11,9 +11,9 @@ namespace ShopifySharp.Tests.Infrastructure;
 [Trait("Category", "Infrastructure"), TestSubject(typeof(ShopifyGraphUserErrorsException))]
 public class ShopifyGraphUserErrorsExceptionTests
 {
-    private const string GenericExceptionMessage = "GraphQL operation returned one or more errors.";
+    private const string GenericExceptionMessage = "GraphQL operation returned one or more user errors.";
 
-    private static ICollection<GraphUserError> CreateErrors(Action<GraphUserError>? customize = null)
+    private static IReadOnlyList<GraphUserError> CreateErrors(Action<GraphUserError>? customize = null)
     {
         var list = new List<GraphUserError>();
         var userError = new GraphUserError

--- a/ShopifySharp.Tests/Services/Graph/GraphService.ErrorHandlingTests.cs
+++ b/ShopifySharp.Tests/Services/Graph/GraphService.ErrorHandlingTests.cs
@@ -13,7 +13,7 @@ namespace ShopifySharp.Tests.Services.Graph;
 public class GraphServiceErrorHandlingTests
 {
     private const string UserErrorsPropertyName = "userErrors";
-    private static string _userErrorsPropertyPath = $"$.{UserErrorsPropertyName}";
+    private const string UserErrorsPropertyPath = $"$.{UserErrorsPropertyName}";
 
     private readonly IRequestExecutionPolicy _policy = A.Fake<IRequestExecutionPolicy>(x => x.Strict());
 
@@ -245,7 +245,7 @@ public class GraphServiceErrorHandlingTests
             var exn = await act.Should()
                 .ThrowAsync<ShopifyJsonParseException>();
 
-            exn.Which.JsonPropertyName.Should().Be(_userErrorsPropertyPath);
+            exn.Which.JsonPropertyName.Should().Be(UserErrorsPropertyPath);
         }
         else
         {

--- a/ShopifySharp.Tests/Services/Graph/GraphService.PostAsyncTests.cs
+++ b/ShopifySharp.Tests/Services/Graph/GraphService.PostAsyncTests.cs
@@ -244,7 +244,7 @@ public class GraphServicePostAsyncTests
         // Assert
         await act.Should()
             .ThrowAsync<ShopifyJsonParseException>()
-            .WithMessage("Failed to parse Shopify's response into a JSON document, please check the inner exception.")
+            .WithMessage("Failed to parse Shopify's response into a JSON document. Check the inner exception for more details.")
             .Where(x => x.RequestId == expectedRequestId)
             .WithInnerException(typeof(JsonException));
     }
@@ -582,7 +582,7 @@ public class GraphServicePostAsyncTests
         // Assert
         await act.Should()
             .ThrowAsync<ShopifyJsonParseException>()
-            .WithMessage("Failed to parse Shopify's response into a JSON document, please check the inner exception.")
+            .WithMessage("Failed to parse Shopify's response into a JSON document. Check the inner exception for more details.")
             .Where(x => x.RequestId == expectedRequestId)
             .WithInnerException(typeof(JsonException));
     }

--- a/ShopifySharp/Infrastructure/ShopifyGraphErrorsException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyGraphErrorsException.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using ShopifySharp.Services.Graph;
+
+namespace ShopifySharp;
+
+/// <summary>
+/// <p>
+/// An exception thrown when the response to a mutation or query contains additional details about the request itself
+/// for the developer to fix or debug. This occurs primarily due to issues with the mutation/query that must be fixed
+/// by the developer, including issues such as missing parameters, missing variables, or invalid types.
+/// </p>
+/// <p>
+/// This exception is distinct from the <see cref="ShopifyGraphUserErrorsException"/>, which is thrown when the response
+/// to a mutation contains additional details for the user to fix or debug.
+/// </p>
+/// </summary>
+[Serializable]
+public class ShopifyGraphErrorsException(
+    IReadOnlyList<GraphError> graphErrors,
+    string? requestId,
+    // GraphRequestCostExtension? requestCost = null,
+    Exception? innerException = null)
+    : ShopifyException(FormatMessage(graphErrors), innerException)
+{
+    public IReadOnlyList<GraphError> GraphErrors { get; } = graphErrors;
+
+    public string? RequestId { get; } = requestId;
+
+    // TODO: add support for parsing request cost and passing to exception
+    // public GraphRequestCostExtension? GraphCost { get; } = graphCost;
+
+    private static string FormatMessage(IReadOnlyList<GraphError> graphErrors)
+    {
+        var firstError = graphErrors.Count == 0 ? null : graphErrors[0];
+
+        if (firstError?.Extensions is { Code: not null and not "" } ext)
+            return $"{ext.Code}: {firstError.Message}";
+
+        return string.IsNullOrWhiteSpace(firstError?.Message)
+            ? "GraphQL operation returned one or more errors."
+            : firstError.Message;
+    }
+}

--- a/ShopifySharp/Infrastructure/ShopifyGraphUserErrorsException.cs
+++ b/ShopifySharp/Infrastructure/ShopifyGraphUserErrorsException.cs
@@ -1,36 +1,46 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ShopifySharp.Services.Graph;
 
 namespace ShopifySharp;
 
+/// <summary>
+/// <p>
+/// An exception thrown when the response to a mutation contains additional details for the user to fix or debug. There
+/// are numerous reasons this can occur, such as insufficient API permissions; attempting to do something that isn't
+/// possible (e.g. canceling an order that doesn't exist); missing or invalid parameters (e.g. creating a product
+/// without supplying the title); and so on.
+/// </p>
+/// <p>
+/// This exception is distinct from the <see cref="ShopifyGraphErrorsException"/>, which is thrown when the response
+/// to a mutation/query contains additional details about a request for the developer to fix or debug.
+/// </p>
+/// </summary>
 [Serializable]
 public class ShopifyGraphUserErrorsException(
-    ICollection<GraphUserError> graphUserErrors,
-    string? requestId = null,
+    IReadOnlyList<GraphUserError> graphUserErrors,
+    string? requestId,
     // GraphRequestCostExtension? requestCost = null,
     Exception? innerException = null)
     : ShopifyException(FormatMessage(graphUserErrors), innerException)
 {
-    public ICollection<GraphUserError> GraphUserErrors { get; } = graphUserErrors;
+    public IReadOnlyList<GraphUserError> GraphUserErrors { get; } = graphUserErrors;
 
     public string? RequestId { get; } = requestId;
 
     // TODO: add support for parsing request cost and passing to exception
     // public GraphRequestCostExtension? GraphCost { get; } = graphCost;
 
-    private static string FormatMessage(ICollection<GraphUserError> graphUserErrors)
+    private static string FormatMessage(IReadOnlyList<GraphUserError> graphUserErrors)
     {
-        var firstError = graphUserErrors.FirstOrDefault();
+        var firstError = graphUserErrors.Count == 0 ? null : graphUserErrors[0];
 
         if (!string.IsNullOrWhiteSpace(firstError?.Code))
             return $"{firstError.Code}: {firstError.Message}";
 
-        if (!string.IsNullOrWhiteSpace(firstError?.Message))
-            return firstError.Message;
-
-        return "GraphQL operation returned one or more errors.";
+        return string.IsNullOrWhiteSpace(firstError?.Message)
+            ? "GraphQL operation returned one or more user errors."
+            : firstError.Message;
     }
 }

--- a/ShopifySharp/Services/Graph/GraphError.cs
+++ b/ShopifySharp/Services/Graph/GraphError.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System.Collections.Generic;
+
 namespace ShopifySharp.Services.Graph;
 
 public record GraphError
@@ -8,6 +10,8 @@ public record GraphError
     #else
     public string Message { get; set; } = null!;
     #endif
+
+    public IReadOnlyList<string>? Path { get; set; }
 
     public GraphErrorExtensions? Extensions { get; set; }
 }

--- a/ShopifySharp/Services/Graph/GraphError.cs
+++ b/ShopifySharp/Services/Graph/GraphError.cs
@@ -1,0 +1,13 @@
+#nullable enable
+namespace ShopifySharp.Services.Graph;
+
+public record GraphError
+{
+    #if NET8_0_OR_GREATER
+    public required string Message { get; set; }
+    #else
+    public string Message { get; set; } = null!;
+    #endif
+
+    public GraphErrorExtensions? Extensions { get; set; }
+}

--- a/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
+++ b/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace ShopifySharp.Services.Graph;
 
 public record GraphErrorExtensions
@@ -13,4 +14,8 @@ public record GraphErrorExtensions
     public double? MaxCost { get; set; }
 
     public string? Documentation { get; set; }
+
+    public string? TypeName { get; set; }
+
+    public string? ArgumentName { get; set; }
 }

--- a/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
+++ b/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
@@ -1,0 +1,16 @@
+namespace ShopifySharp.Services.Graph;
+
+public record GraphErrorExtensions
+{
+#if NET8_0_OR_GREATER
+    public required string Code { get; set; }
+#else
+    public string Code { get; set; } = null!;
+#endif
+
+    public double? Cost { get; set; }
+
+    public double? MaxCost { get; set; }
+
+    public string? Documentation { get; set; }
+}

--- a/ShopifySharp/Services/Graph/GraphExtensions.cs
+++ b/ShopifySharp/Services/Graph/GraphExtensions.cs
@@ -7,7 +7,7 @@ namespace ShopifySharp.Services.Graph;
 [Serializable]
 public record GraphExtensions
 {
-    #if NET60_OR_GREATER
+    #if NET8_0_OR_GREATER
     public required GraphRequestCostExtension Cost { get; set; }
     #else
     public GraphRequestCostExtension Cost { get; set; } = default!;

--- a/ShopifySharp/Services/Graph/GraphRequest.cs
+++ b/ShopifySharp/Services/Graph/GraphRequest.cs
@@ -28,19 +28,11 @@ public class GraphRequest
         set => _variables = value as IDictionary<string, object> ?? value?.ToDictionary();
     }
 
-#if NET8_0_OR_GREATER
-    public required string Query
-    {
-        get => _query ?? "";
-        set => _query = value;
-    }
-#else
     public string Query
     {
         get => _query ?? "";
         set => _query = value;
     }
-#endif
 
     public IDictionary<string, object>? Variables
     {

--- a/ShopifySharp/Services/Graph/GraphRequest.cs
+++ b/ShopifySharp/Services/Graph/GraphRequest.cs
@@ -28,7 +28,7 @@ public class GraphRequest
         set => _variables = value as IDictionary<string, object> ?? value?.ToDictionary();
     }
 
-#if NET60_OR_GREATER
+#if NET8_0_OR_GREATER
     public required string Query
     {
         get => _query ?? "";

--- a/ShopifySharp/Services/Graph/GraphRequestCostExtension.cs
+++ b/ShopifySharp/Services/Graph/GraphRequestCostExtension.cs
@@ -9,7 +9,7 @@ public record GraphRequestCostExtension
 
     public int ActualQueryCost { get; set; }
 
-    #if NET60_OR_GREATER
+    #if NET8_0_OR_GREATER
     public required GraphRequestCostThrottleStatusExtension ThrottleStatus { get; set; }
     #else
     public GraphRequestCostThrottleStatusExtension ThrottleStatus { get; set; }

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -175,6 +175,15 @@ public class GraphService : ShopifyService, IGraphService
             if (graphRequest.UserErrorHandling == GraphRequestUserErrorHandling.Throw)
                 ThrowIfResponseContainsGraphUserErrors(jsonDocument, requestId);
         }
+        catch (Exception exn) when (exn is not ShopifyException)
+        {
+            jsonDocument.Dispose();
+            throw new ShopifyJsonParseException(
+                "An exception was thrown while checking the json document for errors returned by Shopify. Check the inner exception for more details.",
+                jsonPropertyName: (exn is JsonException jxn ? jxn.Path : null) ?? rootPath,
+                requestId: requestId,
+                innerException: exn);
+        }
         catch
         {
             jsonDocument.Dispose();

--- a/ShopifySharp/Services/Graph/GraphService.cs
+++ b/ShopifySharp/Services/Graph/GraphService.cs
@@ -105,7 +105,6 @@ public class GraphService : ShopifyService, IGraphService
 
         try
         {
-            // TODO: add a test for this
             data = await _jsonSerializer.DeserializeAsync(dataElement, resultType, cancellationToken);
         }
         catch (Exception exn)


### PR DESCRIPTION
This PR contains necessary updates/improvements for exception handling in the GraphService that I've discovered while writing documentation and integration tests for #1126.

- A `ShopifyGraphErrorsException` will be thrown if Shopify returns a response containing a non-empty `errors` array at the top level. According to Shopify, these errors are primarily intended for the developer to use for debugging problems with the mutation/query itself.
  - This exception will be thrown regardless of the `GraphRequest.UserErrorHandling` setting.
- A `ShopifyJsonParseException` will be thrown if any kind of exception is thrown during error checking (both user error checking and developer error checking), or during the final deserialization to `T`.
- Removed the `required` keyword on `GraphRequest.Query`.
  - This was removed primarily because it's an annoyance and gums up flows where you create an empty `GraphRequest` then dynamically set the `Query` later on.