### PR TITLE
Fix union case serialization bug

### DIFF
--- a/ShopifySharp.GraphQL.Parser/Writer.fs
+++ b/ShopifySharp.GraphQL.Parser/Writer.fs
@@ -299,11 +299,11 @@ let private getAppropriateClassTNodeTypeFromField (isNamedType: NamedType -> boo
 
 let private writeInheritedUnionCaseType (context: IParsedContext) (unionCaseName: string) writer: ValueTask =
     pipeWriter writer {
-        match context.TryFindUnionRelationship unionCaseName with
-        | Some relationship ->
-            do! $"{relationship.UnionTypeName}, IGraphQLUnionCase"
-        | None ->
-            do! "IGraphQLUnionCase"
+        // Union cases previously wrote both this interface type and their inherited union type. That does not work though,
+        // as A) a union case can appear in more than one union (e.g. Metaobject was in MetaobjectReference and MetaobjectReferencer)
+        // and B) it made it impossible to serialize the union case to json in cases where the union case had a property
+        // chain that referenced its own union type parent (e.g. the Metaobject -> MetaobjectField -> MetaobjectReferencer -> Metaobject).
+        do! "IGraphQLUnionCase"
     }
 
 let private writeClassKnownInheritedType (context: IParsedContext) (class': Class) writer: ValueTask =

--- a/ShopifySharp.Tests.Integration/Features/MetaObjects/MetaObjectQueryTests.cs
+++ b/ShopifySharp.Tests.Integration/Features/MetaObjects/MetaObjectQueryTests.cs
@@ -1,0 +1,71 @@
+using ShopifySharp.GraphQL;
+using ShopifySharp.Services.Graph;
+using ShopifySharp.Tests.Integration.Features.Products.Models;
+
+namespace ShopifySharp.Tests.Integration.Features.MetaObjects;
+
+[Collection("MetaObject Queries")]
+public class MetaObjectQueryTests(VerifyFixture verifyFixture, GraphServiceFixture graphServiceFixture)
+    : IClassFixture<VerifyFixture>, IClassFixture<GraphServiceFixture>
+{
+    private readonly VerifySettings _verifySettings = verifyFixture.Settings;
+    private readonly IGraphService _sut = graphServiceFixture.Service;
+
+    [Fact]
+    public async Task ShouldUpsertMetaObject()
+    {
+        // Setup
+        var metaobject = new Metaobject()
+        {
+            handle = "some-handle",
+            fields =
+            [
+                new MetaobjectField()
+                {
+                    key = "some-key",
+                    value = "some-value",
+                }
+            ],
+        };
+
+        var graphRequest = new GraphRequest
+        {
+            Query =
+                """
+                mutation UpsertMetaobject($handle: MetaobjectHandleInput!, $metaobject: MetaobjectUpsertInput!) {
+                    result: metaobjectUpsert(handle: $handle, metaobject: $metaobject) {
+                        metaobject {
+                            id
+                            fields {
+                                key
+                                value
+                            }
+                        }
+                        userErrors {
+                            field
+                            message
+                        }
+                    }
+                }
+                """,
+            Variables = new Dictionary<string, object>
+            {
+                {
+                    "handle", new Dictionary<string, object>
+                    {
+                        {"handle", "some-handle"},
+                        {"type", "some-type"}
+                    }
+                },
+                { "metaobject", metaobject}
+            },
+            UserErrorHandling = GraphRequestUserErrorHandling.DoNotThrow,
+        };
+
+        // Act
+        var result = await _sut.PostAsync<MutationResponse<MetaobjectUpsertPayload>>(graphRequest);
+
+        // Assert
+        await Verify(result.Data, _verifySettings);
+    }
+}

--- a/ShopifySharp.Tests.Integration/Features/MetaObjects/Snapshots/MetaObjectQueryTests.ShouldUpsertMetaObject.verified.json
+++ b/ShopifySharp.Tests.Integration/Features/MetaObjects/Snapshots/MetaObjectQueryTests.ShouldUpsertMetaObject.verified.json
@@ -1,0 +1,13 @@
+﻿{
+  "Result": {
+    "userErrors": [
+      {
+        "field": [
+          "handle",
+          "type"
+        ],
+        "message": "No metaobject definition exists for type \"some-type\""
+      }
+    ]
+  }
+}

--- a/ShopifySharp/Entities/GraphQL/Generated/AddAllProductsOperation.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AddAllProductsOperation.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents an operation publishing all products to a publication.
 /// </summary>
-public record AddAllProductsOperation : PublicationOperation, IGraphQLUnionCase, IGraphQLObject, INode, IResourceOperation
+public record AddAllProductsOperation : IGraphQLUnionCase, IGraphQLObject, INode, IResourceOperation
 {
     /// <summary>
     /// A globally-unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/AllDiscountItems.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AllDiscountItems.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Targets all items the cart for a specified discount.
 /// </summary>
-public record AllDiscountItems : DiscountItems, IGraphQLUnionCase, IGraphQLObject
+public record AllDiscountItems : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether all items are eligible for the discount. This value always returns `true`.

--- a/ShopifySharp/Entities/GraphQL/Generated/AndroidApplication.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AndroidApplication.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The Android mobile platform application.
 /// </summary>
-public record AndroidApplication : MobilePlatformApplication, IGraphQLUnionCase, IGraphQLObject
+public record AndroidApplication : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The Android application ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/AppInstallation.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AppInstallation.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents an installed application on a shop.
 /// </summary>
-public record AppInstallation : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasMetafields, INode
+public record AppInstallation : IGraphQLUnionCase, IGraphQLObject, IHasMetafields, INode
 {
     /// <summary>
     /// The access scopes granted to the application by a merchant during installation.

--- a/ShopifySharp/Entities/GraphQL/Generated/AppRecurringPricing.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AppRecurringPricing.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 /// The object contains an interval (the frequency at which the shop is billed for an app subscription) and
 /// a price (the amount to be charged to the subscribing shop at each interval).
 /// </summary>
-public record AppRecurringPricing : AppPricingDetails, IGraphQLUnionCase, IGraphQLObject
+public record AppRecurringPricing : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The discount applied to the subscription for a given number of billing intervals.

--- a/ShopifySharp/Entities/GraphQL/Generated/AppSubscriptionDiscountAmount.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AppSubscriptionDiscountAmount.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The fixed amount value of a discount.
 /// </summary>
-public record AppSubscriptionDiscountAmount : AppSubscriptionDiscountValue, IGraphQLUnionCase, IGraphQLObject
+public record AppSubscriptionDiscountAmount : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The fixed amount value of a discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/AppSubscriptionDiscountPercentage.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AppSubscriptionDiscountPercentage.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The percentage value of a discount.
 /// </summary>
-public record AppSubscriptionDiscountPercentage : AppSubscriptionDiscountValue, IGraphQLUnionCase, IGraphQLObject
+public record AppSubscriptionDiscountPercentage : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value of a discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/AppUsagePricing.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AppUsagePricing.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// Defines a usage pricing model for the app subscription.
 /// These charges are variable based on how much the merchant uses the app.
 /// </summary>
-public record AppUsagePricing : AppPricingDetails, IGraphQLUnionCase, IGraphQLObject
+public record AppUsagePricing : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The total usage records for interval.

--- a/ShopifySharp/Entities/GraphQL/Generated/AppleApplication.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/AppleApplication.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The Apple mobile platform application.
 /// </summary>
-public record AppleApplication : MobilePlatformApplication, IGraphQLUnionCase, IGraphQLObject
+public record AppleApplication : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The iOS App Clip application ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/Article.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Article.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// An article in the blogging system.
 /// </summary>
-public record Article : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INavigable, INode
+public record Article : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INavigable, INode
 {
     /// <summary>
     /// The name of the author of the article.

--- a/ShopifySharp/Entities/GraphQL/Generated/Blog.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Blog.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// Shopify stores come with a built-in blogging engine, allowing a shop to have one or more blogs.  Blogs are meant
 /// to be used as a type of magazine or newsletter for the shop, with content that changes over time.
 /// </summary>
-public record Blog : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INode
+public record Blog : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INode
 {
     /// <summary>
     /// List of the blog's articles.

--- a/ShopifySharp/Entities/GraphQL/Generated/CalculatedDraftOrderLineItem.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CalculatedDraftOrderLineItem.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The calculated line item for a draft order.
 /// </summary>
-public record CalculatedDraftOrderLineItem : DraftOrderPlatformDiscountAllocationTarget, IGraphQLUnionCase, IGraphQLObject
+public record CalculatedDraftOrderLineItem : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The custom applied discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/CardPaymentDetails.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CardPaymentDetails.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Card payment details related to a transaction.
 /// </summary>
-public record CardPaymentDetails : PaymentDetails, IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
+public record CardPaymentDetails : IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
 {
     /// <summary>
     /// The response code from the address verification system (AVS). The code is always a single letter.

--- a/ShopifySharp/Entities/GraphQL/Generated/CatalogCsvOperation.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CatalogCsvOperation.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A catalog csv operation represents a CSV file import.
 /// </summary>
-public record CatalogCsvOperation : PublicationOperation, IGraphQLUnionCase, IGraphQLObject, INode, IResourceOperation
+public record CatalogCsvOperation : IGraphQLUnionCase, IGraphQLObject, INode, IResourceOperation
 {
     /// <summary>
     /// A globally-unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/Collection.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Collection.cs
@@ -32,7 +32,7 @@ using System.Collections.Generic;
 /// and contextual publication for location-based catalogs.
 /// Learn about [using metafields with smart collections](https://shopify.dev/docs/apps/build/custom-data/metafields/use-metafield-capabilities).
 /// </summary>
-public record Collection : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INode, IPublishable
+public record Collection : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INode, IPublishable
 {
     /// <summary>
     /// The number of

--- a/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleCategoryCondition.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleCategoryCondition.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Specifies the taxonomy category to used for the condition.
 /// </summary>
-public record CollectionRuleCategoryCondition : CollectionRuleConditionObject, IGraphQLUnionCase, IGraphQLObject
+public record CollectionRuleCategoryCondition : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The taxonomy category used as condition.

--- a/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleMetafieldCondition.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleMetafieldCondition.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Identifies a metafield definition used as a rule for the smart collection.
 /// </summary>
-public record CollectionRuleMetafieldCondition : CollectionRuleConditionObject, IGraphQLUnionCase, IGraphQLObject
+public record CollectionRuleMetafieldCondition : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The metafield definition associated with the condition.

--- a/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleProductCategoryCondition.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleProductCategoryCondition.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Specifies the condition for a Product Category field.
 /// </summary>
-public record CollectionRuleProductCategoryCondition : CollectionRuleConditionObject, IGraphQLUnionCase, IGraphQLObject
+public record CollectionRuleProductCategoryCondition : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The value of the condition.

--- a/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleTextCondition.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CollectionRuleTextCondition.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Specifies the condition for a text field.
 /// </summary>
-public record CollectionRuleTextCondition : CollectionRuleConditionObject, IGraphQLUnionCase, IGraphQLObject
+public record CollectionRuleTextCondition : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The value of the condition.

--- a/ShopifySharp/Entities/GraphQL/Generated/Company.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Company.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents information about a company which is also a customer of the shop.
 /// </summary>
-public record Company : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INavigable, INode
+public record Company : IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INavigable, INode
 {
     /// <summary>
     /// The number of contacts that belong to the company.

--- a/ShopifySharp/Entities/GraphQL/Generated/CompanyLocation.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CompanyLocation.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 /// shop. Configuration of B2B relationship, for example prices lists and checkout
 /// settings, may be done for a location.
 /// </summary>
-public record CompanyLocation : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INavigable, INode
+public record CompanyLocation : IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INavigable, INode
 {
     /// <summary>
     /// The address used as billing address for the location.

--- a/ShopifySharp/Entities/GraphQL/Generated/Customer.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Customer.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 /// scopes](https://shopify.dev/api/usage/access-scopes) for apps that don't have a
 /// legitimate use for the associated data.
 /// </summary>
-public record Customer : CommentEventEmbed, IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasStoreCreditAccounts, ILegacyInteroperability, INode
+public record Customer : IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasStoreCreditAccounts, ILegacyInteroperability, INode
 {
     /// <summary>
     /// A list of addresses associated with the customer.

--- a/ShopifySharp/Entities/GraphQL/Generated/CustomerCreditCard.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CustomerCreditCard.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a card instrument for customer payment method.
 /// </summary>
-public record CustomerCreditCard : CustomerPaymentInstrument, IGraphQLUnionCase, IGraphQLObject
+public record CustomerCreditCard : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The billing address of the card.

--- a/ShopifySharp/Entities/GraphQL/Generated/CustomerPaypalBillingAgreement.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CustomerPaypalBillingAgreement.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a PayPal instrument for customer payment method.
 /// </summary>
-public record CustomerPaypalBillingAgreement : CustomerPaymentInstrument, IGraphQLUnionCase, IGraphQLObject
+public record CustomerPaypalBillingAgreement : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The billing address of this payment method.

--- a/ShopifySharp/Entities/GraphQL/Generated/CustomerShopPayAgreement.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/CustomerShopPayAgreement.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a Shop Pay card instrument for customer payment method.
 /// </summary>
-public record CustomerShopPayAgreement : CustomerPaymentInstrument, IGraphQLUnionCase, IGraphQLObject
+public record CustomerShopPayAgreement : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The billing address of the card.

--- a/ShopifySharp/Entities/GraphQL/Generated/DeliveryCustomization.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DeliveryCustomization.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A delivery customization.
 /// </summary>
-public record DeliveryCustomization : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, INode
+public record DeliveryCustomization : IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// The enabled status of the delivery customization.

--- a/ShopifySharp/Entities/GraphQL/Generated/DeliveryParticipant.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DeliveryParticipant.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// A participant defines carrier-calculated rates for shipping services
 /// with a possible merchant-defined fixed fee or a percentage-of-rate fee.
 /// </summary>
-public record DeliveryParticipant : DeliveryRateProvider, IGraphQLUnionCase, IGraphQLObject, INode
+public record DeliveryParticipant : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// Whether to display new shipping services automatically to the customer when the service becomes available.

--- a/ShopifySharp/Entities/GraphQL/Generated/DeliveryRateDefinition.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DeliveryRateDefinition.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The merchant-defined rate of the [DeliveryMethodDefinition](https://shopify.dev/api/admin-graphql/latest/objects/DeliveryMethodDefinition).
 /// </summary>
-public record DeliveryRateDefinition : DeliveryRateProvider, IGraphQLUnionCase, IGraphQLObject, INode
+public record DeliveryRateDefinition : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// A globally-unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/DepositPercentage.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DepositPercentage.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A percentage deposit.
 /// </summary>
-public record DepositPercentage : DepositConfiguration, IGraphQLUnionCase, IGraphQLObject
+public record DepositPercentage : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value of the deposit.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountAmount.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountAmount.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// The fixed amount value of a discount, and whether the amount is applied to each
 /// entitled item or spread evenly across the entitled items.
 /// </summary>
-public record DiscountAmount : DiscountCustomerGetsValue, IGraphQLUnionCase, IGraphQLObject
+public record DiscountAmount : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The value of the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticApp.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticApp.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountAutomaticApp` object, with the exception that `DiscountCodeApp`
 /// stores information about discount codes that are managed by an app using Shopify Functions.
 /// </summary>
-public record DiscountAutomaticApp : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountAutomaticApp : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The details about the app extension that's providing the

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticBasic.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticBasic.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountAutomaticBasic` object, but customers need to enter a code to
 /// receive a discount.
 /// </summary>
-public record DiscountAutomaticBasic : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountAutomaticBasic : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The number of times that the discount has been used.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticBxgy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticBxgy.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountAutomaticBxgy` object, but customers need to enter a code to
 /// receive a discount.
 /// </summary>
-public record DiscountAutomaticBxgy : Discount, IGraphQLUnionCase, IGraphQLObject, IHasEvents, INode
+public record DiscountAutomaticBxgy : IGraphQLUnionCase, IGraphQLObject, IHasEvents, INode
 {
     /// <summary>
     /// The number of times that the discount has been used.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticFreeShipping.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticFreeShipping.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountAutomaticFreeShipping` object, but customers need to enter a code to
 /// receive a discount.
 /// </summary>
-public record DiscountAutomaticFreeShipping : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountAutomaticFreeShipping : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether the discount applies on one-time purchases.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticNode.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountAutomaticNode.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 /// Learn more about working with [Shopify's discount model](https://shopify.dev/docs/apps/build/discounts),
 /// including related queries, mutations, limitations, and considerations.
 /// </summary>
-public record DiscountAutomaticNode : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
+public record DiscountAutomaticNode : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// A discount that's applied automatically when an order meets specific criteria.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeApp.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeApp.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountCodeApp` object, with the exception that `DiscountAutomaticApp`
 /// stores information about automatic discounts that are managed by an app using Shopify Functions.
 /// </summary>
-public record DiscountCodeApp : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCodeApp : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The details about the app extension that's providing the

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeBasic.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeBasic.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountCodeBasic` object, but discounts are automatically applied,
 /// without the need for customers to enter a code.
 /// </summary>
-public record DiscountCodeBasic : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCodeBasic : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether a customer can only use the discount once.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeBxgy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeBxgy.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountCodeBxgy` object, but discounts are automatically applied,
 /// without the need for customers to enter a code.
 /// </summary>
-public record DiscountCodeBxgy : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCodeBxgy : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether a customer can only use the discount once.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeFreeShipping.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeFreeShipping.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 /// object has similar functionality to the `DiscountCodeFreeShipping` object, but discounts are automatically applied,
 /// without the need for customers to enter a code.
 /// </summary>
-public record DiscountCodeFreeShipping : Discount, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCodeFreeShipping : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether a customer can only use the discount once.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeNode.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCodeNode.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 /// Learn more about working with [Shopify's discount model](https://shopify.dev/docs/apps/build/discounts),
 /// including related queries, mutations, limitations, and considerations.
 /// </summary>
-public record DiscountCodeNode : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
+public record DiscountCodeNode : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// The underlying code discount object.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCollections.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCollections.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// A list of collections that the discount can have as a prerequisite or a list of
 /// collections to which the discount can be applied.
 /// </summary>
-public record DiscountCollections : DiscountItems, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCollections : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The list of collections that the discount can have as a prerequisite or the

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCountries.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCountries.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The shipping destinations where the discount can be applied.
 /// </summary>
-public record DiscountCountries : DiscountShippingDestinationSelection, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCountries : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The codes for the countries where the discount can be applied.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCountryAll.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCountryAll.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The `DiscountCountryAll` object lets you target all countries as shipping destination for discount eligibility.
 /// </summary>
-public record DiscountCountryAll : DiscountShippingDestinationSelection, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCountryAll : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether the discount can be applied to all countries as shipping destination. This value is always `true`.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCustomerAll.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCustomerAll.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The `DiscountCustomerAll` object lets you target all customers for discount eligibility.
 /// </summary>
-public record DiscountCustomerAll : DiscountCustomerSelection, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCustomerAll : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether the discount can be applied by all customers. This value is always `true`.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCustomerSegments.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCustomerSegments.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A list of customer segments who are eligible for the discount.
 /// </summary>
-public record DiscountCustomerSegments : DiscountCustomerSelection, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCustomerSegments : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The list of customer segments who are eligible for the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountCustomers.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountCustomers.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A list of individual customers eligible for the discount.
 /// </summary>
-public record DiscountCustomers : DiscountCustomerSelection, IGraphQLUnionCase, IGraphQLObject
+public record DiscountCustomers : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The list of individual customers eligible for the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountMinimumQuantity.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountMinimumQuantity.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The minimum quantity of items required for the discount to apply.
 /// </summary>
-public record DiscountMinimumQuantity : DiscountMinimumRequirement, IGraphQLUnionCase, IGraphQLObject
+public record DiscountMinimumQuantity : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The minimum quantity of items that's required for the discount to be applied.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountMinimumSubtotal.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountMinimumSubtotal.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The minimum subtotal required for the discount to apply.
 /// </summary>
-public record DiscountMinimumSubtotal : DiscountMinimumRequirement, IGraphQLUnionCase, IGraphQLObject
+public record DiscountMinimumSubtotal : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The minimum subtotal that's required for the discount to be applied.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountNode.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountNode.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 /// Learn more about working with [Shopify's discount model](https://shopify.dev/docs/apps/build/discounts),
 /// including related mutations, limitations, and considerations.
 /// </summary>
-public record DiscountNode : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
+public record DiscountNode : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// A discount that's applied at checkout or on cart.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountOnQuantity.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountOnQuantity.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The quantity of items discounted, the discount value, and how the discount will be applied.
 /// </summary>
-public record DiscountOnQuantity : DiscountCustomerGetsValue, IGraphQLUnionCase, IGraphQLObject
+public record DiscountOnQuantity : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The discount's effect on qualifying items.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountPercentage.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountPercentage.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A discount effect that gives customers a percentage off of specified items on their order.
 /// </summary>
-public record DiscountPercentage : DiscountCustomerGetsValue, IGraphQLUnionCase, IGraphQLObject
+public record DiscountPercentage : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value of the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountProducts.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountProducts.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 /// prerequisite or a list of products and product variants to which the discount
 /// can be applied.
 /// </summary>
-public record DiscountProducts : DiscountItems, IGraphQLUnionCase, IGraphQLObject
+public record DiscountProducts : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The list of products that the discount can have as a prerequisite or the list

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountPurchaseAmount.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountPurchaseAmount.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// A purchase amount in the context of a discount. This object can be used to
 /// define the minimum purchase amount required for a discount to be applicable.
 /// </summary>
-public record DiscountPurchaseAmount : DiscountCustomerBuysValue, IGraphQLUnionCase, IGraphQLObject
+public record DiscountPurchaseAmount : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The purchase amount in decimal format.

--- a/ShopifySharp/Entities/GraphQL/Generated/DiscountQuantity.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DiscountQuantity.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 /// define the minimum quantity of items required to apply a discount.
 /// Alternatively, it can be used to define the quantity of items that can be discounted.
 /// </summary>
-public record DiscountQuantity : DiscountCustomerBuysValue, IGraphQLUnionCase, IGraphQLObject
+public record DiscountQuantity : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The quantity of items.

--- a/ShopifySharp/Entities/GraphQL/Generated/DraftOrder.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DraftOrder.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 /// legitimate use for the associated data.
 /// Draft orders created on or after April 1, 2025 will be automatically purged after one year of inactivity.
 /// </summary>
-public record DraftOrder : CommentEventEmbed, IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasLocalizationExtensions, IHasLocalizedFields, IHasMetafields, ILegacyInteroperability, INavigable, INode
+public record DraftOrder : IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasLocalizationExtensions, IHasLocalizedFields, IHasMetafields, ILegacyInteroperability, INavigable, INode
 {
     /// <summary>
     /// Whether or not to accept automatic discounts on the draft order during calculation.

--- a/ShopifySharp/Entities/GraphQL/Generated/DraftOrderLineItem.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/DraftOrderLineItem.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The line item for a draft order.
 /// </summary>
-public record DraftOrderLineItem : DraftOrderPlatformDiscountAllocationTarget, IGraphQLUnionCase, IGraphQLObject, INode
+public record DraftOrderLineItem : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// The custom applied discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/FulfillmentOrder.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/FulfillmentOrder.cs
@@ -128,7 +128,7 @@ using System.Collections.Generic;
 /// to be notified whenever fulfillment order related domain events occur.
 /// [Learn about fulfillment workflows](https://shopify.dev/apps/fulfillment).
 /// </summary>
-public record FulfillmentOrder : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, INode
+public record FulfillmentOrder : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// The fulfillment order's assigned location. This is the location where the fulfillment is expected to happen.

--- a/ShopifySharp/Entities/GraphQL/Generated/GenericFile.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/GenericFile.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents any file other than HTML.
 /// </summary>
-public record GenericFile : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, IFile, INode
+public record GenericFile : IGraphQLUnionCase, IGraphQLObject, IFile, INode
 {
     /// <summary>
     /// A word or phrase to describe the contents or the function of a file.

--- a/ShopifySharp/Entities/GraphQL/Generated/InventoryTransfer.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/InventoryTransfer.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents the intention to move inventory between locations.
 /// </summary>
-public record InventoryTransfer : CommentEventEmbed, IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
+public record InventoryTransfer : IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// The date and time the inventory transfer was created in UTC format.

--- a/ShopifySharp/Entities/GraphQL/Generated/InvoiceReturnOutcome.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/InvoiceReturnOutcome.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The financial transfer details for a return outcome that results in an invoice.
 /// </summary>
-public record InvoiceReturnOutcome : ReturnOutcomeFinancialTransfer, IGraphQLUnionCase, IGraphQLObject
+public record InvoiceReturnOutcome : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The total monetary value to be invoiced in shop and presentment currencies.

--- a/ShopifySharp/Entities/GraphQL/Generated/LocalPaymentMethodsPaymentDetails.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/LocalPaymentMethodsPaymentDetails.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Local payment methods payment details related to a transaction.
 /// </summary>
-public record LocalPaymentMethodsPaymentDetails : PaymentDetails, IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
+public record LocalPaymentMethodsPaymentDetails : IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
 {
     /// <summary>
     /// The descriptor by the payment provider. Only available for Amazon Pay and Buy with Prime.

--- a/ShopifySharp/Entities/GraphQL/Generated/Location.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Location.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 /// locations that have `fulfills_online_orders: true` and are configured with a shipping rate, pickup enabled or
 /// local delivery will be able to sell from their storefront.
 /// </summary>
-public record Location : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, ILegacyInteroperability, INode
+public record Location : IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, ILegacyInteroperability, INode
 {
     /// <summary>
     /// Whether the location can be reactivated. If `false`, then trying to activate the location with the

--- a/ShopifySharp/Entities/GraphQL/Generated/Market.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Market.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 /// [configure international pricing](https://shopify.dev/apps/internationalization/product-price-lists),
 /// or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
 /// </summary>
-public record Market : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, INode
+public record Market : IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// Whether the market has a customization with the given ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/MediaImage.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/MediaImage.cs
@@ -25,7 +25,7 @@ using System.Collections.Generic;
 /// [product variants](https://shopify.dev/docs/apps/build/online-store/product-variant-media), and
 /// [asynchronous media management](https://shopify.dev/docs/apps/build/graphql/migrate/new-product-model/product-model-components#asynchronous-media-management).
 /// </summary>
-public record MediaImage : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, IFile, IHasMetafields, IMedia, INode
+public record MediaImage : IGraphQLUnionCase, IGraphQLObject, IFile, IHasMetafields, IMedia, INode
 {
     /// <summary>
     /// A word or phrase to share the nature or contents of a media.

--- a/ShopifySharp/Entities/GraphQL/Generated/Metaobject.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Metaobject.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Provides an object instance represented by a MetaobjectDefinition.
 /// </summary>
-public record Metaobject : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, INode
+public record Metaobject : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// Metaobject capabilities for this Metaobject.

--- a/ShopifySharp/Entities/GraphQL/Generated/Model3d.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Model3d.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a Shopify hosted 3D model.
 /// </summary>
-public record Model3d : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, IFile, IMedia, INode
+public record Model3d : IGraphQLUnionCase, IGraphQLObject, IFile, IMedia, INode
 {
     /// <summary>
     /// A word or phrase to describe the contents or the function of a file.

--- a/ShopifySharp/Entities/GraphQL/Generated/MoneyV2.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/MoneyV2.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A precise monetary value and its associated currency. For example, 12.99 USD.
 /// </summary>
-public record MoneyV2 : DeliveryConditionCriteria, IGraphQLUnionCase, IGraphQLObject
+public record MoneyV2 : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// A monetary value in decimal format, allowing for precise representation of cents or fractional

--- a/ShopifySharp/Entities/GraphQL/Generated/OnlineStoreThemeFileBodyBase64.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OnlineStoreThemeFileBodyBase64.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents the base64 encoded body of a theme file.
 /// </summary>
-public record OnlineStoreThemeFileBodyBase64 : OnlineStoreThemeFileBody, IGraphQLUnionCase, IGraphQLObject
+public record OnlineStoreThemeFileBodyBase64 : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The body of the theme file, base64 encoded.

--- a/ShopifySharp/Entities/GraphQL/Generated/OnlineStoreThemeFileBodyText.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OnlineStoreThemeFileBodyText.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents the body of a theme file.
 /// </summary>
-public record OnlineStoreThemeFileBodyText : OnlineStoreThemeFileBody, IGraphQLUnionCase, IGraphQLObject
+public record OnlineStoreThemeFileBodyText : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The body of the theme file.

--- a/ShopifySharp/Entities/GraphQL/Generated/OnlineStoreThemeFileBodyUrl.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OnlineStoreThemeFileBodyUrl.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents the url of the body of a theme file.
 /// </summary>
-public record OnlineStoreThemeFileBodyUrl : OnlineStoreThemeFileBody, IGraphQLUnionCase, IGraphQLObject
+public record OnlineStoreThemeFileBodyUrl : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The short lived url for the body of the theme file.

--- a/ShopifySharp/Entities/GraphQL/Generated/Order.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Order.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 /// for apps that don't have a legitimate use for the associated data.
 /// Learn more about [building apps for orders and fulfillment](https://shopify.dev/docs/apps/build/orders-fulfillment).
 /// </summary>
-public record Order : CommentEventEmbed, IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasLocalizationExtensions, IHasLocalizedFields, IHasMetafieldDefinitions, IHasMetafields, ILegacyInteroperability, INode
+public record Order : IGraphQLUnionCase, IGraphQLObject, ICommentEventSubject, IHasEvents, IHasLocalizationExtensions, IHasLocalizedFields, IHasMetafieldDefinitions, IHasMetafields, ILegacyInteroperability, INode
 {
     /// <summary>
     /// A list of additional fees applied to an order, such as duties, import fees, or [tax lines](https://shopify.dev/docs/api/admin-graphql/latest/objects/order#field-Order.fields.additionalFees.taxLines).

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddCustomItem.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddCustomItem.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 /// custom line item. For example, you might want to add gift wrapping service
 /// as a custom line item.
 /// </summary>
-public record OrderStagedChangeAddCustomItem : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeAddCustomItem : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The price of an individual item without any discounts applied. This value can't be negative.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddLineItemDiscount.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddLineItemDiscount.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The discount applied to an item that was added during the current order edit.
 /// </summary>
-public record OrderStagedChangeAddLineItemDiscount : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeAddLineItemDiscount : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The description of the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddShippingLine.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddShippingLine.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// A new [shipping line](https://shopify.dev/api/admin-graphql/latest/objects/shippingline)
 /// added as part of an order edit.
 /// </summary>
-public record OrderStagedChangeAddShippingLine : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeAddShippingLine : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The phone number at the shipping address.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddVariant.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeAddVariant.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A change to the order representing the addition of an existing product variant.
 /// </summary>
-public record OrderStagedChangeAddVariant : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeAddVariant : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The quantity of the product variant that was added.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeDecrementItem.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeDecrementItem.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// An removal of items from an existing line item on the order.
 /// </summary>
-public record OrderStagedChangeDecrementItem : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeDecrementItem : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The number of items removed.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeIncrementItem.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeIncrementItem.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// An addition of items to an existing line item on the order.
 /// </summary>
-public record OrderStagedChangeIncrementItem : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeIncrementItem : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The number of items added.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeRemoveShippingLine.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderStagedChangeRemoveShippingLine.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A shipping line removed during an order edit.
 /// </summary>
-public record OrderStagedChangeRemoveShippingLine : OrderStagedChange, IGraphQLUnionCase, IGraphQLObject
+public record OrderStagedChangeRemoveShippingLine : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The removed shipping line.

--- a/ShopifySharp/Entities/GraphQL/Generated/OrderTransaction.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/OrderTransaction.cs
@@ -24,7 +24,7 @@ using System.Collections.Generic;
 /// Learn more about [payment processing](https://help.shopify.com/manual/payments)
 /// and [payment gateway integrations](https://www.shopify.com/ca/payment-gateways).
 /// </summary>
-public record OrderTransaction : StoreCreditAccountTransactionOrigin, IGraphQLUnionCase, IGraphQLObject, INode
+public record OrderTransaction : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// The masked account number associated with the payment method.

--- a/ShopifySharp/Entities/GraphQL/Generated/Page.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Page.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A page on the Online Store.
 /// </summary>
-public record Page : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INavigable, INode
+public record Page : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INavigable, INode
 {
     /// <summary>
     /// The text content of the page, complete with HTML markup.

--- a/ShopifySharp/Entities/GraphQL/Generated/PaymentCustomization.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PaymentCustomization.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A payment customization.
 /// </summary>
-public record PaymentCustomization : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, INode
+public record PaymentCustomization : IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, INode
 {
     /// <summary>
     /// The enabled status of the payment customization.

--- a/ShopifySharp/Entities/GraphQL/Generated/PaypalWalletPaymentDetails.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PaypalWalletPaymentDetails.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// PayPal Wallet payment details related to a transaction.
 /// </summary>
-public record PaypalWalletPaymentDetails : PaymentDetails, IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
+public record PaypalWalletPaymentDetails : IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
 {
     /// <summary>
     /// The name of payment method used by the buyer.

--- a/ShopifySharp/Entities/GraphQL/Generated/PriceRuleFixedAmountValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PriceRuleFixedAmountValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The value of a fixed amount price rule.
 /// </summary>
-public record PriceRuleFixedAmountValue : PriceRuleValue, IGraphQLUnionCase, IGraphQLObject
+public record PriceRuleFixedAmountValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The monetary value of the price rule.

--- a/ShopifySharp/Entities/GraphQL/Generated/PriceRulePercentValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PriceRulePercentValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The value of a percent price rule.
 /// </summary>
-public record PriceRulePercentValue : PriceRuleValue, IGraphQLUnionCase, IGraphQLObject
+public record PriceRulePercentValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percent value of the price rule.

--- a/ShopifySharp/Entities/GraphQL/Generated/PricingPercentageValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PricingPercentageValue.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// One type of value given to a customer when a discount is applied to an order.
 /// The application of a discount with this value gives the customer the specified percentage off a specified item.
 /// </summary>
-public record PricingPercentageValue : PricingValue, IGraphQLUnionCase, IGraphQLObject
+public record PricingPercentageValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value of the object. This is a number between -100 (free) and 0 (no discount).

--- a/ShopifySharp/Entities/GraphQL/Generated/Product.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Product.cs
@@ -16,7 +16,7 @@ using System.Collections.Generic;
 /// Learn more about working with [Shopify's product model](https://shopify.dev/docs/apps/build/graphql/migrate/new-product-model/product-model-components),
 /// including limitations and considerations.
 /// </summary>
-public record Product : CommentEventEmbed, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, ILegacyInteroperability, INavigable, INode, IOnlineStorePreviewable, IPublishable
+public record Product : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, ILegacyInteroperability, INavigable, INode, IOnlineStorePreviewable, IPublishable
 {
     /// <summary>
     /// The number of

--- a/ShopifySharp/Entities/GraphQL/Generated/ProductVariant.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/ProductVariant.cs
@@ -28,7 +28,7 @@ using System.Collections.Generic;
 /// - [`SellingPlanGroup`](https://shopify.dev/docs/api/admin-graphql/latest/objects/SellingPlanGroup): Used for subscriptions and selling plans
 /// Learn more about [Shopify's product model](https://shopify.dev/docs/apps/build/graphql/migrate/new-product-model/product-model-components).
 /// </summary>
-public record ProductVariant : CommentEventEmbed, IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, ILegacyInteroperability, INavigable, INode
+public record ProductVariant : IGraphQLUnionCase, IGraphQLObject, IHasEvents, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, ILegacyInteroperability, INavigable, INode
 {
     /// <summary>
     /// Whether the product variant is available for sale.

--- a/ShopifySharp/Entities/GraphQL/Generated/PublicationResourceOperation.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PublicationResourceOperation.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A bulk update operation on a publication.
 /// </summary>
-public record PublicationResourceOperation : PublicationOperation, IGraphQLUnionCase, IGraphQLObject, INode, IResourceOperation
+public record PublicationResourceOperation : IGraphQLUnionCase, IGraphQLObject, INode, IResourceOperation
 {
     /// <summary>
     /// A globally-unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/PurchasingCompany.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/PurchasingCompany.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents information about the purchasing company for the order or draft order.
 /// </summary>
-public record PurchasingCompany : PurchasingEntity, IGraphQLUnionCase, IGraphQLObject
+public record PurchasingCompany : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The company associated to the order or draft order.

--- a/ShopifySharp/Entities/GraphQL/Generated/RefundReturnOutcome.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/RefundReturnOutcome.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The financial transfer details for a return outcome that results in a refund.
 /// </summary>
-public record RefundReturnOutcome : ReturnOutcomeFinancialTransfer, IGraphQLUnionCase, IGraphQLObject
+public record RefundReturnOutcome : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The total monetary value to be refunded in shop and presentment currencies.

--- a/ShopifySharp/Entities/GraphQL/Generated/ReverseDeliveryShippingDeliverable.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/ReverseDeliveryShippingDeliverable.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A reverse shipping deliverable that may include a label and tracking information.
 /// </summary>
-public record ReverseDeliveryShippingDeliverable : ReverseDeliveryDeliverable, IGraphQLUnionCase, IGraphQLObject
+public record ReverseDeliveryShippingDeliverable : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The return label attached to the reverse delivery.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanCheckoutChargePercentageValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanCheckoutChargePercentageValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The percentage value of the price used for checkout charge.
 /// </summary>
-public record SellingPlanCheckoutChargePercentageValue : SellingPlanCheckoutChargeValue, IGraphQLUnionCase, IGraphQLObject
+public record SellingPlanCheckoutChargePercentageValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value of the price used for checkout charge.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanFixedBillingPolicy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanFixedBillingPolicy.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// The fixed selling plan billing policy defines how much of the price of the product will be billed to customer
 /// at checkout. If there is an outstanding balance, it determines when it will be paid.
 /// </summary>
-public record SellingPlanFixedBillingPolicy : SellingPlanBillingPolicy, IGraphQLUnionCase, IGraphQLObject
+public record SellingPlanFixedBillingPolicy : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The checkout charge when the full amount isn't charged at checkout.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanFixedDeliveryPolicy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanFixedDeliveryPolicy.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a fixed selling plan delivery policy.
 /// </summary>
-public record SellingPlanFixedDeliveryPolicy : SellingPlanDeliveryPolicy, IGraphQLUnionCase, IGraphQLObject
+public record SellingPlanFixedDeliveryPolicy : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The specific anchor dates upon which the delivery interval calculations should be made.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanFixedPricingPolicy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanFixedPricingPolicy.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 /// For example, a subscription with a $10 discount and two deliveries will have a $5
 /// discount applied to each delivery.
 /// </summary>
-public record SellingPlanFixedPricingPolicy : SellingPlanPricingPolicy, IGraphQLUnionCase, IGraphQLObject, ISellingPlanPricingPolicyBase
+public record SellingPlanFixedPricingPolicy : IGraphQLUnionCase, IGraphQLObject, ISellingPlanPricingPolicyBase
 {
     /// <summary>
     /// The price adjustment type.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanPricingPolicyPercentageValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanPricingPolicyPercentageValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The percentage value of a selling plan pricing policy percentage type.
 /// </summary>
-public record SellingPlanPricingPolicyPercentageValue : SellingPlanPricingPolicyAdjustmentValue, IGraphQLUnionCase, IGraphQLObject
+public record SellingPlanPricingPolicyPercentageValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanRecurringBillingPolicy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanRecurringBillingPolicy.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a recurring selling plan billing policy.
 /// </summary>
-public record SellingPlanRecurringBillingPolicy : SellingPlanBillingPolicy, IGraphQLUnionCase, IGraphQLObject
+public record SellingPlanRecurringBillingPolicy : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Specific anchor dates upon which the billing interval calculations should be made.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanRecurringDeliveryPolicy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanRecurringDeliveryPolicy.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a recurring selling plan delivery policy.
 /// </summary>
-public record SellingPlanRecurringDeliveryPolicy : SellingPlanDeliveryPolicy, IGraphQLUnionCase, IGraphQLObject
+public record SellingPlanRecurringDeliveryPolicy : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The specific anchor dates upon which the delivery interval calculations should be made.

--- a/ShopifySharp/Entities/GraphQL/Generated/SellingPlanRecurringPricingPolicy.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SellingPlanRecurringPricingPolicy.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 /// when the recurring pricing policy comes into effect. Recurring pricing policies
 /// are not available for deferred purchase options.
 /// </summary>
-public record SellingPlanRecurringPricingPolicy : SellingPlanPricingPolicy, IGraphQLUnionCase, IGraphQLObject, ISellingPlanPricingPolicyBase
+public record SellingPlanRecurringPricingPolicy : IGraphQLUnionCase, IGraphQLObject, ISellingPlanPricingPolicyBase
 {
     /// <summary>
     /// The price adjustment type.

--- a/ShopifySharp/Entities/GraphQL/Generated/ShippingLine.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/ShippingLine.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents the shipping details that the customer chose for their order.
 /// </summary>
-public record ShippingLine : DraftOrderPlatformDiscountAllocationTarget, IGraphQLUnionCase, IGraphQLObject
+public record ShippingLine : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// A reference to the carrier service that provided the rate.

--- a/ShopifySharp/Entities/GraphQL/Generated/Shop.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Shop.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a collection of general settings and information about the shop.
 /// </summary>
-public record Shop : MetafieldReferencer, IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INode
+public record Shop : IGraphQLUnionCase, IGraphQLObject, IHasMetafieldDefinitions, IHasMetafields, IHasPublishedTranslations, INode
 {
     /// <summary>
     /// Account owner information.

--- a/ShopifySharp/Entities/GraphQL/Generated/ShopPayInstallmentsPaymentDetails.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/ShopPayInstallmentsPaymentDetails.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Shop Pay Installments payment details related to a transaction.
 /// </summary>
-public record ShopPayInstallmentsPaymentDetails : PaymentDetails, IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
+public record ShopPayInstallmentsPaymentDetails : IGraphQLUnionCase, IGraphQLObject, IBasePaymentDetails
 {
     /// <summary>
     /// The name of payment method used by the buyer.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionAppliedCodeDiscount.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionAppliedCodeDiscount.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents an applied code discount.
 /// </summary>
-public record SubscriptionAppliedCodeDiscount : SubscriptionDiscount, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionAppliedCodeDiscount : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryMethodLocalDelivery.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryMethodLocalDelivery.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// A subscription delivery method for local delivery.
 /// The other subscription delivery methods can be found in the `SubscriptionDeliveryMethod` union type.
 /// </summary>
-public record SubscriptionDeliveryMethodLocalDelivery : SubscriptionDeliveryMethod, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDeliveryMethodLocalDelivery : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The address to deliver to.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryMethodPickup.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryMethodPickup.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A delivery method with a pickup option.
 /// </summary>
-public record SubscriptionDeliveryMethodPickup : SubscriptionDeliveryMethod, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDeliveryMethodPickup : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The details of the pickup delivery method to use.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryMethodShipping.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryMethodShipping.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a shipping delivery method: a mailing address and a shipping option.
 /// </summary>
-public record SubscriptionDeliveryMethodShipping : SubscriptionDeliveryMethod, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDeliveryMethodShipping : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The address to ship to.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryOptionResultFailure.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryOptionResultFailure.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A failure to find the available delivery options for a subscription contract.
 /// </summary>
-public record SubscriptionDeliveryOptionResultFailure : SubscriptionDeliveryOptionResult, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDeliveryOptionResultFailure : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The reason for the failure.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryOptionResultSuccess.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDeliveryOptionResultSuccess.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The delivery option for a subscription contract.
 /// </summary>
-public record SubscriptionDeliveryOptionResultSuccess : SubscriptionDeliveryOptionResult, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDeliveryOptionResultSuccess : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The available delivery options.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDiscountFixedAmountValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDiscountFixedAmountValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The value of the discount and how it will be applied.
 /// </summary>
-public record SubscriptionDiscountFixedAmountValue : SubscriptionDiscountValue, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDiscountFixedAmountValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The fixed amount value of the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDiscountPercentageValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionDiscountPercentageValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// The percentage value of the discount.
 /// </summary>
-public record SubscriptionDiscountPercentageValue : SubscriptionDiscountValue, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionDiscountPercentageValue : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The percentage value of the discount.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionLocalDeliveryOption.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionLocalDeliveryOption.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A local delivery option for a subscription contract.
 /// </summary>
-public record SubscriptionLocalDeliveryOption : SubscriptionDeliveryOption, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionLocalDeliveryOption : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The code of the local delivery option.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionManualDiscount.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionManualDiscount.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Custom subscription discount.
 /// </summary>
-public record SubscriptionManualDiscount : SubscriptionDiscount, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionManualDiscount : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Entitled line items used to apply the subscription discount on.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionPickupOption.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionPickupOption.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A pickup option to deliver a subscription contract.
 /// </summary>
-public record SubscriptionPickupOption : SubscriptionDeliveryOption, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionPickupOption : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The code of the pickup option.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionShippingOption.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionShippingOption.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A shipping option to deliver a subscription contract.
 /// </summary>
-public record SubscriptionShippingOption : SubscriptionDeliveryOption, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionShippingOption : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The carrier service that's providing this shipping option.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionShippingOptionResultFailure.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionShippingOptionResultFailure.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Failure determining available shipping options for delivery of a subscription contract.
 /// </summary>
-public record SubscriptionShippingOptionResultFailure : SubscriptionShippingOptionResult, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionShippingOptionResultFailure : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Failure reason.

--- a/ShopifySharp/Entities/GraphQL/Generated/SubscriptionShippingOptionResultSuccess.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/SubscriptionShippingOptionResultSuccess.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A shipping option for delivery of a subscription contract.
 /// </summary>
-public record SubscriptionShippingOptionResultSuccess : SubscriptionShippingOptionResult, IGraphQLUnionCase, IGraphQLObject
+public record SubscriptionShippingOptionResultSuccess : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Available shipping options.

--- a/ShopifySharp/Entities/GraphQL/Generated/TaxonomyAttribute.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/TaxonomyAttribute.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A Shopify product taxonomy attribute.
 /// </summary>
-public record TaxonomyAttribute : TaxonomyCategoryAttribute, IGraphQLUnionCase, IGraphQLObject, INode
+public record TaxonomyAttribute : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// A globally-unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/TaxonomyChoiceListAttribute.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/TaxonomyChoiceListAttribute.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A Shopify product taxonomy choice list attribute.
 /// </summary>
-public record TaxonomyChoiceListAttribute : TaxonomyCategoryAttribute, IGraphQLUnionCase, IGraphQLObject, INode
+public record TaxonomyChoiceListAttribute : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// The unique ID of the TaxonomyAttribute.

--- a/ShopifySharp/Entities/GraphQL/Generated/TaxonomyMeasurementAttribute.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/TaxonomyMeasurementAttribute.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A Shopify product taxonomy measurement attribute.
 /// </summary>
-public record TaxonomyMeasurementAttribute : TaxonomyCategoryAttribute, IGraphQLUnionCase, IGraphQLObject, INode
+public record TaxonomyMeasurementAttribute : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// The unique ID of the TaxonomyAttribute.

--- a/ShopifySharp/Entities/GraphQL/Generated/TaxonomyValue.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/TaxonomyValue.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a Shopify product taxonomy value.
 /// </summary>
-public record TaxonomyValue : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, INode
+public record TaxonomyValue : IGraphQLUnionCase, IGraphQLObject, INode
 {
     /// <summary>
     /// A globally-unique ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/TenderTransactionCreditCardDetails.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/TenderTransactionCreditCardDetails.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Information about the credit card used for this transaction.
 /// </summary>
-public record TenderTransactionCreditCardDetails : TenderTransactionDetails, IGraphQLUnionCase, IGraphQLObject
+public record TenderTransactionCreditCardDetails : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The name of the company that issued the customer's credit card. Example: `Visa`.

--- a/ShopifySharp/Entities/GraphQL/Generated/VaultCreditCard.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/VaultCreditCard.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a credit card payment instrument.
 /// </summary>
-public record VaultCreditCard : PaymentInstrument, IGraphQLUnionCase, IGraphQLObject
+public record VaultCreditCard : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The billing address of the card.

--- a/ShopifySharp/Entities/GraphQL/Generated/VaultPaypalBillingAgreement.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/VaultPaypalBillingAgreement.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a paypal billing agreement payment instrument.
 /// </summary>
-public record VaultPaypalBillingAgreement : PaymentInstrument, IGraphQLUnionCase, IGraphQLObject
+public record VaultPaypalBillingAgreement : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// Whether the paypal billing agreement is inactive.

--- a/ShopifySharp/Entities/GraphQL/Generated/Video.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Video.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Represents a Shopify hosted video.
 /// </summary>
-public record Video : MetafieldReference, IGraphQLUnionCase, IGraphQLObject, IFile, IMedia, INode
+public record Video : IGraphQLUnionCase, IGraphQLObject, IFile, IMedia, INode
 {
     /// <summary>
     /// A word or phrase to share the nature or contents of a media.

--- a/ShopifySharp/Entities/GraphQL/Generated/WebhookEventBridgeEndpoint.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/WebhookEventBridgeEndpoint.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// An Amazon EventBridge partner event source to which webhook subscriptions publish events.
 /// </summary>
-public record WebhookEventBridgeEndpoint : WebhookSubscriptionEndpoint, IGraphQLUnionCase, IGraphQLObject
+public record WebhookEventBridgeEndpoint : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The ARN of this EventBridge partner event source.

--- a/ShopifySharp/Entities/GraphQL/Generated/WebhookHttpEndpoint.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/WebhookHttpEndpoint.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// An HTTPS endpoint to which webhook subscriptions send POST requests.
 /// </summary>
-public record WebhookHttpEndpoint : WebhookSubscriptionEndpoint, IGraphQLUnionCase, IGraphQLObject
+public record WebhookHttpEndpoint : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The URL to which the webhooks events are sent.

--- a/ShopifySharp/Entities/GraphQL/Generated/WebhookPubSubEndpoint.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/WebhookPubSubEndpoint.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A Google Cloud Pub/Sub topic to which webhook subscriptions publish events.
 /// </summary>
-public record WebhookPubSubEndpoint : WebhookSubscriptionEndpoint, IGraphQLUnionCase, IGraphQLObject
+public record WebhookPubSubEndpoint : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The Google Cloud Pub/Sub project ID.

--- a/ShopifySharp/Entities/GraphQL/Generated/Weight.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Weight.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A weight, which includes a numeric value and a unit of measurement.
 /// </summary>
-public record Weight : DeliveryConditionCriteria, IGraphQLUnionCase, IGraphQLObject
+public record Weight : IGraphQLUnionCase, IGraphQLObject
 {
     /// <summary>
     /// The unit of measurement for `value`.


### PR DESCRIPTION
Union case types were incorrectly inheriting from concrete union base types (e.g. Metaobject from MetafieldReference), causing JSON serialization failures when the polymorphic type system couldn't find them in the allowed derived types.

This occurred because union cases could appear in multiple unions and created circular serialization chains. Modified the GraphQL parser to make union cases inherit only from IGraphQLUnionCase interface while preserving the wrapper-based union pattern.

This PR:

- Updates GraphQL parser to generate correct inheritance for union cases
- Regenerates all GraphQL entity types with fixed inheritance pattern
- Adds an integration test for Metaobject serialization
- Fixes the "Runtime type not supported by polymorphic type" exception in #1211
