### PR TITLE
Correct JSON property name to 'channel_liable' in TaxLine

### DIFF
--- a/ShopifySharp/Entities/TaxLine.cs
+++ b/ShopifySharp/Entities/TaxLine.cs
@@ -7,7 +7,7 @@ public class TaxLine
     /// <summary>
     /// Whether the channel that submitted the tax line is responsible for remitting it.
     /// </summary>
-    [JsonProperty("channelLiable")]
+    [JsonProperty("channel_liable")]
     public bool? ChannelLiable { get; set; }
 
     /// <summary>


### PR DESCRIPTION
Correct json property name is channel_liable. See https://shopify.dev/docs/api/admin-rest/latest/resources/order for confirmation.