### PR TITLE
Fix Metafield jsonValue type to handle arrays of data

### DIFF
--- a/ShopifySharp/Entities/GraphQL/Generated/Types/Metafield.generated.cs
+++ b/ShopifySharp/Entities/GraphQL/Generated/Types/Metafield.generated.cs
@@ -55,7 +55,7 @@ public record Metafield : IGraphQLObject, IHasCompareDigest, ILegacyInteroperabi
     /// The data stored in the metafield in JSON format.
     /// </summary>
     [JsonPropertyName("jsonValue")]
-    public string? jsonValue { get; set; } = null;
+    public System.Text.Json.JsonDocument? jsonValue { get; set; } = null;
 
     /// <summary>
     /// The unique identifier for the metafield within its namespace.


### PR DESCRIPTION
The MetaData class property jsonValue is set to be a string? which, if it is an array in the actual data, causes an exception. If this value was System.Text.Json.JsonDocument? instead it would parse properly.