### PR TITLE
Fix required keyword causing json parse exceptions when extensions is missing a property

### DIFF
--- a/ShopifySharp/Converters/SystemTextJson/ObjectDictionaryConverter.cs
+++ b/ShopifySharp/Converters/SystemTextJson/ObjectDictionaryConverter.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ShopifySharp.Infrastructure.Serialization.Json;
+
+namespace ShopifySharp.Converters.SystemTextJson;
+
+/// <summary>
+/// A custom JSON converter for dictionaries with <c>string</c> keys and <c>object</c> values. This converter is necessary
+/// because System.Text.Json does not deserialize json values into their underlying CLR types when using <c>object</c>;
+/// rather, System.Text.Json deserializes json values into <see cref="IJsonElement"/>, which is unexpected behavior.
+/// </summary>
+/// <remarks>
+/// This converter handles deserialization of dictionary values into appropriate CLR types such as:
+/// <list type="bullet">
+/// <item><description><c>string</c> for JSON string values.</description></item>
+/// <item><description><c>long</c> or <c>double</c> for JSON number values.</description></item>
+/// <item><description><c>bool</c> for JSON boolean values.</description></item>
+/// <item><description><c>null</c> for JSON null values.</description></item>
+/// <item><description><c>SystemJsonElement</c> for unsupported or complex JSON structures.</description></item>
+/// </list>
+/// </remarks>
+public class ObjectDictionaryConverter : JsonConverter<IReadOnlyDictionary<string, object?>>
+{
+    public override IReadOnlyDictionary<string, object?> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var result = new Dictionary<string, object?>();
+
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected StartObject token");
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return result;
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected PropertyName token");
+
+            var propertyName = reader.GetString();
+
+            // Always read even if the property name is null, to ensure we advance the reader past the property value for the next loop
+            reader.Read();
+
+            if (propertyName is null)
+                continue;
+
+            object? value = reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => reader.TryGetInt64(out var l) ? l : reader.GetDouble(),
+                JsonTokenType.True => true,
+                JsonTokenType.False => false,
+                JsonTokenType.Null => null,
+                _ => new SystemJsonElement(JsonDocument.ParseValue(ref reader).RootElement.Clone())
+            };
+
+            result[propertyName] = value;
+        }
+
+        throw new JsonException("Expected EndObject token");
+    }
+
+    public override void Write(Utf8JsonWriter writer, IReadOnlyDictionary<string, object?> value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/ShopifySharp/Services/Graph/GraphError.cs
+++ b/ShopifySharp/Services/Graph/GraphError.cs
@@ -5,11 +5,8 @@ namespace ShopifySharp.Services.Graph;
 
 public record GraphError
 {
-    #if NET8_0_OR_GREATER
-    public required string Message { get; set; }
-    #else
-    public string Message { get; set; } = null!;
-    #endif
+    // TODO: make this nullable
+    public string Message { get; set; } = string.Empty;
 
     public IReadOnlyList<string>? Path { get; set; }
 

--- a/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
+++ b/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
@@ -19,4 +19,7 @@ public record GraphErrorExtensions
     public string? TypeName { get; set; }
 
     public string? ArgumentName { get; set; }
+
+    [JsonConverter(typeof(ObjectDictionaryConverter))]
+    public IReadOnlyDictionary<string, object?>? Value { get; set; }
 }

--- a/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
+++ b/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
@@ -1,13 +1,14 @@
 #nullable enable
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using ShopifySharp.Converters.SystemTextJson;
+
 namespace ShopifySharp.Services.Graph;
 
 public record GraphErrorExtensions
 {
-#if NET8_0_OR_GREATER
-    public required string Code { get; set; }
-#else
-    public string Code { get; set; } = null!;
-#endif
+    // TODO: make this nullable
+    public string Code { get; set; } = string.Empty;
 
     public double? Cost { get; set; }
 

--- a/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
+++ b/ShopifySharp/Services/Graph/GraphErrorExtensions.cs
@@ -22,4 +22,6 @@ public record GraphErrorExtensions
 
     [JsonConverter(typeof(ObjectDictionaryConverter))]
     public IReadOnlyDictionary<string, object?>? Value { get; set; }
+
+    public IReadOnlyList<GraphErrorExtensionsProblem>? Problems { get; set; }
 }

--- a/ShopifySharp/Services/Graph/GraphErrorExtensionsProblem.cs
+++ b/ShopifySharp/Services/Graph/GraphErrorExtensionsProblem.cs
@@ -1,0 +1,13 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace ShopifySharp.Services.Graph;
+
+public record GraphErrorExtensionsProblem
+{
+    public IReadOnlyList<string>? Path { get; set; }
+
+    public string? Explanation { get; set; }
+
+    public string? Message { get; set; }
+}


### PR DESCRIPTION
This PR fixes a bug reported in #1145 where the `required` keyword in the `GraphError` and `GraphErrorExtensions` class would cause a ShopifyJsonParseException to be thrown when those properties were missing in the `errors` json. Since there is no actual documentation for which properties will be returned here and when, I'm going to make them all nullable in the next minor release.

This PR also adds `GraphErrorExtensions.Value` and `GraphErrorExtensions.Problems`, which are both nullable.