### PR TITLE
Add `IJsonElement.ValueEquals(xyz)` and `IJsonElement.ValueIsNullOrWhiteSpaceString()` methods

### DIFF
--- a/ShopifySharp.Tests/Infrastructure/Serialization/Json/SystemJsonElementTests.cs
+++ b/ShopifySharp.Tests/Infrastructure/Serialization/Json/SystemJsonElementTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using JetBrains.Annotations;
@@ -237,6 +238,372 @@ public class SystemJsonElementTests
 
         // Assert
         propertyCount.Should().Be(2);
+    }
+
+    #endregion
+
+    #nullable enable
+
+    #region ValueEquals(string?)
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_StringVariant_WhenTheValuesAreEqual_ShouldReturnTrue(
+        [CombinatorialValues("", " ", "foo")] string jsonValue,
+        [CombinatorialValues("", " ", "foo")] string testValue
+    )
+    {
+        // Setup
+        var jsonStr = $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": {{jsonStr}}
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(testValue);
+
+        // Assert
+        var shouldMatch = jsonValue == testValue;
+        valueEquals.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_StringVariant_WhenTheJsonValueIsAnEmptyString_BothNullAndEmptyStringsShouldMatch(
+        [CombinatorialValues(null, "")] string? testValue
+    )
+    {
+        // Setup
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": ""
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(testValue);
+
+        // Assert
+        valueEquals.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", false)]
+    public void ValueEquals_StringVariant_WhenTheJsonValueIsNull_OnlyNullValuesShouldMatch(
+        string? testValue,
+        bool shouldMatch
+    )
+    {
+        // Setup
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": null
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(testValue);
+
+        // Assert
+        valueEquals.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_StringVariant_WhenTheElementIsNotAStringOrNull_ReturnsFalse(
+        [CombinatorialValues("{}", "[]", "123", "[123]", "true", "false")] string? jsonValue,
+        [CombinatorialValues(null, "", "foo")] string? testValue
+    )
+    {
+        // Setup
+        var jsonStr = jsonValue is null ? "null" : $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": {{jsonStr}}
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(testValue);
+
+        // Assert
+        valueEquals.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ValueEquals(ReadOnlySpan<byte>)
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_ReadOnlySpanBytesVariant_WhenTheValuesAreEqual_ShouldReturnTrue(
+        [CombinatorialValues("", " ", "foo")] string jsonValue,
+        [CombinatorialValues("", " ", "foo")] string testValue
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<byte>(Encoding.UTF8.GetBytes(testValue));
+        var jsonStr = $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": {{jsonStr}}
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        var shouldMatch = jsonValue == testValue;
+        valueEquals.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_ReadOnlySpanBytesVariant_WhenTheJsonValueIsAnEmptyString_BothNullAndEmptyStringsShouldMatch(
+        [CombinatorialValues(null, "")] string? testValue
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<byte>(testValue is null ? null : Encoding.UTF8.GetBytes(testValue));
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": ""
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        valueEquals.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", false)]
+    public void ValueEquals_ReadOnlySpanBytesVariant_WhenTheJsonValueIsNull_OnlyNullValuesShouldMatch(
+        string? testValue,
+        bool shouldMatch
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<byte>(testValue is null ? null : Encoding.UTF8.GetBytes(testValue));
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": null
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        valueEquals.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_ReadOnlySpanBytesVariant_WhenTheElementIsNotAStringOrNull_ReturnsFalse(
+        [CombinatorialValues("{}", "[]", "123", "[123]", "true", "false")] string? jsonValue,
+        [CombinatorialValues(null, "", "foo")] string? testValue
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<byte>(testValue is null ? null : Encoding.UTF8.GetBytes(testValue));
+        var jsonStr = jsonValue is null ? "null" : $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": {{jsonStr}}
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        valueEquals.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ValueEquals(ReadOnlySpan<char>)
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_ReadOnlySpanCharsVariant_WhenTheValuesAreEqual_ShouldReturnTrue(
+        [CombinatorialValues("", " ", "foo")] string jsonValue,
+        [CombinatorialValues("", " ", "foo")] string testValue
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<char>(testValue.ToCharArray());
+        var jsonStr = $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": {{jsonStr}}
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        var shouldMatch = jsonValue == testValue;
+        valueEquals.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_ReadOnlySpanCharsVariant_WhenTheJsonValueIsAnEmptyString_BothNullAndEmptyStringsShouldMatch(
+        [CombinatorialValues(null, "")] string? testValue
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<char>(testValue?.ToCharArray());
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": ""
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        valueEquals.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", false)]
+    public void ValueEquals_ReadOnlySpanCharsVariant_WhenTheJsonValueIsNull_OnlyNullValuesShouldMatch(
+        string? testValue,
+        bool shouldMatch
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<char>(testValue?.ToCharArray());
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": null
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        valueEquals.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ValueEquals_ReadOnlySpanCharsVariant_WhenTheElementIsNotAStringOrNull_ReturnsFalse(
+        [CombinatorialValues("{}", "[]", "123", "[123]", "true", "false")] string? jsonValue,
+        [CombinatorialValues(null, "", "foo")] string? testValue
+    )
+    {
+        // Setup
+        var span = new ReadOnlySpan<char>(testValue?.ToCharArray());
+        var jsonStr = jsonValue is null ? "null" : $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+    $$"""
+        {
+          "foo": {{jsonStr}}
+        }
+        """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueEquals(span);
+
+        // Assert
+        valueEquals.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ValueIsNullOrWhiteSpaceString()
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData(" ", true)]
+    [InlineData("    ", true)]
+    [InlineData("foo", false)]
+    public void ValueIsNullOrWhiteSpaceString_ReturnsExpectedValue(
+        string? jsonValue,
+        bool expectNullOrWhiteSpace
+    )
+    {
+        // Setup
+        var jsonStr = jsonValue is null ? "null" : $"\"{jsonValue}\"";
+        var doc = JsonDocument.Parse(
+        $$"""
+          {
+            "foo": {{jsonStr}}
+          }
+          """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueIsNullOrWhiteSpaceString();
+
+        // Assert
+        valueEquals.Should().Be(expectNullOrWhiteSpace, "the result should be {0}", expectNullOrWhiteSpace);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    [InlineData("123")]
+    [InlineData("[1, 2, 3]")]
+    [InlineData("true")]
+    [InlineData("false")]
+    public void ValueIsNullOrWhiteSpaceString_WhenTheElementIsNotAStringOrNull_ReturnsFalse(
+        string? jsonValue
+    )
+    {
+        // Setup
+        var doc = JsonDocument.Parse(
+        $$"""
+          {
+            "foo": {{jsonValue}}
+          }
+          """);
+        var node = new SystemJsonElement(doc).GetProperty("foo");
+
+        // Act
+        var valueEquals = node.ValueIsNullOrWhiteSpaceString();
+
+        // Assert
+        valueEquals.Should().BeFalse("non-null, non-string properties should return false");
     }
 
     #endregion

--- a/ShopifySharp/Infrastructure/Serialization/Json/IJsonElement.cs
+++ b/ShopifySharp/Infrastructure/Serialization/Json/IJsonElement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace ShopifySharp.Infrastructure.Serialization.Json;
@@ -19,4 +20,12 @@ public interface IJsonElement : IDisposable
     int GetArrayLength();
 
     int GetPropertyCount();
+
+    bool ValueEquals(string? text);
+
+    bool ValueEquals(ReadOnlySpan<byte> utf8Text);
+
+    bool ValueEquals(ReadOnlySpan<char> text);
+
+    bool ValueIsNullOrWhiteSpaceString();
 }

--- a/ShopifySharp/Infrastructure/Serialization/Json/SystemJsonElement.cs
+++ b/ShopifySharp/Infrastructure/Serialization/Json/SystemJsonElement.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Text.Json;
 
 namespace ShopifySharp.Infrastructure.Serialization.Json;
@@ -46,6 +47,21 @@ internal class SystemJsonElement(JsonElement element, JsonDocument? document = n
     public int GetArrayLength() => element.GetArrayLength();
 
     public int GetPropertyCount() => element.GetPropertyCount();
+
+    public bool ValueEquals(string? text) => element.ValueEquals(text);
+
+    public bool ValueEquals(ReadOnlySpan<byte> utf8Text) => element.ValueEquals(utf8Text);
+
+    public bool ValueEquals(ReadOnlySpan<char> text) => element.ValueEquals(text);
+
+    public bool ValueIsNullOrWhiteSpaceString()
+    {
+        if (ValueType == JsonValueType.Null)
+            return true;
+        if (ValueType != JsonValueType.String)
+            return false;
+        return ValueEquals(ReadOnlySpan<byte>.Empty) || string.IsNullOrWhiteSpace(element.GetString());
+    }
 
     public void Dispose()
     {


### PR DESCRIPTION

This PR adds a couple of QoL improvements to the `IJsonElement` interface and its current sole implementation, `SystemJsonElement`:

- `public bool ValueEquals(string? text)`
- `public bool ValueEquals(ReadOnlySpan<byte> utf8Text)`
- `public bool ValueEquals(ReadOnlySpan<char> text)`
- `public bool ValueIsNullOrWhiteSpaceString()`
