### PR TITLE
Fix content disposal bug

### DIFF
--- a/ShopifySharp.Tests/Services/ShopifyServiceTests.cs
+++ b/ShopifySharp.Tests/Services/ShopifyServiceTests.cs
@@ -1,15 +1,32 @@
+#nullable enable
 using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FakeItEasy;
 using FluentAssertions;
 using JetBrains.Annotations;
+using ShopifySharp.Infrastructure;
+using ShopifySharp.Infrastructure.Policies.ExponentialRetry;
 using ShopifySharp.Tests.TestClasses;
 using Xunit;
 
 namespace ShopifySharp.Tests.Services;
 
-[Trait("Category", "ShopifyService")]
+[Trait("Category", "ShopifyService"), Trait("Category", "DotNetFramework")]
 [TestSubject(typeof(ShopifyService))]
 public class ShopifyServiceTests
 {
+    public static HttpMethod[] MakeHttpMethodList() => [HttpMethod.Get, HttpMethod.Post, HttpMethod.Put, HttpMethod.Delete, HttpMethod.Head];
+
+    public static Func<IRequestExecutionPolicy>[] MakeFakedExecutionPoliciesList() =>
+        [
+            () => A.Fake<IRequestExecutionPolicy>(x => x.Wrapping(new DefaultRequestExecutionPolicy())),
+            () => A.Fake<IRequestExecutionPolicy>(x => x.Wrapping(new RetryExecutionPolicy())),
+            () => A.Fake<IRequestExecutionPolicy>(x => x.Wrapping(new LeakyBucketExecutionPolicy())),
+            () => A.Fake<IRequestExecutionPolicy>(x => x.Wrapping(new ExponentialRetryPolicy(ExponentialRetryPolicyOptions.Default())))
+        ];
+
     #region PrepareRequest(string path) and BuildRequestUri
 
     [Fact]
@@ -24,6 +41,60 @@ public class ShopifyServiceTests
 
         // Assert
         result.ToUri().Should().Be(expectedUri);
+    }
+
+    #endregion
+
+    #region internal ExecuteRequestCoreAsync
+
+    [Theory]
+    [CombinatorialData]
+    public async Task Internal_ExecuteRequestCoreAsync_WhenRunningTheExecutionPolicy_ShouldNotDisposeTheBaseRequestMessageContent(
+        [CombinatorialMemberData(nameof(MakeHttpMethodList))] HttpMethod httpMethod,
+        [CombinatorialMemberData(nameof(MakeFakedExecutionPoliciesList))] Func<IRequestExecutionPolicy> makePolicy
+    )
+    {
+        // Setup
+        var sut = new TestShopifyServiceWithExposedExecuteRequestCoreAsync();
+        var handler = A.Fake<HttpMessageHandler>();
+        var content = A.Fake<HttpContent>(x => x.Wrapping(new StringContent("""{"foo":"bar"}""")));
+        var policy = makePolicy();
+
+        sut.SetExecutionPolicy(policy);
+        sut.SetHttpClient(new HttpClient(handler));
+
+        var callToHandler = A.CallTo(handler)
+            .WithReturnType<Task<HttpResponseMessage>>()
+            .Where(call => call.Method.Name == "SendAsync");
+        var callToPolicy = A.CallTo(policy)
+            .WithReturnType<Task<RequestResult<string>>>()
+            .Where(call => call.Method.Name == "Run");
+        var callToDisposeContent = A.CallTo(content)
+            .WithVoidReturnType()
+            .Where(call => call.Method.Name == "Dispose");
+
+        callToHandler.ReturnsLazily(() => new HttpResponseMessage
+        {
+            Content = new JsonContent(new { products = true }),
+            StatusCode = HttpStatusCode.OK
+        });
+
+        // Act
+        var act = async () => await sut.ExecuteRequestCoreAsync(
+            new RequestUri(new Uri("https://example.com")),
+            httpMethod,
+            content,
+            [],
+            null);
+
+        // Assert
+        var result = await act.Should().NotThrowAsync();
+
+        result.Subject.Result.Should().Be("""{"products":true}""");
+
+        callToPolicy.MustHaveHappenedOnceExactly();
+        callToHandler.MustHaveHappenedOnceExactly();
+        callToDisposeContent.MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/ShopifySharp.Tests/TestClasses/TestShopifyServiceWithExposedExecuteRequestCoreAsync.cs
+++ b/ShopifySharp.Tests/TestClasses/TestShopifyServiceWithExposedExecuteRequestCoreAsync.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ShopifySharp.Infrastructure;
+
+namespace ShopifySharp.Tests.TestClasses;
+
+public class TestShopifyServiceWithExposedExecuteRequestCoreAsync()
+    : ShopifyService("some-shop-domain", "some-access-token")
+{
+    public new Task<RequestResult<string>> ExecuteRequestCoreAsync(
+        RequestUri uri,
+        HttpMethod method,
+        HttpContent content,
+        Dictionary<string, string> headers,
+        int? graphqlQueryCost,
+        CancellationToken cancellationToken = default
+    ) => base.ExecuteRequestCoreAsync(uri, method, content, headers, graphqlQueryCost, cancellationToken);
+}

--- a/ShopifySharp/Services/ShopifyService.cs
+++ b/ShopifySharp/Services/ShopifyService.cs
@@ -190,6 +190,7 @@ public abstract class ShopifyService : IShopifyService
     )
     {
         using var baseRequestMessage = PrepareRequestMessage(uri, method, content, headers);
+        var requestInfo = await baseRequestMessage.GetRequestInfo();
         var policyResult = await _ExecutionPolicy.Run(baseRequestMessage, async (requestMessage) =>
         {
             using var response = await _Client.SendAsync(requestMessage, cancellationToken);
@@ -201,10 +202,10 @@ public abstract class ShopifyService : IShopifyService
             #endif
 
             //Check for and throw exception when necessary.
-            CheckResponseExceptions(await baseRequestMessage.GetRequestInfo(), response, rawResult);
+            CheckResponseExceptions(requestInfo, response, rawResult);
 
             return new RequestResult<string>(
-                await baseRequestMessage.GetRequestInfo(),
+                requestInfo,
                 response.Headers,
                 rawResult,
                 rawResult,


### PR DESCRIPTION
This change fixes a bug where ShopifySharp would throw an exception when running on .NET Framework while trying to read the request message's content after the request had already been sent. .NET Framework's HttpClient disposes the HttpRequestMessage's `Content` after sending the request (https://stackoverflow.com/a/25495500). When ShopifySharp tried to read the disposed request content, an `ObjectDisposedException` would be thrown. This bug did not occur outside of .NET Framework, as the request message's content is not disposed by the HttpClient there.

Closes #1080 and #1129.