### PR TITLE
Add tests for serializing and deserializing HTML-encodable characters with the Serializer's Newtonsoft methods

### DIFF
--- a/ShopifySharp.Tests/Infrastructure/Serialization/SerializerTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/Serialization/SerializerTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using JetBrains.Annotations;
+using ShopifySharp.Infrastructure;
+using Xunit;
+
+namespace ShopifySharp.Tests.Infrastructure.Serialization;
+
+[Trait("Category", "Serialization"), TestSubject(typeof(Serializer))]
+public class SerializerTests
+{
+    #region (Newtonsoft) Serializer.Serialize
+
+    [Theory]
+    [InlineData("º")]
+    [InlineData("<")]
+    [InlineData(">")]
+    public void Serialize_WhenSerializingHtmlEncodableCharacters_ShouldNotEncodeToHtml(string encodableCharacter)
+    {
+        // Act
+        var json = Serializer.Serialize(encodableCharacter);
+
+        // Assert
+        json.Should().Be($"\"{encodableCharacter}\"");
+    }
+
+    [Theory]
+    [InlineData("Spiral flute 40º")]
+    [InlineData("Spiral flute 40<")]
+    [InlineData("Spiral flute 40>")]
+    public void Serialize_WhenSerializingProductObjectWithHtmlEncodableCharacters_ShouldNotEncodeToHtml(string productTitle)
+    {
+        // Setup
+        var expectedJson = $$"""{"title":"{{productTitle}}","published_at":null}""";
+        var product = new Product { Title = productTitle };
+
+        // Act
+        var json = Serializer.Serialize(product);
+
+        // Assert
+        json.Should().Be(expectedJson);
+    }
+
+    #endregion
+
+    #region (Newtonsoft) Serializer.Deserialize(string json, Type objectType)
+
+    [Theory]
+    [InlineData("º")]
+    [InlineData("<")]
+    [InlineData(">")]
+    public void Deserialize_WhenDeserializingHtmlEncodableStrings_ShouldNotDeserializeToEncodableHtml(string encodableCharacter)
+    {
+        // Setup
+        var json = $$"""{"foo":"{{encodableCharacter}}"}""";
+
+        // Act
+        var result = Serializer.Deserialize(json, typeof(TestFoo));
+
+        // Assert
+        result.Should().BeOfType(typeof(TestFoo));
+        result.As<TestFoo>().Foo.Should().Be(encodableCharacter);
+    }
+
+    [Theory]
+    [InlineData("Spiral flute 40º")]
+    [InlineData("Spiral flute 40<")]
+    [InlineData("Spiral flute 40>")]
+    public void Deserialize_WhenDeserializingProductObjectWithHtmlEncodableCharacters_ShouldNotDeserializeToEncodableHtml(string productTitle)
+    {
+        // Setup
+        var json = $$"""{"title":"{{productTitle}}","published_at":null}""";
+        var expectedProduct = new Product { Title = productTitle, PublishedAt = null };
+
+        // Act
+        var result = Serializer.Deserialize(json, typeof(Product));
+
+        // Assert
+        result.Should().BeOfType(typeof(Product));
+        result.As<Product>().Should().BeEquivalentTo(expectedProduct);
+    }
+
+    #endregion
+
+    #region (Newtonsoft) Serializer.Deserialize<T>(string json, string rootElementPath = null, DateParseHandling? dateParseHandlingOverride = null)}
+
+    [Theory]
+    [InlineData("º")]
+    [InlineData("<")]
+    [InlineData(">")]
+    public void Deserialize_T_WhenDeserializingHtmlEncodableStrings_ShouldNotDeserializeToEncodableHtml(string encodableCharacter)
+    {
+        // Setup
+        var json = $$"""{"foo":"{{encodableCharacter}}"}""";
+
+        // Act
+        var result = Serializer.Deserialize<TestFoo>(json);
+
+        // Assert
+        result.Foo.Should().Be(encodableCharacter);
+    }
+
+    [Theory]
+    [InlineData("Spiral flute 40º")]
+    [InlineData("Spiral flute 40<")]
+    [InlineData("Spiral flute 40>")]
+    public void Deserialize_T_WhenDeserializingProductObjectWithHtmlEncodableStrings_ShouldNotDeserializeToEncodableHtml(string productTitle)
+    {
+        // Setup
+        var json = $$"""{"title":"{{productTitle}}","published_at":null}""";
+        var expectedProduct = new Product { Title = productTitle, PublishedAt = null };
+
+        // Act
+        var result = Serializer.Deserialize<Product>(json);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedProduct);
+    }
+
+    [Theory]
+    [InlineData("Spiral flute 40º")]
+    [InlineData("Spiral flute 40<")]
+    [InlineData("Spiral flute 40>")]
+    public void Deserialize_T_WhenDeserializingProductObjectWithHtmlEncodableStrings_AndUsingRootPath_ShouldNotDeserializeToEncodableHtml(string productTitle)
+    {
+        // Setup
+        var json = $$"""{"title":"{{productTitle}}","published_at":null}""";
+
+        // Act
+        var result = Serializer.Deserialize<string>(json, "title");
+
+        // Assert
+        result.Should().BeEquivalentTo(productTitle);
+    }
+
+    #endregion
+
+    private record TestFoo
+    {
+        public string Foo { get; set; }
+    }
+}

--- a/ShopifySharp.sln.DotSettings
+++ b/ShopifySharp.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeEditing/SuppressUninitializedWarningFix/Enabled/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeAttributeFilters/=System_002EObsoleteAttribute/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=encodable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fulfillments/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=metafield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=myshopify/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This PR just adds some unit tests to confirm behavior for serializing and deserializing HTML-encodable characters (e.g. `º`, `<` and `>`) using `Serializer.Serialize` and `Serializer.Deserialize`.

See #1118